### PR TITLE
feat(files): add read_course_file tool for remote MCP deployments

### DIFF
--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -10,6 +10,7 @@ from .logging import log_error, log_warning
 load_dotenv()
 
 _INVALID_INT_ENV_VARS: dict[str, str] = {}
+_INVALID_FLOAT_ENV_VARS: dict[str, str] = {}
 
 VALID_SANDBOX_MODES = frozenset({"auto", "local", "container"})
 
@@ -32,6 +33,21 @@ def _int_env(name: str, default: int) -> int:
         return default
 
 
+def _float_env(name: str, default: float) -> float:
+    value = os.getenv(name)
+    if value is None or value.strip() == "":
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        _INVALID_FLOAT_ENV_VARS[name] = value
+        return default
+    if parsed <= 0:
+        _INVALID_FLOAT_ENV_VARS[name] = value
+        return default
+    return parsed
+
+
 class Config:
     """Configuration class for Canvas MCP server."""
 
@@ -46,6 +62,7 @@ class Config:
         self.api_timeout = _int_env("API_TIMEOUT", 30)
         self.cache_ttl = _int_env("CACHE_TTL", 300)
         self.max_concurrent_requests = _int_env("MAX_CONCURRENT_REQUESTS", 10)
+        self.read_file_max_size_mb = _float_env("READ_FILE_MAX_SIZE_MB", 100.0)
 
         # Development configuration
         self.log_level = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -152,6 +169,12 @@ def validate_config() -> bool:
     for env_name, env_value in _INVALID_INT_ENV_VARS.items():
         log_warning(
             f"{env_name} expects an integer; using default value "
+            f"(got '{env_value}')"
+        )
+
+    for env_name, env_value in _INVALID_FLOAT_ENV_VARS.items():
+        log_warning(
+            f"{env_name} expects a positive number; using default value "
             f"(got '{env_value}')"
         )
 

--- a/src/canvas_mcp/tools/files.py
+++ b/src/canvas_mcp/tools/files.py
@@ -25,6 +25,7 @@ from ..core.client import (
     make_canvas_request,
     upload_file_to_storage,
 )
