### PR TITLE
feat: Make rubric assessment optional for simple grading

### DIFF
--- a/src/canvas_mcp/code_api/canvas/grading/bulkGrade.ts
+++ b/src/canvas_mcp/code_api/canvas/grading/bulkGrade.ts
@@ -2,13 +2,14 @@ import { listSubmissions, Submission } from "../assignments/listSubmissions.js";
 import { gradeWithRubric } from "./gradeWithRubric.js";
 
 export interface GradeResult {
-  points: number;
-  rubricAssessment: Record<string, {
+  points?: number;
+  rubricAssessment?: Record<string, {
     points: number;
     ratingId?: string;
     comments?: string;
   }>;
-  comment: string;
+  grade?: string | number;
+  comment?: string;
 }
 
 export interface BulkGradeInput {
@@ -60,6 +61,7 @@ async function processBatch(
             assignmentId: input.assignmentId,
             userId: submission.user_id,
             rubricAssessment: gradeResult.rubricAssessment,
+            grade: gradeResult.grade,
             comment: gradeResult.comment
           });
         }


### PR DESCRIPTION
- Made rubricAssessment optional in GradeWithRubricInput interface
- Added grade field for simple numeric/letter grading
- Updated gradeWithRubric() to handle both rubric-based and simple grading
- Made all fields optional in GradeResult interface
- Added grade field to GradeResult
- Updated bulkGrade() to pass grade field through to gradeWithRubric()

This allows assignments without rubrics to be graded with simple grade values instead of requiring rubric structure.