### PR TITLE
chore: update FastMCP to >=2.10.0 for MCP 2.10 spec compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 ]
 keywords = ["canvas", "lms", "mcp", "claude", "education", "api"]
 dependencies = [
-    "fastmcp>=1.0.0",
+    "fastmcp>=2.10.0",
     "httpx>=0.28.1",
     "requests>=2.32.0",
     "python-dotenv>=1.0.0",


### PR DESCRIPTION
## Summary
Updates FastMCP dependency from >=1.0.0 to >=2.10.0 for MCP 2.10 specification compliance.

## Changes
- Updated `fastmcp>=1.0.0` to `fastmcp>=2.10.0` in `pyproject.toml`
- Ensures MCP 2.10 spec compliance and access to latest FastMCP features

## Testing
After merging, run `pip install -e .` to install the updated dependency.

Fixes #24 (HIGH priority item)

---
Generated with [Claude Code](https://claude.ai/code)