### PR TITLE
Fix Canvas assignment description truncation issue

### DIFF
--- a/src/canvas_mcp/tools/assignments.py
+++ b/src/canvas_mcp/tools/assignments.py
@@ -8,7 +8,7 @@ from mcp.server.fastmcp import FastMCP
 from ..core.anonymization import anonymize_response_data
 from ..core.cache import get_course_code, get_course_id
 from ..core.client import fetch_all_paginated_results, make_canvas_request
-from ..core.dates import format_date, truncate_text
+from ..core.dates import format_date
 from ..core.logging import log_error
 from ..core.validation import validate_params
 
@@ -77,7 +77,7 @@ def register_assignment_tools(mcp: FastMCP):
 
         details = [
             f"Name: {response.get('name', 'N/A')}",
-            f"Description: {truncate_text(response.get('description', 'N/A'), 300)}",
+            f"Description: {response.get('description', 'N/A')}",
             f"Due Date: {format_date(response.get('due_at'))}",
             f"Points Possible: {response.get('points_possible', 'N/A')}",
             f"Submission Types: {', '.join(response.get('submission_types', ['N/A']))}",


### PR DESCRIPTION
The get_assignment_details tool was truncating assignment descriptions to 300 characters, causing important HTML content to be cut off mid-sentence.

Changes:
- Removed truncate_text() call from description field in assignments.py:80
- Removed unused truncate_text import from assignments.py:11
- Full HTML descriptions are now returned without character limits

This fixes the issue where descriptions were being cut off with "..." instead of returning complete content as provided by the Canvas API.

Fixes issue with assignment 1368816 in course 60366 and all other assignments with lengthy descriptions.