### PR TITLE
fix: add missing env.template file

### DIFF
--- a/env.template
+++ b/env.template
@@ -1,0 +1,15 @@
+# Canvas API Configuration
+CANVAS_API_TOKEN=your_token_here
+CANVAS_API_URL=https://canvas.youruniversity.edu/api/v1
+
+# MCP Server Configuration (optional)
+MCP_SERVER_NAME=canvas-mcp
+
+# Privacy Settings
+# Students: Set to false (you only access your own data)
+# Educators: Set to true for FERPA-compliant student data anonymization
+ENABLE_DATA_ANONYMIZATION=false
+ANONYMIZATION_DEBUG=false
+
+# Optional: Institution name for display
+INSTITUTION_NAME=Your University Name


### PR DESCRIPTION
## Summary

Adds the missing `env.template` file that was referenced in README.md and documentation files.

## Changes

- Created `env.template` with Canvas API configuration variables
- Included `CANVAS_API_URL` with `/api/v1` suffix as recommended
- Added privacy settings for both students and educators
- Included helpful comments for each configuration option

## Related Issue

Closes #13

---

🤖 Generated with [Claude Code](https://claude.ai/code)