+from ..core.config import get_config
 from ..core.file_validation import (
     FileValidationResult,
     format_file_size,
@@ -125,8 +126,20 @@ def register_shared_file_tools(mcp: FastMCP):
         Args:
             course_identifier: Course code or Canvas ID
             file_id: Canvas file ID
-            max_size_mb: Maximum file size in MB to read (default: 25). Files larger than this will be rejected to avoid excessive memory usage.
+            max_size_mb: Maximum file size in MB to read (default: 25). Clamped server-side to
+                READ_FILE_MAX_SIZE_MB (default 100). Files larger than the effective limit are
+                rejected to avoid excessive memory usage.
         """
+        if max_size_mb <= 0:
+            return (
+                f"Error: max_size_mb must be positive (got {max_size_mb}). "
+                f"Pass a value like 25 for a 25 MB limit."
+            )
+
+        server_max_mb = get_config().read_file_max_size_mb
+        effective_max_mb = min(float(max_size_mb), server_max_mb)
+        max_size_bytes = int(effective_max_mb * 1024 * 1024)
+
         course_id = await get_course_id(course_identifier)
 
         # Get file metadata from Canvas API
@@ -148,35 +161,31 @@ def register_shared_file_tools(mcp: FastMCP):
             return "Error: No download URL available for this file. Check permissions."
 
         # Check reported file size before downloading
-        max_size_bytes = int(max_size_mb * 1024 * 1024)
         if reported_size and reported_size > max_size_bytes:
             return (
                 f"Error: File '{filename}' is {format_file_size(reported_size)}, "
-                f"which exceeds the {max_size_mb} MB limit. "
+                f"which exceeds the {effective_max_mb} MB limit. "
                 f"Use download_course_file instead for large files."
             )
 
         # Download the file content into memory
         client = _get_http_client()
         try:
-            chunks = []
-            total_bytes = 0
+            buffer = bytearray()
             async with client.stream("GET", download_url, follow_redirects=True) as response:
                 response.raise_for_status()
 
                 async for chunk in response.aiter_bytes(chunk_size=8192):
-                    total_bytes += len(chunk)
-                    if total_bytes > max_size_bytes:
+                    if len(buffer) + len(chunk) > max_size_bytes:
                         return (
-                            f"Error: File '{filename}' exceeds the {max_size_mb} MB limit "
+                            f"Error: File '{filename}' exceeds the {effective_max_mb} MB limit "
                             f"during download. Use download_course_file instead for large files."
                         )
-                    chunks.append(chunk)
+                    buffer.extend(chunk)
 
-            file_bytes = b"".join(chunks)
-            base64_content = base64.b64encode(file_bytes).decode("ascii")
+            base64_content = base64.b64encode(buffer).decode("ascii")
 
-            size_str = format_file_size(total_bytes)
+            size_str = format_file_size(len(buffer))
             course_display = await get_course_code(course_id) or course_identifier
 
             result = f"Read: {filename}\n"

--- a/src/canvas_mcp/tools/files.py
+++ b/src/canvas_mcp/tools/files.py
@@ -1,6 +1,6 @@
 """File-related MCP tools for Canvas API.
 
-Provides tools for uploading, downloading, and listing files in Canvas courses.
+Provides tools for uploading, downloading, reading, and listing files in Canvas courses.
 Uploaded files can be used with other tools like add_module_item (for adding
 files to modules) and send_conversation (for attaching files to messages).
 
@@ -12,6 +12,7 @@ The Canvas file upload process uses a 3-step protocol:
 This module handles all three steps transparently.
 """
 
+import base64
 import tempfile
 
 from mcp.server.fastmcp import FastMCP
@@ -105,6 +106,89 @@ def register_shared_file_tools(mcp: FastMCP):
 
         except Exception as e:
             return f"Error downloading file: {str(e)}"
+
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @validate_params
+    async def read_course_file(
+        course_identifier: str | int,
+        file_id: str | int,
+        max_size_mb: float = 25.0,
+    ) -> str:
+        """Read a file from a Canvas course and return its content as base64.
+
+        Unlike download_course_file which saves to the server's local filesystem,
+        this tool returns the file content directly in the response. This is useful
+        when the MCP server runs on a different machine than the client.
+
+        Use list_course_files or list_module_items to find file IDs.
+
+        Args:
+            course_identifier: Course code or Canvas ID
+            file_id: Canvas file ID
+            max_size_mb: Maximum file size in MB to read (default: 25). Files larger than this will be rejected to avoid excessive memory usage.
+        """
+        course_id = await get_course_id(course_identifier)
+
+        # Get file metadata from Canvas API
+        file_info = await make_canvas_request(
+            "get",
+            f"/courses/{course_id}/files/{file_id}"
+        )
+
+        if isinstance(file_info, dict) and "error" in file_info:
+            return f"Error getting file info: {file_info['error']}"
+
+        raw_filename = file_info.get("display_name") or file_info.get("filename", f"file_{file_id}")
+        filename = sanitize_filename(raw_filename)
+        download_url = file_info.get("url")
+        content_type = file_info.get("content-type", "unknown")
+        reported_size = file_info.get("size", 0)
+
+        if not download_url:
+            return "Error: No download URL available for this file. Check permissions."
+
+        # Check reported file size before downloading
+        max_size_bytes = int(max_size_mb * 1024 * 1024)
+        if reported_size and reported_size > max_size_bytes:
+            return (
+                f"Error: File '{filename}' is {format_file_size(reported_size)}, "
+                f"which exceeds the {max_size_mb} MB limit. "
+                f"Use download_course_file instead for large files."
+            )
+
+        # Download the file content into memory
+        client = _get_http_client()
+        try:
+            chunks = []
+            total_bytes = 0
+            async with client.stream("GET", download_url, follow_redirects=True) as response:
+                response.raise_for_status()
+
+                async for chunk in response.aiter_bytes(chunk_size=8192):
+                    total_bytes += len(chunk)
+                    if total_bytes > max_size_bytes:
+                        return (
+                            f"Error: File '{filename}' exceeds the {max_size_mb} MB limit "
+                            f"during download. Use download_course_file instead for large files."
+                        )
+                    chunks.append(chunk)
+
+            file_bytes = b"".join(chunks)
+            base64_content = base64.b64encode(file_bytes).decode("ascii")
+
+            size_str = format_file_size(total_bytes)
+            course_display = await get_course_code(course_id) or course_identifier
+
+            result = f"Read: {filename}\n"
+            result += f"  Size: {size_str}\n"
+            result += f"  Type: {content_type}\n"
+            result += f"  Course: {course_display}\n"
+            result += "  Encoding: base64\n"
+            result += f"  Content:\n{base64_content}\n"
+            return result
+
+        except Exception as e:
+            return f"Error reading file: {str(e)}"
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     @validate_params

--- a/tests/tools/test_files.py
+++ b/tests/tools/test_files.py
@@ -1046,6 +1046,73 @@ class TestReadCourseFile:
 
         assert "Read: backup_name.pdf" in result
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad_value", [0, 0.0, -1, -25.0])
+    async def test_read_rejects_non_positive_max_size(self, mock_read_api, bad_value):
+        """Test non-positive max_size_mb is rejected before any Canvas request."""
+        read_fn = get_tool_function('read_course_file')
+        result = await read_fn("60366", 12345, max_size_mb=bad_value)
+
+        assert "error" in result.lower()
+        assert "must be positive" in result.lower()
+        # Should short-circuit before making any Canvas API call
+        mock_read_api['make_canvas_request'].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_clamps_to_server_hard_max(self, mock_read_api):
+        """Caller-requested max_size_mb is clamped to the server-side hard max."""
+        from unittest.mock import MagicMock, patch
+
+        # Pretend the server operator set a 10 MB hard cap.
+        fake_config = MagicMock()
+        fake_config.read_file_max_size_mb = 10.0
+
+        # File is 50 MB; caller naively asks for 1000 MB. After clamping,
+        # the effective limit is 10 MB and the file should be rejected.
+        mock_read_api['make_canvas_request'].return_value = {
+            "id": 12345,
+            "display_name": "huge.bin",
+            "url": "https://canvas.example.com/files/12345/download",
+            "size": 50 * 1024 * 1024,
+            "content-type": "application/octet-stream",
+        }
+
+        with patch('canvas_mcp.tools.files.get_config', return_value=fake_config):
+            read_fn = get_tool_function('read_course_file')
+            result = await read_fn("60366", 12345, max_size_mb=1000.0)
+
+        assert "error" in result.lower()
+        assert "exceeds" in result.lower()
+        # The message should reflect the clamped effective limit, not 1000.
+        assert "10" in result
+        assert "1000" not in result
+
+    @pytest.mark.asyncio
+    async def test_read_clamp_allows_file_within_server_max(self, mock_read_api):
+        """Clamping does not reject files that fit inside the server-side hard max."""
+        from unittest.mock import MagicMock, patch
+
+        fake_config = MagicMock()
+        fake_config.read_file_max_size_mb = 10.0
+
+        small_content = b"hello world"
+        mock_read_api['make_canvas_request'].return_value = {
+            "id": 12345,
+            "display_name": "small.txt",
+            "url": "https://canvas.example.com/files/12345/download",
+            "size": len(small_content),
+            "content-type": "text/plain",
+        }
+        self._setup_mock_stream(mock_read_api['_get_http_client'], small_content)
+
+        # Caller asks for way more than the server max — it should clamp silently
+        # and still succeed because the file itself is tiny.
+        with patch('canvas_mcp.tools.files.get_config', return_value=fake_config):
+            read_fn = get_tool_function('read_course_file')
+            result = await read_fn("60366", 12345, max_size_mb=1000.0)
+
+        assert "Read: small.txt" in result
+
 
 class TestListCourseFiles:
     """Tests for list_course_files tool."""

--- a/tests/tools/test_files.py
+++ b/tests/tools/test_files.py
@@ -842,6 +842,211 @@ class TestDownloadCourseFile:
         assert "error" in result.lower()
 
 
+class TestReadCourseFile:
+    """Tests for read_course_file tool."""
+
+    @pytest.fixture
+    def mock_read_api(self):
+        """Fixture to mock APIs needed for read_course_file."""
+        with patch('canvas_mcp.tools.files.get_course_id') as mock_get_id, \
+             patch('canvas_mcp.tools.files.get_course_code') as mock_get_code, \
+             patch('canvas_mcp.tools.files.make_canvas_request') as mock_request, \
+             patch('canvas_mcp.tools.files._get_http_client') as mock_client:
+
+            mock_get_id.return_value = "60366"
+            mock_get_code.return_value = "badm_350_120251"
+
+            yield {
+                'get_course_id': mock_get_id,
+                'get_course_code': mock_get_code,
+                'make_canvas_request': mock_request,
+                '_get_http_client': mock_client,
+            }
+
+    def _setup_mock_stream(self, mock_client, content=b"file content here"):
+        """Helper to set up a mock streaming response."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock()
+
+        async def aiter_bytes(chunk_size=8192):
+            yield content
+
+        mock_response.aiter_bytes = aiter_bytes
+
+        mock_stream_cm = AsyncMock()
+        mock_stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_http = AsyncMock()
+        mock_http.stream = MagicMock(return_value=mock_stream_cm)
+        mock_client.return_value = mock_http
+
+        return mock_http
+
+    @pytest.mark.asyncio
+    async def test_read_success(self, mock_read_api):
+        """Test successful file read returns base64 content."""
+        import base64
+
+        file_content = b"Hello, this is a test PDF content"
+        expected_b64 = base64.b64encode(file_content).decode("ascii")
+
+        mock_read_api['make_canvas_request'].return_value = {
+            "id": 12345,
+            "display_name": "syllabus.pdf",
+            "url": "https://canvas.example.com/files/12345/download",
+            "size": len(file_content),
+            "content-type": "application/pdf",
+        }
+
+        self._setup_mock_stream(mock_read_api['_get_http_client'], file_content)
+
+        read_fn = get_tool_function('read_course_file')
+        result = await read_fn("badm_350_120251", 12345)
+
+        assert "Read: syllabus.pdf" in result
+        assert "application/pdf" in result
+        assert "badm_350_120251" in result
+        assert "base64" in result
+        assert expected_b64 in result
+
+    @pytest.mark.asyncio
+    async def test_read_api_error(self, mock_read_api):
+        """Test handling of Canvas API error."""
+        mock_read_api['make_canvas_request'].return_value = {
+            "error": "File not found"
+        }
+
+        read_fn = get_tool_function('read_course_file')
+        result = await read_fn("60366", 99999)
+
+        assert "error" in result.lower()
+        assert "File not found" in result
+
+    @pytest.mark.asyncio
+    async def test_read_no_url(self, mock_read_api):
+        """Test handling when file has no download URL."""
+        mock_read_api['make_canvas_request'].return_value = {
+            "id": 12345,
+            "display_name": "locked.pdf",
+            "size": 1024,
+        }
+
+        read_fn = get_tool_function('read_course_file')
+        result = await read_fn("60366", 12345)
+
+        assert "error" in result.lower()
+        assert "download url" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_exceeds_reported_size_limit(self, mock_read_api):
+        """Test rejection when reported file size exceeds the limit."""
+        mock_read_api['make_canvas_request'].return_value = {
+            "id": 12345,
+            "display_name": "huge_video.mp4",
+            "url": "https://canvas.example.com/files/12345/download",
+            "size": 50 * 1024 * 1024,  # 50 MB
+            "content-type": "video/mp4",
+        }
+
+        read_fn = get_tool_function('read_course_file')
+        result = await read_fn("60366", 12345, max_size_mb=25.0)
+
+        assert "error" in result.lower()
+        assert "exceeds" in result.lower()
+        assert "download_course_file" in result
+
+    @pytest.mark.asyncio
+    async def test_read_exceeds_size_during_download(self, mock_read_api):
+        """Test rejection when file exceeds size limit during streaming."""
+        mock_read_api['make_canvas_request'].return_value = {
+            "id": 12345,
+            "display_name": "test.bin",
+            "url": "https://canvas.example.com/files/12345/download",
+            "size": 0,  # Unknown size
+            "content-type": "application/octet-stream",
+        }
+
+        # Create content larger than 1 MB limit
+        large_content = b"x" * (2 * 1024 * 1024)
+        self._setup_mock_stream(mock_read_api['_get_http_client'], large_content)
+
+        read_fn = get_tool_function('read_course_file')
+        result = await read_fn("60366", 12345, max_size_mb=1.0)
+
+        assert "error" in result.lower()
+        assert "exceeds" in result.lower()
+        assert "download_course_file" in result
+
+    @pytest.mark.asyncio
+    async def test_read_custom_size_limit(self, mock_read_api):
+        """Test that custom max_size_mb is respected."""
+        small_content = b"small file"
+
+        mock_read_api['make_canvas_request'].return_value = {
+            "id": 12345,
+            "display_name": "small.txt",
+            "url": "https://canvas.example.com/files/12345/download",
+            "size": len(small_content),
+            "content-type": "text/plain",
+        }
+
+        self._setup_mock_stream(mock_read_api['_get_http_client'], small_content)
+
+        read_fn = get_tool_function('read_course_file')
+        result = await read_fn("60366", 12345, max_size_mb=0.001)
+
+        # 10 bytes is within 0.001 MB (~1 KB), so should succeed
+        assert "Read: small.txt" in result
+
+    @pytest.mark.asyncio
+    async def test_read_http_error(self, mock_read_api):
+        """Test handling of HTTP errors during read."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        mock_read_api['make_canvas_request'].return_value = {
+            "id": 12345,
+            "display_name": "test.pdf",
+            "url": "https://canvas.example.com/files/12345/download",
+            "content-type": "application/pdf",
+        }
+
+        mock_response = AsyncMock()
+        mock_response.raise_for_status = MagicMock(side_effect=Exception("403 Forbidden"))
+
+        mock_stream_cm = AsyncMock()
+        mock_stream_cm.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+        mock_http = AsyncMock()
+        mock_http.stream = MagicMock(return_value=mock_stream_cm)
+        mock_read_api['_get_http_client'].return_value = mock_http
+
+        read_fn = get_tool_function('read_course_file')
+        result = await read_fn("60366", 12345)
+
+        assert "error" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_read_uses_filename_fallback(self, mock_read_api):
+        """Test fallback to 'filename' when 'display_name' is missing."""
+        mock_read_api['make_canvas_request'].return_value = {
+            "id": 12345,
+            "filename": "backup_name.pdf",
+            "url": "https://canvas.example.com/files/12345/download",
+            "content-type": "application/pdf",
+        }
+
+        self._setup_mock_stream(mock_read_api['_get_http_client'])
+
+        read_fn = get_tool_function('read_course_file')
+        result = await read_fn("60366", 12345)
+
+        assert "Read: backup_name.pdf" in result
+
+
 class TestListCourseFiles:
     """Tests for list_course_files tool."""
 


### PR DESCRIPTION
## Summary

- New MCP tool: `read_course_file(course_identifier, file_id, max_size_mb=25.0)`
- Streams a Canvas course file into memory and returns the content **base64-encoded in the response body**, complementing the existing `download_course_file` which writes to the server's local filesystem
- Registered inside `register_shared_file_tools` with `ToolAnnotations(readOnlyHint=True)` — available to both student and educator roles
- Tool count: 87 → 88

### Motivation

`download_course_file` saves to the **server's** filesystem. That's fine when the MCP server runs locally next to the client, but breaks down when the server is remote — e.g., the streamable-HTTP deployment pattern where the server lives on a VPS/LAN host and clients connect over HTTP. In that topology, "downloading" onto the server is a no-op from the user's perspective — the bytes never reach the client.

`read_course_file` solves this by returning the file content directly in the tool response (base64), so a remote MCP client can decode and use the file locally without any shared filesystem.

### Safety

- **Configurable size cap** (default 25 MB) to bound memory usage
- Enforced **twice**: first against Canvas's reported `size` before starting the download, then again during streaming in case the reported size was missing or wrong
- Oversized files return a clear error pointing the caller to `download_course_file`
- Reuses upstream's `sanitize_filename`, `format_file_size`, and the shared `_get_http_client()` — no new dependencies

## Test plan

- [x] 8 new tests in `TestReadCourseFile` covering: success, API error, missing download URL, size-cap rejection (reported size), size-cap rejection (mid-stream), custom size limit, HTTP error, filename fallback
- [x] Full suite: **357 passed, 19 skipped** (baseline unchanged)
- [x] `ruff check` clean on modified files
- [x] No changes to `download_course_file`, `list_course_files`, or `upload_course_file`