### PR TITLE
fix: remove dead code and bump dependency version floors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,11 @@ keywords = ["canvas", "lms", "mcp", "claude", "education", "api"]
 dependencies = [
     "fastmcp>=2.14.0",
     "httpx>=0.28.1",
-    "requests>=2.32.0",
-    "python-dotenv>=1.0.0",
-    "pydantic>=2.12.0",
-    "python-dateutil>=2.8.0",
-    "uvicorn>=0.32.0",
+    "requests>=2.33.1",
+    "python-dotenv>=1.2.2",
+    "pydantic>=2.13.1",
+    "python-dateutil>=2.9.0",
+    "uvicorn>=0.34.0",
 ]
 
 

--- a/src/canvas_mcp/tools/student_tools.py
+++ b/src/canvas_mcp/tools/student_tools.py
@@ -28,7 +28,6 @@ def register_student_tools(mcp: FastMCP):
         """
         # Calculate the date range (use timezone-aware datetime)
         end_date = datetime.now(timezone.utc) + timedelta(days=days)
-        end_date.strftime("%Y-%m-%d")
 
         # Get upcoming events for the current user
         events = await fetch_all_paginated_results(


### PR DESCRIPTION
Fixes actionable low/medium priority items from weekly maintenance report #91:

- Remove discarded `.strftime()` call in `student_tools.py:31` (dead code, result was never assigned or used)
- Bump dependency version floors: uvicorn >=0.34.0, pydantic >=2.13.1, requests >=2.33.1, python-dotenv >=1.2.2, python-dateutil >=2.9.0

fastmcp floor unchanged — major version bump needs separate branch + testing.

Closes #91

Generated with [Claude Code](https://claude.ai/code)