### PR TITLE
fix: submission status always show not submitted even though submitted

### DIFF
--- a/src/canvas_mcp/tools/student_tools.py
+++ b/src/canvas_mcp/tools/student_tools.py
@@ -75,11 +75,16 @@ def register_student_tools(mcp: FastMCP):
             # Get course name
             course_display = await get_course_code(course_id) if course_id else "Unknown Course"
 
-            # Get submission status
-            submission = assignment.get("submission")
-            if submission:
-                submitted = submission.get("submitted_at") is not None
-                status = "✅ Submitted" if submitted else "❌ Not Submitted"
+            assignment_id = assignment.get("id")
+            if course_id and assignment_id:
+                sub = await make_canvas_request(
+                    "get",
+                    f"/courses/{course_id}/assignments/{assignment_id}/submissions/self"
+                )
+                if isinstance(sub, dict) and sub.get("submitted_at"):
+                    status = "✅ Submitted"
+                else:
+                    status = "❌ Not Submitted"
             else:
                 status = "❌ Not Submitted"
 


### PR DESCRIPTION
## Issue

`get_my_upcoming_assignments` always showed "Not Submitted" for all assignments, even when the student had already submitted them.

### Root Cause
**`/users/self/upcoming_events` does not include submission data** (`src/canvas_mcp/tools/student_tools.py`)
   - The tool relied on `assignment.get("submission")` from the upcoming events response.
   - This endpoint never returns a `submission` key, so the value was always `None`, falling through to the "Not Submitted" default.

## Verification
Tested by calling the Canvas API directly:

- `GET /users/self/upcoming_events` — confirmed no `submission` key in response.
- `GET /courses/{id}/assignments/{id}/submissions/self` — confirmed returns `submitted_at` with timestamp for submitted assignments.

## Before
<img width="946" height="482" alt="image" src="https://github.com/user-attachments/assets/4784f590-caa6-4874-9f5f-d72e54131ff4" />

## After
<img width="839" height="443" alt="image" src="https://github.com/user-attachments/assets/797fd79b-6dee-47e6-9d60-09df94555c4b" />
