### PR TITLE
refactor: drop import-time config singleton + fix stdout anonymization warnings

### DIFF
--- a/src/canvas_mcp/core/__init__.py
+++ b/src/canvas_mcp/core/__init__.py
@@ -6,7 +6,7 @@ from .client import (
     fetch_all_paginated_results,
     make_canvas_request,
 )
-from .config import API_BASE_URL, API_TOKEN, get_config, validate_config
+from .config import get_config, reset_config, validate_config
 from .dates import format_date, parse_date, truncate_text
 from .types import AnnouncementInfo, AssignmentInfo, CourseInfo, PageInfo
 from .validation import (
@@ -35,7 +35,6 @@ __all__ = [
     'PageInfo',
     'AnnouncementInfo',
     'get_config',
-    'validate_config',
-    'API_BASE_URL',
-    'API_TOKEN'
+    'reset_config',
+    'validate_config'
 ]

--- a/src/canvas_mcp/core/client.py
+++ b/src/canvas_mcp/core/client.py
@@ -144,7 +144,7 @@ def _get_http_client() -> httpx.AsyncClient:
         config = get_config()
         http_client = httpx.AsyncClient(
             headers={
-                'Authorization': f'Bearer {config.api_token}',
+                'Authorization': f'Bearer {config.canvas_api_token}',
                 'User-Agent': f'canvas-mcp/{__version__} (https://github.com/vishalsachdev/canvas-mcp)'
             },
             timeout=config.api_timeout
@@ -210,7 +210,7 @@ async def make_canvas_request(
     else:
         # Global client (stdio mode)
         client = _get_http_client()
-        url = f"{config.api_base_url.rstrip('/')}{endpoint}"
+        url = f"{config.canvas_api_url.rstrip('/')}{endpoint}"
         _close_client = False
 
     # Gate outbound calls with concurrency semaphore (uses MAX_CONCURRENT_REQUESTS)

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -118,9 +118,16 @@ def reset_config() -> None:
     The next ``get_config()`` call rebuilds it from the current environment.
     Used by tests that patch environment variables so they don't read stale
     config captured at first access.
+
+    Also clears the invalid-env-var caches, which are populated during
+    ``Config.__init__`` and read by ``validate_config()``; otherwise a stale
+    entry from a prior parse would produce a warning inconsistent with the
+    rebuilt configuration's environment.
     """
     global _config
     _config = None
+    _INVALID_INT_ENV_VARS.clear()
+    _INVALID_FLOAT_ENV_VARS.clear()
 
 
 def validate_config() -> bool:

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -123,6 +123,14 @@ def reset_config() -> None:
     ``Config.__init__`` and read by ``validate_config()``; otherwise a stale
     entry from a prior parse would produce a warning inconsistent with the
     rebuilt configuration's environment.
+
+    Scope: this resets the config singleton only. Derived state built from
+    config elsewhere is **not** reset here — notably the stdio HTTP client in
+    ``core.client``, which captures the ``Authorization`` token at creation and
+    is reused until its event loop closes. A caller rotating ``CANVAS_API_TOKEN``
+    at runtime must also ``await cleanup_http_client()`` so the next request
+    rebuilds the client with the new credentials. (Tests mock the request layer,
+    and HTTP-transport mode uses per-request clients, so neither is affected.)
     """
     global _config
     _config = None

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -99,16 +99,6 @@ class Config:
         # Role-based tool filtering
         self.canvas_role = os.getenv("CANVAS_ROLE", "all").lower()
 
-    @property
-    def api_base_url(self) -> str:
-        """Legacy compatibility for API_BASE_URL."""
-        return self.canvas_api_url
-
-    @property
-    def api_token(self) -> str:
-        """Legacy compatibility for API_TOKEN."""
-        return self.canvas_api_token
-
 
 # Global configuration instance
 _config: Config | None = None
@@ -120,6 +110,17 @@ def get_config() -> Config:
     if _config is None:
         _config = Config()
     return _config
+
+
+def reset_config() -> None:
+    """Discard the cached configuration singleton.
+
+    The next ``get_config()`` call rebuilds it from the current environment.
+    Used by tests that patch environment variables so they don't read stale
+    config captured at first access.
+    """
+    global _config
+    _config = None
 
 
 def validate_config() -> bool:
@@ -187,8 +188,3 @@ def validate_config() -> bool:
             log_warning(f"{env_name} is set but {note}.")
 
     return True
-
-
-# Legacy compatibility - these will be used by existing code
-API_BASE_URL = get_config().api_base_url
-API_TOKEN = get_config().api_token

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -53,7 +53,6 @@ from .tools import (
     register_student_tools,
 )
 
-
 _CANVAS_URL_RE = re.compile(
     r"^https://[a-zA-Z0-9.-]+\.instructure\.com/api/v1$"
 )

--- a/src/canvas_mcp/tools/admin_tools.py
+++ b/src/canvas_mcp/tools/admin_tools.py
@@ -7,6 +7,7 @@ from mcp.types import ToolAnnotations
 from ..core.anonymization import anonymize_response_data
 from ..core.cache import get_course_code, get_course_id
 from ..core.client import fetch_all_paginated_results, make_canvas_request
+from ..core.logging import log_warning
 from ..core.validation import validate_params
 
 
@@ -101,7 +102,10 @@ def register_admin_tools(mcp: FastMCP):
                 try:
                     members = anonymize_response_data(members, data_type="users")
                 except Exception as e:
-                    print(f"Warning: Failed to anonymize group member data: {str(e)}")
+                    log_warning(
+                        "Failed to anonymize group member data; continuing with original data",
+                        error_type=type(e).__name__,
+                    )
                     # Continue with original data for functionality
                 output += "Members:\n"
                 for member in members:
@@ -141,7 +145,10 @@ def register_admin_tools(mcp: FastMCP):
         try:
             users = anonymize_response_data(users, data_type="users")
         except Exception as e:
-            print(f"Warning: Failed to anonymize user data: {str(e)}")
+            log_warning(
+                "Failed to anonymize user data; continuing with original data",
+                error_type=type(e).__name__,
+            )
             # Continue with original data for functionality
 
         users_info = []
@@ -208,7 +215,10 @@ def register_admin_tools(mcp: FastMCP):
         try:
             students = anonymize_response_data(students, data_type="users")
         except Exception as e:
-            print(f"Warning: Failed to anonymize student analytics data: {str(e)}")
+            log_warning(
+                "Failed to anonymize student analytics data; continuing with original data",
+                error_type=type(e).__name__,
+            )
 
         by_id = {u.get("id"): u for u in students}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,21 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from canvas_mcp.core.config import reset_config
+
+
+@pytest.fixture(autouse=True)
+def reset_config_between_tests():
+    """Discard the cached config singleton before and after each test.
+
+    Without this, the first test to call get_config() freezes the singleton
+    from its environment; later tests that patch env vars (e.g. anonymization
+    toggles) would silently read stale config.
+    """
+    reset_config()
+    yield
+    reset_config()
+
 
 @pytest.fixture
 def mock_canvas_request():

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,44 @@
+"""Tests for configuration management (singleton lifecycle, env parsing)."""
+
+import canvas_mcp.core.config as config_module
+from canvas_mcp.core.config import get_config, reset_config
+
+
+def test_get_config_returns_cached_singleton():
+    """get_config() returns the same instance until reset_config() is called."""
+    first = get_config()
+    assert get_config() is first
+    reset_config()
+    assert get_config() is not first
+
+
+def test_reset_config_rebuilds_from_current_env(monkeypatch):
+    """A value patched after first access is picked up after reset_config()."""
+    monkeypatch.setenv("MCP_SERVER_NAME", "before")
+    reset_config()
+    assert get_config().mcp_server_name == "before"
+
+    monkeypatch.setenv("MCP_SERVER_NAME", "after")
+    reset_config()
+    assert get_config().mcp_server_name == "after"
+
+
+def test_reset_config_clears_invalid_env_caches(monkeypatch):
+    """reset_config() discards stale invalid-env-var warnings.
+
+    Without clearing these module-level caches, an invalid value parsed for a
+    prior config would keep producing warnings after the env is corrected and
+    config is rebuilt.
+    """
+    monkeypatch.setenv("API_TIMEOUT", "not-an-int")
+    reset_config()
+    get_config()  # triggers _int_env -> records the invalid value
+    assert "API_TIMEOUT" in config_module._INVALID_INT_ENV_VARS
+
+    # Correct the environment and reset: the stale warning must not persist.
+    monkeypatch.setenv("API_TIMEOUT", "45")
+    reset_config()
+    assert "API_TIMEOUT" not in config_module._INVALID_INT_ENV_VARS
+
+    get_config()  # valid now -> nothing recorded
+    assert "API_TIMEOUT" not in config_module._INVALID_INT_ENV_VARS

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,26 +1,25 @@
 """Tests for configuration management (singleton lifecycle, env parsing)."""
 
 import canvas_mcp.core.config as config_module
-from canvas_mcp.core.config import get_config, reset_config
 
 
 def test_get_config_returns_cached_singleton():
     """get_config() returns the same instance until reset_config() is called."""
-    first = get_config()
-    assert get_config() is first
-    reset_config()
-    assert get_config() is not first
+    first = config_module.get_config()
+    assert config_module.get_config() is first
+    config_module.reset_config()
+    assert config_module.get_config() is not first
 
 
 def test_reset_config_rebuilds_from_current_env(monkeypatch):
     """A value patched after first access is picked up after reset_config()."""
     monkeypatch.setenv("MCP_SERVER_NAME", "before")
-    reset_config()
-    assert get_config().mcp_server_name == "before"
+    config_module.reset_config()
+    assert config_module.get_config().mcp_server_name == "before"
 
     monkeypatch.setenv("MCP_SERVER_NAME", "after")
-    reset_config()
-    assert get_config().mcp_server_name == "after"
+    config_module.reset_config()
+    assert config_module.get_config().mcp_server_name == "after"
 
 
 def test_reset_config_clears_invalid_env_caches(monkeypatch):
@@ -31,14 +30,14 @@ def test_reset_config_clears_invalid_env_caches(monkeypatch):
     config is rebuilt.
     """
     monkeypatch.setenv("API_TIMEOUT", "not-an-int")
-    reset_config()
-    get_config()  # triggers _int_env -> records the invalid value
+    config_module.reset_config()
+    config_module.get_config()  # triggers _int_env -> records the invalid value
     assert "API_TIMEOUT" in config_module._INVALID_INT_ENV_VARS
 
     # Correct the environment and reset: the stale warning must not persist.
     monkeypatch.setenv("API_TIMEOUT", "45")
-    reset_config()
+    config_module.reset_config()
     assert "API_TIMEOUT" not in config_module._INVALID_INT_ENV_VARS
 
-    get_config()  # valid now -> nothing recorded
+    config_module.get_config()  # valid now -> nothing recorded
     assert "API_TIMEOUT" not in config_module._INVALID_INT_ENV_VARS

--- a/tests/tools/test_admin_tools.py
+++ b/tests/tools/test_admin_tools.py
@@ -208,6 +208,35 @@ class TestListUsers:
 
         assert "Error" in result
 
+    @pytest.mark.asyncio
+    async def test_list_users_anonymization_failure_logs_warning(self, mock_canvas_api):
+        """A failing anonymization is reported via log_warning (stderr), not print.
+
+        Bare print() would corrupt the MCP stdio JSON-RPC stream, and str(e) could
+        leak the PII that failed to scrub. The handler must route through
+        log_warning, log only the exception type, and continue with original data.
+        """
+        mock_canvas_api['fetch_all_paginated_results'].return_value = [
+            {"id": 201, "name": "Alice Smith", "email": "alice@example.com",
+             "enrollments": [{"role": "StudentEnrollment"}]},
+        ]
+
+        with patch(
+            'canvas_mcp.tools.admin_tools.anonymize_response_data',
+            side_effect=RuntimeError("alice@example.com"),
+        ), patch('canvas_mcp.tools.admin_tools.log_warning') as mock_warn:
+            fn = get_tool_function('list_users')
+            result = await fn("badm_350_120251")
+
+        # Warning routed to logger, not stdout
+        mock_warn.assert_called_once()
+        _, kwargs = mock_warn.call_args
+        # Only the exception type is logged — never the PII-bearing message
+        assert kwargs.get("error_type") == "RuntimeError"
+        assert "alice@example.com" not in str(mock_warn.call_args)
+        # Falls back to original (un-anonymized) data so the tool still works
+        assert "201" in result
+
 
 # ---------------------------------------------------------------------------
 # get_student_analytics

--- a/tests/tools/test_admin_tools.py
+++ b/tests/tools/test_admin_tools.py
@@ -155,6 +155,27 @@ class TestListGroups:
 
         assert "Error" in result
 
+    @pytest.mark.asyncio
+    async def test_list_groups_anonymization_failure_logs_warning(self, mock_canvas_api):
+        """A failing member anonymization is reported via log_warning, not print."""
+        mock_canvas_api['fetch_all_paginated_results'].side_effect = [
+            [{"id": 1, "name": "Group A", "group_category_id": 10, "members_count": 1}],
+            [{"id": 101, "name": "Alice", "email": "alice@example.com"}],
+        ]
+
+        with patch(
+            'canvas_mcp.tools.admin_tools.anonymize_response_data',
+            side_effect=RuntimeError("alice@example.com"),
+        ), patch('canvas_mcp.tools.admin_tools.log_warning') as mock_warn:
+            fn = get_tool_function('list_groups')
+            result = await fn("badm_350_120251")
+
+        mock_warn.assert_called_once()
+        _, kwargs = mock_warn.call_args
+        assert kwargs.get("error_type") == "RuntimeError"
+        assert "alice@example.com" not in str(mock_warn.call_args)
+        assert "Group A" in result  # falls back to original data
+
 
 # ---------------------------------------------------------------------------
 # list_users
@@ -292,3 +313,26 @@ class TestGetStudentAnalytics:
         result = await fn("badm_350_120251")
 
         assert "0" in result or "No" in result or "students" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_get_student_analytics_anonymization_failure_logs_warning(self, mock_canvas_api):
+        """A failing student anonymization is reported via log_warning, not print."""
+        mock_canvas_api['make_canvas_request'].return_value = {
+            "id": 60366, "name": "Business Administration 350"
+        }
+        mock_canvas_api['fetch_all_paginated_results'].side_effect = [
+            [{"id": 301, "name": "Alice", "email": "alice@example.com"}],  # students
+            [{"id": 401, "name": "HW1", "published": True, "points_possible": 100}],  # assignments
+        ]
+
+        with patch(
+            'canvas_mcp.tools.admin_tools.anonymize_response_data',
+            side_effect=RuntimeError("alice@example.com"),
+        ), patch('canvas_mcp.tools.admin_tools.log_warning') as mock_warn:
+            fn = get_tool_function('get_student_analytics')
+            await fn("badm_350_120251")
+
+        mock_warn.assert_called_once()
+        _, kwargs = mock_warn.call_args
+        assert kwargs.get("error_type") == "RuntimeError"
+        assert "alice@example.com" not in str(mock_warn.call_args)


### PR DESCRIPTION
## Summary

Ports the portable **architecture** refactors from the `jaymesdec` fork's
`claude/canvas-mcp-refactor-e9o3mt` session into upstream, adapted by hand
(the fork's history has no merge base with `main`, so literal `git cherry-pick`
wasn't viable). The fork is far ahead in *features* (130 tools, plus
accounts/gradebook/google_auth modules that don't exist here); only the
genuinely portable, low-risk refactor pieces are included. **Public MCP tool
surface is unchanged.**

## Changes

**1. Config: drop the import-time singleton (`ef5aa39`)** — ported from fork `5cfc113`
- `config.py` ended with `API_BASE_URL = get_config().api_base_url` / `API_TOKEN = ...`,
  dead legacy constants (used nowhere but re-exported) that forced the config singleton
  to be built **at import time** — before any test could patch env vars, making
  env-dependent behavior effectively untestable.
- Removed those constants and their `core/__init__.py` exports.
- Removed the legacy `api_base_url`/`api_token` `Config` properties; repointed the stdio
  HTTP client in `client.py` to the canonical `canvas_api_url`/`canvas_api_token` attrs.
- Added `reset_config()` + an autouse `conftest` fixture that resets config around every test.

**2. Route anonymization warnings to stderr, not stdout (`02855de`)** — ported from fork `f5008e6`
- Three handlers in `admin_tools.py` used bare `print()`, writing to **stdout** — the MCP
  JSON-RPC transport channel for stdio servers — which can corrupt the protocol stream.
  They also interpolated `str(e)`, which on an anonymization failure may contain the very
  PII that failed to scrub.
- Routed all three through `log_warning()` (stderr), logging only the **exception type**.

**3. Lint (`9806cd2`)** — `ruff check src/` reported one import-spacing violation in `server.py`;
fixed. Whole `src/` tree now passes `ruff check`.

## Architecture survey

Reviewed the tool-registration wiring (`server.py` / `tools/__init__.py`): the explicit,
role-based registration is clean and readable — an auto-discovery registry would add risk
and reduce clarity, so it was left as-is.

## Testing
- `uv run python -m pytest tests/` → **391 passed, 21 skipped** (matches baseline).
- `ruff check src/` → clean.
- Automated diff review (high effort) → 0 findings.

## Deferred
The fork's `list_assignments` filtering/pagination (`0b0647c`) is a *feature*, not a refactor —
portable later if wanted, out of scope here.

https://claude.ai/code/session_01C8DNJyNnW3eMpYwRaz9bRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8DNJyNnW3eMpYwRaz9bRo)_