### PR TITLE
Review recent major changes in repository

### DIFF
--- a/src/canvas_mcp/code_api/canvas/discussions/bulkGradeDiscussion.ts
+++ b/src/canvas_mcp/code_api/canvas/discussions/bulkGradeDiscussion.ts
@@ -105,6 +105,15 @@ function validateCriteria(criteria: GradingCriteria): void {
     throw new Error('maxPeerReviewPoints cannot be negative');
   }
 
+  if (criteria.maxPeerReviewPoints !== undefined &&
+      criteria.peerReviewPointsEach > 0 &&
+      criteria.maxPeerReviewPoints < criteria.peerReviewPointsEach) {
+    throw new Error(
+      `maxPeerReviewPoints (${criteria.maxPeerReviewPoints}) cannot be less than peerReviewPointsEach (${criteria.peerReviewPointsEach}). ` +
+      'This configuration would result in 0 points for all peer reviews.'
+    );
+  }
+
   if (criteria.latePenalty?.enabled) {
     if (criteria.latePenalty.penaltyPercent < 0 || criteria.latePenalty.penaltyPercent > 1) {
       throw new Error('latePenalty.penaltyPercent must be between 0 and 1');
@@ -143,7 +152,7 @@ async function fetchAllDiscussionEntries(
         if (replies && Array.isArray(replies)) {
           allEntries.push(...replies);
         }
-      } catch (error) {
+      } catch (error: any) {
         console.warn(`Failed to fetch replies for entry ${entry.id}:`, error);
         // Continue processing other entries
       }


### PR DESCRIPTION
Adds validation to prevent invalid grading configuration where maxPeerReviewPoints is less than peerReviewPointsEach.

This configuration would result in Math.floor(max / each) = 0, causing students to receive 0 points for peer reviews regardless of how many they complete.

Also adds missing TypeScript type annotation for error handling.

Example of invalid configuration now caught:
- peerReviewPointsEach = 5
- maxPeerReviewPoints = 3
- Result: 0 peer reviews can count (Math.floor(3/5) = 0)

Related to PR #27 fixes in commit 4d2bfb2.