### PR TITLE
feat(http): token-only fail-closed auth for hosted multi-user HTTP MCP (#115)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,18 +21,27 @@ RUN uv pip install --system --no-cache -e .
 RUN adduser --disabled-password --gecos '' mcp && \
     chown -R mcp:mcp /app
 
-# Set environment variables (users must provide CANVAS_API_TOKEN and CANVAS_API_URL at runtime)
-# Example: docker run -e CANVAS_API_TOKEN=xyz -e CANVAS_API_URL=https://... canvas-mcp
+# Set environment variables.
+# HTTP deployments pin CANVAS_API_URL at runtime and must NOT set CANVAS_API_TOKEN —
+# callers supply their own token per request via the X-Canvas-Token header.
+# Code execution (execute_typescript) ships OFF by default for this network-facing
+# image; opt in with -e EXECUTE_TYPESCRIPT_ENABLED=true only behind real auth.
+# Example (stdio/local): docker run -e CANVAS_API_TOKEN=xyz -e CANVAS_API_URL=https://... canvas-mcp
 ENV MCP_SERVER_NAME="canvas-mcp" \
     ENABLE_DATA_ANONYMIZATION="false" \
-    ANONYMIZATION_DEBUG="false"
+    ANONYMIZATION_DEBUG="false" \
+    EXECUTE_TYPESCRIPT_ENABLED="false"
 
 # Switch to non-root user
 USER mcp
+
+# HTTP port the container listens on (App Service injects PORT/WEBSITES_PORT)
+EXPOSE 8819
 
 # Health check to verify installation
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD python -c "import canvas_mcp; print('OK')" || exit 1
 
-# Run the MCP server
-CMD ["canvas-mcp-server"]
+# Run the MCP server over HTTP (required for container/ingress; stdio is unreachable).
+# Honors the platform-injected port, falling back to 8819.
+CMD ["sh", "-c", "canvas-mcp-server --transport streamable-http --host 0.0.0.0 --port ${PORT:-${WEBSITES_PORT:-8819}}"]

--- a/env.template
+++ b/env.template
@@ -38,6 +38,13 @@ TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
 # Controls which tools are registered: student (~31), educator (~86), all (default)
 # CANVAS_ROLE=all
 
+# HTTP transport — multi-user access-key gate (Optional; HTTP mode only)
+# Comma/space-separated list of accepted keys. An HTTP caller must send a
+# matching X-MCP-Access-Key header. Leave empty to disable (rely on external
+# auth). Ignored entirely in stdio mode. In HTTP mode, also pin CANVAS_API_URL
+# and do NOT set CANVAS_API_TOKEN — each caller sends their own X-Canvas-Token.
+# MCP_ACCESS_KEYS=
+
 # Optional Metadata
 INSTITUTION_NAME=Your Institution Name
 TIMEZONE=UTC

--- a/src/canvas_mcp/core/client.py
+++ b/src/canvas_mcp/core/client.py
@@ -2,13 +2,15 @@
 
 import asyncio
 import weakref
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 from urllib.parse import urlencode
 
 import httpx
 
 from .anonymization import anonymize_response_data
-from .credentials import get_request_credentials
+from .credentials import get_request_credentials, is_http_request_active
 from .logging import log_debug, log_error, log_warning, sanitize_url
 
 # Rate limit retry configuration
@@ -17,6 +19,16 @@ INITIAL_BACKOFF_SECONDS = 2
 
 # Default number of results per page for paginated requests
 DEFAULT_PAGE_SIZE = 100
+
+
+def _canvas_auth_headers(api_token: str) -> dict[str, str]:
+    """Build the standard Canvas auth + User-Agent headers for a token."""
+    from .. import __version__
+
+    return {
+        "Authorization": f"Bearer {api_token}",
+        "User-Agent": f"canvas-mcp/{__version__} (https://github.com/vishalsachdev/canvas-mcp)",
+    }
 
 # HTTP client will be initialized with configuration
 http_client: httpx.AsyncClient | None = None
@@ -139,14 +151,10 @@ def _get_http_client() -> httpx.AsyncClient:
         _http_client_loop_ref = None
 
     if http_client is None:
-        from .. import __version__
         from .config import get_config
         config = get_config()
         http_client = httpx.AsyncClient(
-            headers={
-                'Authorization': f'Bearer {config.canvas_api_token}',
-                'User-Agent': f'canvas-mcp/{__version__} (https://github.com/vishalsachdev/canvas-mcp)'
-            },
+            headers=_canvas_auth_headers(config.canvas_api_token),
             timeout=config.api_timeout
         )
         _http_client_loop_ref = weakref.ref(current_loop) if current_loop is not None else None
@@ -159,6 +167,35 @@ async def cleanup_http_client() -> None:
     if http_client is not None:
         await http_client.aclose()
         http_client = None
+
+
+@asynccontextmanager
+async def canvas_authenticated_client() -> AsyncIterator[httpx.AsyncClient]:
+    """Yield a Canvas-authenticated httpx client for the current context.
+
+    Resolution, fail-closed:
+    - Per-request credentials present (HTTP mode) -> a fresh client with the
+      caller's token.
+    - No per-request credentials but an HTTP request is active -> raise
+      PermissionError (never fall back to the server's own token).
+    - Otherwise (stdio mode) -> the shared global client (env-based token).
+    """
+    from .config import get_config
+
+    req_creds = get_request_credentials()
+    if req_creds:
+        config = get_config()
+        async with httpx.AsyncClient(
+            headers=_canvas_auth_headers(req_creds.api_token),
+            timeout=config.api_timeout,
+        ) as client:
+            yield client
+        return
+
+    if is_http_request_active():
+        raise PermissionError("Canvas token required for HTTP request")
+
+    yield _get_http_client()
 
 
 async def make_canvas_request(
@@ -196,17 +233,20 @@ async def make_canvas_request(
 
     if req_creds:
         # Per-request client with user's credentials (HTTP mode)
-        from .. import __version__
-
         client = httpx.AsyncClient(
-            headers={
-                "Authorization": f"Bearer {req_creds.api_token}",
-                "User-Agent": f"canvas-mcp/{__version__} (https://github.com/vishalsachdev/canvas-mcp)",
-            },
+            headers=_canvas_auth_headers(req_creds.api_token),
             timeout=config.api_timeout,
         )
         url = f"{req_creds.api_url.rstrip('/')}{endpoint}"
         _close_client = True
+    elif is_http_request_active():
+        # HTTP request without a per-request token: fail closed. Never fall
+        # back to the server's own credentials (would mis-attribute actions).
+        log_warning(
+            "Blocked Canvas API request without per-request Canvas token",
+            endpoint=sanitize_url(endpoint),
+        )
+        return {"error": "Canvas token required for HTTP request"}
     else:
         # Global client (stdio mode)
         client = _get_http_client()
@@ -399,27 +439,17 @@ async def upload_file_to_storage(
                 # Redirect - follow it to get file info from Canvas
                 redirect_url = response.headers.get('Location')
                 if redirect_url:
-                    # Follow the redirect to get file info
-                    # This goes back to Canvas API, needs auth
-                    req_creds = get_request_credentials()
-                    if req_creds:
-                        from .. import __version__
-
-                        async with httpx.AsyncClient(
-                            headers={
-                                "Authorization": f"Bearer {req_creds.api_token}",
-                                "User-Agent": f"canvas-mcp/{__version__} (https://github.com/vishalsachdev/canvas-mcp)",
-                            },
-                            timeout=config.api_timeout,
-                        ) as canvas_client:
+                    # Follow the redirect to get file info. This goes back to the
+                    # Canvas API and needs auth; route through the shared
+                    # fail-closed resolver so HTTP mode never uses the server's
+                    # own token.
+                    try:
+                        async with canvas_authenticated_client() as canvas_client:
                             confirm_response = await canvas_client.get(redirect_url)
                             confirm_response.raise_for_status()
                             return confirm_response.json()
-                    else:
-                        canvas_client = _get_http_client()
-                        confirm_response = await canvas_client.get(redirect_url)
-                        confirm_response.raise_for_status()
-                        return confirm_response.json()
+                    except PermissionError as e:
+                        return {"error": str(e)}
                 else:
                     return {"error": "Redirect without Location header"}
 

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -15,6 +15,13 @@ _INVALID_FLOAT_ENV_VARS: dict[str, str] = {}
 VALID_SANDBOX_MODES = frozenset({"auto", "local", "container"})
 
 
+def _parse_keys(raw: str) -> frozenset[str]:
+    """Parse a comma/whitespace-separated list of access keys into a set."""
+    if not raw:
+        return frozenset()
+    return frozenset(k for k in raw.replace(",", " ").split() if k)
+
+
 def _bool_env(name: str, default: bool) -> bool:
     value = os.getenv(name)
     if value is None:
@@ -91,6 +98,12 @@ class Config:
         # Code execution kill switch — set EXECUTE_TYPESCRIPT_ENABLED=false to
         # disable the execute_typescript tool without changing CANVAS_ROLE.
         self.execute_typescript_enabled = _bool_env("EXECUTE_TYPESCRIPT_ENABLED", True)
+
+        # HTTP access-key gate (v1, multi-user). Comma- or whitespace-separated
+        # list of accepted keys; an HTTP caller must present a matching
+        # X-MCP-Access-Key header. Empty disables the gate (rely on external
+        # auth). stdio mode ignores this entirely.
+        self.mcp_access_keys = _parse_keys(os.getenv("MCP_ACCESS_KEYS", ""))
 
         # Optional metadata
         self.institution_name = os.getenv("INSTITUTION_NAME", "")

--- a/src/canvas_mcp/core/credentials.py
+++ b/src/canvas_mcp/core/credentials.py
@@ -1,12 +1,16 @@
 """Per-request credential context for HTTP transport.
 
 When the server runs in HTTP mode, each request carries its own Canvas API
-credentials via headers (X-Canvas-Token, X-Canvas-URL). This module uses
-Python's contextvars to thread those credentials through the async call
-stack without modifying any tool signatures.
+token via the X-Canvas-Token header. The Canvas API URL is pinned by server
+configuration (CANVAS_API_URL), never supplied by the client. This module
+uses Python's contextvars to thread the per-request token through the async
+call stack without modifying any tool signatures.
 
 In stdio mode, the ContextVar remains unset (None), and the client falls
-back to the global .env-based configuration.
+back to the global .env-based configuration. To keep that fallback from
+leaking the server's own token in HTTP mode, an additional ``_http_request_active``
+marker distinguishes "HTTP request with no token" (must fail closed) from
+"stdio mode" (env fallback is intended).
 """
 
 from contextvars import ContextVar
@@ -25,6 +29,10 @@ _request_credentials: ContextVar[RequestCredentials | None] = ContextVar(
     "request_credentials", default=None
 )
 
+_http_request_active: ContextVar[bool] = ContextVar(
+    "http_request_active", default=False
+)
+
 
 def get_request_credentials() -> RequestCredentials | None:
     """Get the current request's Canvas credentials, or None for stdio mode."""
@@ -39,3 +47,23 @@ def set_request_credentials(creds: RequestCredentials) -> None:
 def clear_request_credentials() -> None:
     """Clear credentials after request completes."""
     _request_credentials.set(None)
+
+
+def is_http_request_active() -> bool:
+    """Return True while handling an HTTP request.
+
+    Used to fail closed: in HTTP mode a missing per-request token must never
+    fall back to the server's own credentials.
+    """
+    return _http_request_active.get()
+
+
+def set_http_request_active(active: bool = True) -> None:
+    """Mark whether the current async context is handling an HTTP request."""
+    _http_request_active.set(active)
+
+
+def clear_http_request_context() -> None:
+    """Clear all per-request HTTP context after the request completes."""
+    _request_credentials.set(None)
+    _http_request_active.set(False)

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -9,12 +9,13 @@ academic tracking.
 
 Supports two transport modes:
 - stdio (default): Local process communication, credentials from .env
-- streamable-http: HTTP server, per-request credentials via X-Canvas-Token/X-Canvas-URL headers
+- streamable-http: HTTP server, per-request token via X-Canvas-Token header;
+  the Canvas API URL is pinned by server config (CANVAS_API_URL), not the client.
 """
 
 import argparse
 import asyncio
-import re
+import json
 import sys
 from typing import Any
 
@@ -23,7 +24,8 @@ from mcp.server.fastmcp import FastMCP
 from .core.config import get_config, validate_config
 from .core.credentials import (
     RequestCredentials,
-    clear_request_credentials,
+    clear_http_request_context,
+    set_http_request_active,
     set_request_credentials,
 )
 from .core.logging import log_error, log_info, log_warning
@@ -53,50 +55,70 @@ from .tools import (
     register_student_tools,
 )
 
-_CANVAS_URL_RE = re.compile(
-    r"^https://[a-zA-Z0-9.-]+\.instructure\.com/api/v1$"
-)
+
+async def _send_json_error(send: Any, status: int, message: str) -> None:
+    """Emit a minimal ASGI JSON error response (used to fail closed)."""
+    body = json.dumps({"error": message}).encode("utf-8")
+    await send({
+        "type": "http.response.start",
+        "status": status,
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(body)).encode("ascii")),
+        ],
+    })
+    await send({"type": "http.response.body", "body": body})
 
 
 class CanvasCredentialMiddleware:
-    """ASGI middleware that extracts Canvas credentials from HTTP headers.
+    """ASGI middleware that extracts the caller's Canvas token from headers.
 
-    For each incoming HTTP request, reads X-Canvas-Token and X-Canvas-URL
-    headers and sets them in the ContextVar so make_canvas_request uses
-    the caller's credentials instead of the server's .env config.
+    For each incoming HTTP request, reads X-Canvas-Token and combines it with
+    the server-pinned CANVAS_API_URL so make_canvas_request uses the caller's
+    own Canvas token instead of any server .env token.
 
-    The X-Canvas-URL header is validated against a strict allowlist pattern
-    (must be an instructure.com HTTPS URL ending in /api/v1) to prevent SSRF.
+    Fail-closed semantics:
+    - A missing/blank X-Canvas-Token returns HTTP 401 before the app runs.
+    - X-Canvas-URL is ignored (logged); the Canvas API URL is never
+      client-controlled, which removes the SSRF surface entirely.
+    - The "HTTP request active" marker is set so downstream code refuses to
+      fall back to the server's own credentials.
     """
 
     def __init__(self, app: Any) -> None:
         self.app = app
 
     async def __call__(self, scope: dict, receive: Any, send: Any) -> None:
-        if scope["type"] == "http":
-            # Parse headers from ASGI scope (list of [name, value] byte pairs)
-            headers = dict(scope.get("headers", []))
-            token = headers.get(b"x-canvas-token", b"").decode()
-            canvas_url = headers.get(b"x-canvas-url", b"").decode()
-
-            if token and canvas_url:
-                if not _CANVAS_URL_RE.match(canvas_url):
-                    log_warning(
-                        "Rejected invalid X-Canvas-URL header; "
-                        "must be https://*.instructure.com/api/v1",
-                        url=canvas_url,
-                    )
-                else:
-                    set_request_credentials(
-                        RequestCredentials(api_token=token, api_url=canvas_url)
-                    )
-            try:
-                await self.app(scope, receive, send)
-            finally:
-                clear_request_credentials()
-        else:
+        if scope["type"] != "http":
             # Passthrough for lifespan and other non-HTTP scopes
             await self.app(scope, receive, send)
+            return
+
+        set_http_request_active(True)
+        try:
+            # Parse headers from ASGI scope (list of [name, value] byte pairs)
+            headers = dict(scope.get("headers", []))
+            token = headers.get(b"x-canvas-token", b"").decode("utf-8", errors="ignore").strip()
+
+            if b"x-canvas-url" in headers:
+                log_warning("Ignoring X-Canvas-URL header; Canvas API URL is server-pinned")
+
+            if not token:
+                await _send_json_error(send, 401, "Missing X-Canvas-Token header")
+                return
+
+            canvas_url = get_config().canvas_api_url.strip()
+            if not canvas_url:
+                log_error("CANVAS_API_URL is required in HTTP mode but is not configured")
+                await _send_json_error(send, 500, "Server Canvas API URL is not configured")
+                return
+
+            set_request_credentials(
+                RequestCredentials(api_token=token, api_url=canvas_url)
+            )
+            await self.app(scope, receive, send)
+        finally:
+            clear_http_request_context()
 
 
 def create_server(
@@ -242,14 +264,27 @@ def main() -> None:
     args = parser.parse_args()
     is_http = args.transport == "streamable-http"
 
-    # In HTTP mode, .env credentials are optional (per-request auth instead)
-    if not is_http:
+    config = get_config()
+
+    # HTTP mode: the Canvas URL is server-pinned and per-user tokens arrive via
+    # X-Canvas-Token. A server token must NOT be set, or a missing request token
+    # could silently fall back to it (mis-attributing actions to the operator).
+    if is_http:
+        if not config.canvas_api_url:
+            log_error("CANVAS_API_URL is required in HTTP mode (the Canvas API URL is server-pinned)")
+            sys.exit(1)
+        if config.canvas_api_token:
+            log_error(
+                "CANVAS_API_TOKEN must NOT be set in HTTP mode — clients supply their "
+                "own token via the X-Canvas-Token header. Unset it and restart."
+            )
+            sys.exit(1)
+    else:
+        # stdio mode: .env credentials are required (single-user, env-based auth)
         if not validate_config():
             log_error("Please check your .env file configuration")
             log_error("Use the env.template file as a reference")
             sys.exit(1)
-
-    config = get_config()
 
     # Handle special commands
     if args.config:
@@ -314,7 +349,7 @@ def main() -> None:
         log_info(
             f"Starting Canvas MCP server in HTTP mode on {args.host}:{args.port}"
         )
-        log_info("Credentials: per-request via X-Canvas-Token / X-Canvas-URL headers")
+        log_info("Credentials: per-request via X-Canvas-Token header; Canvas API URL is server-pinned")
     else:
         log_info(f"Starting Canvas MCP server with API URL: {config.canvas_api_url}")
 

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -15,6 +15,7 @@ Supports two transport modes:
 
 import argparse
 import asyncio
+import hmac
 import json
 import sys
 from typing import Any
@@ -70,6 +71,15 @@ async def _send_json_error(send: Any, status: int, message: str) -> None:
     await send({"type": "http.response.body", "body": body})
 
 
+def _access_key_ok(presented: str, allowed: frozenset[str]) -> bool:
+    """Constant-time check of a presented access key against the allowed set."""
+    if not presented:
+        return False
+    # compare_digest against each key; the any() still runs every comparison's
+    # constant-time op, avoiding early-exit timing leaks on the matched key.
+    return any(hmac.compare_digest(presented, key) for key in allowed)
+
+
 class CanvasCredentialMiddleware:
     """ASGI middleware that extracts the caller's Canvas token from headers.
 
@@ -78,6 +88,8 @@ class CanvasCredentialMiddleware:
     own Canvas token instead of any server .env token.
 
     Fail-closed semantics:
+    - When MCP_ACCESS_KEYS is configured, a missing/invalid X-MCP-Access-Key
+      returns HTTP 401 before anything else (the v1 multi-user gate).
     - A missing/blank X-Canvas-Token returns HTTP 401 before the app runs.
     - X-Canvas-URL is ignored (logged); the Canvas API URL is never
       client-controlled, which removes the SSRF surface entirely.
@@ -98,6 +110,16 @@ class CanvasCredentialMiddleware:
         try:
             # Parse headers from ASGI scope (list of [name, value] byte pairs)
             headers = dict(scope.get("headers", []))
+            config = get_config()
+
+            # v1 access-key gate (when configured): reject before touching creds.
+            allowed_keys = config.mcp_access_keys
+            if allowed_keys:
+                presented = headers.get(b"x-mcp-access-key", b"").decode("utf-8", errors="ignore").strip()
+                if not _access_key_ok(presented, allowed_keys):
+                    await _send_json_error(send, 401, "Invalid or missing X-MCP-Access-Key")
+                    return
+
             token = headers.get(b"x-canvas-token", b"").decode("utf-8", errors="ignore").strip()
 
             if b"x-canvas-url" in headers:
@@ -107,7 +129,7 @@ class CanvasCredentialMiddleware:
                 await _send_json_error(send, 401, "Missing X-Canvas-Token header")
                 return
 
-            canvas_url = get_config().canvas_api_url.strip()
+            canvas_url = config.canvas_api_url.strip()
             if not canvas_url:
                 log_error("CANVAS_API_URL is required in HTTP mode but is not configured")
                 await _send_json_error(send, 500, "Server Canvas API URL is not configured")
@@ -279,6 +301,12 @@ def main() -> None:
                 "own token via the X-Canvas-Token header. Unset it and restart."
             )
             sys.exit(1)
+        if not config.mcp_access_keys:
+            log_warning(
+                "HTTP mode has no MCP_ACCESS_KEYS configured — the endpoint is NOT "
+                "key-gated. Anyone who can reach it and holds a Canvas token can connect. "
+                "Set MCP_ACCESS_KEYS or place the endpoint behind external authentication."
+            )
     else:
         # stdio mode: .env credentials are required (single-user, env-based auth)
         if not validate_config():

--- a/src/canvas_mcp/tools/code_execution.py
+++ b/src/canvas_mcp/tools/code_execution.py
@@ -17,6 +17,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
 from ..core.config import get_config
+from ..core.credentials import get_request_credentials, is_http_request_active
 from ..core.logging import log_warning
 from ..core.validation import validate_params
 
@@ -32,20 +33,35 @@ _SAFE_ENV_KEYS = frozenset({
 })
 
 
+def _resolve_canvas_credentials(config: Any) -> tuple[str, str]:
+    """Resolve (canvas_api_url, canvas_api_token) for the current context.
+
+    Fail-closed: in HTTP mode the caller's per-request token is required and
+    the server's own token is never used for code execution.
+    """
+    req_creds = get_request_credentials()
+    if req_creds:
+        return req_creds.api_url, req_creds.api_token
+    if is_http_request_active():
+        raise PermissionError("Canvas token required for HTTP code execution")
+    return config.canvas_api_url, config.canvas_api_token
+
+
 def _build_safe_env(config: Any) -> dict[str, str]:
     """Build a filtered environment dict for subprocess execution.
 
     Only passes through keys in _SAFE_ENV_KEYS, plus explicitly adds
-    CANVAS_API_URL and CANVAS_API_TOKEN from config.
+    CANVAS_API_URL and CANVAS_API_TOKEN from the request context or config.
     """
     env: dict[str, str] = {}
     for key in _SAFE_ENV_KEYS:
         val = os.environ.get(key)
         if val is not None:
             env[key] = val
-    # Explicitly add Canvas credentials from config
-    env["CANVAS_API_URL"] = config.canvas_api_url
-    env["CANVAS_API_TOKEN"] = config.canvas_api_token
+    # Explicitly add Canvas credentials (per-request token in HTTP mode)
+    canvas_api_url, canvas_api_token = _resolve_canvas_credentials(config)
+    env["CANVAS_API_URL"] = canvas_api_url
+    env["CANVAS_API_TOKEN"] = canvas_api_token
     return env
 
 
@@ -319,6 +335,11 @@ def register_code_execution_tools(mcp: FastMCP) -> None:
         config = get_config()
         warnings: list[str] = []
 
+        try:
+            canvas_api_url, _canvas_api_token = _resolve_canvas_credentials(config)
+        except PermissionError as e:
+            return f"❌ {str(e)}"
+
         sandbox_enabled = config.enable_ts_sandbox
         sandbox_mode_setting = config.ts_sandbox_mode
         if sandbox_mode_setting not in {"auto", "local", "container"}:
@@ -326,7 +347,7 @@ def register_code_execution_tools(mcp: FastMCP) -> None:
 
         block_outbound = config.ts_sandbox_block_outbound_network
         allowlist_hosts = _parse_allowlist_hosts(config.ts_sandbox_allowlist_hosts)
-        canvas_host = _normalize_host(config.canvas_api_url)
+        canvas_host = _normalize_host(canvas_api_url)
         if sandbox_enabled and block_outbound and canvas_host:
             if canvas_host not in allowlist_hosts:
                 allowlist_hosts.append(canvas_host)
@@ -468,9 +489,9 @@ def register_code_execution_tools(mcp: FastMCP) -> None:
                     "-w",
                     "/workspace",
                     "-e",
-                    f"CANVAS_API_URL={config.canvas_api_url}",
+                    f"CANVAS_API_URL={canvas_api_url}",
                     "-e",
-                    f"CANVAS_API_TOKEN={config.canvas_api_token}",
+                    f"CANVAS_API_TOKEN={_canvas_api_token}",
                 ])
                 if node_options_container:
                     cmd.extend(["-e", f"NODE_OPTIONS={node_options_container}"])

--- a/src/canvas_mcp/tools/files.py
+++ b/src/canvas_mcp/tools/files.py
@@ -20,7 +20,7 @@ from mcp.types import ToolAnnotations
 
 from ..core.cache import get_course_code, get_course_id
 from ..core.client import (
-    _get_http_client,
+    canvas_authenticated_client,
     fetch_all_paginated_results,
     make_canvas_request,
     upload_file_to_storage,
@@ -84,16 +84,16 @@ def register_shared_file_tools(mcp: FastMCP):
             return "Error: Invalid filename - path outside allowed directory"
 
         # Download the file using streaming to handle large files efficiently
-        client = _get_http_client()
         try:
             total_bytes = 0
-            async with client.stream("GET", download_url, follow_redirects=True) as response:
-                response.raise_for_status()
+            async with canvas_authenticated_client() as client:
+                async with client.stream("GET", download_url, follow_redirects=True) as response:
+                    response.raise_for_status()
 
-                with open(save_path, 'wb') as f:
-                    async for chunk in response.aiter_bytes(chunk_size=8192):
-                        f.write(chunk)
-                        total_bytes += len(chunk)
+                    with open(save_path, 'wb') as f:
+                        async for chunk in response.aiter_bytes(chunk_size=8192):
+                            f.write(chunk)
+                            total_bytes += len(chunk)
 
             size_str = format_file_size(total_bytes)
             course_display = await get_course_code(course_id) or course_identifier
@@ -169,19 +169,19 @@ def register_shared_file_tools(mcp: FastMCP):
             )
 
         # Download the file content into memory
-        client = _get_http_client()
         try:
             buffer = bytearray()
-            async with client.stream("GET", download_url, follow_redirects=True) as response:
-                response.raise_for_status()
+            async with canvas_authenticated_client() as client:
+                async with client.stream("GET", download_url, follow_redirects=True) as response:
+                    response.raise_for_status()
 
-                async for chunk in response.aiter_bytes(chunk_size=8192):
-                    if len(buffer) + len(chunk) > max_size_bytes:
-                        return (
-                            f"Error: File '{filename}' exceeds the {effective_max_mb} MB limit "
-                            f"during download. Use download_course_file instead for large files."
-                        )
-                    buffer.extend(chunk)
+                    async for chunk in response.aiter_bytes(chunk_size=8192):
+                        if len(buffer) + len(chunk) > max_size_bytes:
+                            return (
+                                f"Error: File '{filename}' exceeds the {effective_max_mb} MB limit "
+                                f"during download. Use download_course_file instead for large files."
+                            )
+                        buffer.extend(chunk)
 
             base64_content = base64.b64encode(buffer).decode("ascii")
 

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -6,10 +6,20 @@ import pytest
 
 from canvas_mcp.core.credentials import (
     RequestCredentials,
+    clear_http_request_context,
     clear_request_credentials,
     get_request_credentials,
+    is_http_request_active,
+    set_http_request_active,
     set_request_credentials,
 )
+
+
+class _FakeConfig:
+    """Minimal stand-in for the config object the middleware reads."""
+
+    def __init__(self, canvas_api_url="https://canvas.illinois.edu/api/v1"):
+        self.canvas_api_url = canvas_api_url
 
 # ---------------------------------------------------------------------------
 # ContextVar credential tests
@@ -68,8 +78,8 @@ class TestCanvasCredentialMiddleware:
         return CanvasCredentialMiddleware(inner_app)
 
     @pytest.mark.asyncio
-    async def test_extracts_headers_and_sets_credentials(self, middleware):
-        """Middleware sets ContextVar from X-Canvas-Token and X-Canvas-URL headers."""
+    async def test_token_only_pins_url(self, middleware):
+        """Middleware sets creds from X-Canvas-Token and the SERVER-pinned URL."""
         captured_creds = {}
 
         async def capture_app(scope, receive, send):
@@ -77,112 +87,114 @@ class TestCanvasCredentialMiddleware:
             if creds:
                 captured_creds["token"] = creds.api_token
                 captured_creds["url"] = creds.api_url
+                captured_creds["http_active"] = is_http_request_active()
+
+        middleware.app = capture_app
+
+        scope = {
+            "type": "http",
+            "headers": [(b"x-canvas-token", b"my-secret-token")],
+        }
+        with patch(
+            "canvas_mcp.server.get_config",
+            return_value=_FakeConfig("https://canvas.illinois.edu/api/v1"),
+        ):
+            await middleware(scope, AsyncMock(), AsyncMock())
+
+        assert captured_creds["token"] == "my-secret-token"
+        # URL comes from server config, NOT the client
+        assert captured_creds["url"] == "https://canvas.illinois.edu/api/v1"
+        assert captured_creds["http_active"] is True
+        # Context cleared after request
+        assert get_request_credentials() is None
+        assert is_http_request_active() is False
+
+    @pytest.mark.asyncio
+    async def test_canvas_url_header_is_ignored(self, middleware):
+        """A client-supplied X-Canvas-URL is ignored; the pinned URL is always used."""
+        captured = {}
+
+        async def capture_app(scope, receive, send):
+            creds = get_request_credentials()
+            captured["url"] = creds.api_url if creds else None
 
         middleware.app = capture_app
 
         scope = {
             "type": "http",
             "headers": [
-                (b"x-canvas-token", b"my-secret-token"),
-                (b"x-canvas-url", b"https://school.instructure.com/api/v1"),
+                (b"x-canvas-token", b"tok"),
+                # Attacker-controlled URL must have no effect (SSRF prevention).
+                (b"x-canvas-url", b"http://169.254.169.254/latest/meta-data/"),
             ],
         }
-        await middleware(scope, AsyncMock(), AsyncMock())
+        with patch(
+            "canvas_mcp.server.get_config",
+            return_value=_FakeConfig("https://canvas.illinois.edu/api/v1"),
+        ):
+            await middleware(scope, AsyncMock(), AsyncMock())
 
-        assert captured_creds["token"] == "my-secret-token"
-        assert captured_creds["url"] == "https://school.instructure.com/api/v1"
-        # Credentials should be cleared after request
+        assert captured["url"] == "https://canvas.illinois.edu/api/v1"
+
+    @pytest.mark.asyncio
+    async def test_missing_token_returns_401(self, middleware):
+        """Without X-Canvas-Token, the request is rejected 401 and the app never runs."""
+        app_called = {"value": False}
+
+        async def inner(scope, receive, send):
+            app_called["value"] = True
+
+        middleware.app = inner
+        send = AsyncMock()
+
+        scope = {"type": "http", "headers": []}
+        await middleware(scope, AsyncMock(), send)
+
+        assert app_called["value"] is False  # fail closed: inner app not reached
+        # First send call is the response start with status 401
+        first_call = send.call_args_list[0][0][0]
+        assert first_call["type"] == "http.response.start"
+        assert first_call["status"] == 401
+        # Context cleared
         assert get_request_credentials() is None
+        assert is_http_request_active() is False
 
     @pytest.mark.asyncio
-    async def test_rejects_non_instructure_url(self, middleware):
-        """Middleware rejects X-Canvas-URL values that are not instructure.com URLs (SSRF prevention)."""
-        captured_creds = {"set": False}
+    async def test_blank_token_returns_401(self, middleware):
+        """A blank/whitespace X-Canvas-Token is treated as missing."""
+        app_called = {"value": False}
 
-        async def check_app(scope, receive, send):
-            captured_creds["set"] = get_request_credentials() is not None
+        async def inner(scope, receive, send):
+            app_called["value"] = True
 
-        middleware.app = check_app
+        middleware.app = inner
+        send = AsyncMock()
 
-        for bad_url in [
-            "http://169.254.169.254/latest/meta-data/",
-            "https://evil.example.com/api/v1",
-            "https://school.instructure.com.evil.com/api/v1",
-            "http://school.instructure.com/api/v1",  # http not https
-            "https://school.instructure.com/api/v1/extra",  # extra path
-            "",
-        ]:
-            captured_creds["set"] = False
-            scope = {
-                "type": "http",
-                "headers": [
-                    (b"x-canvas-token", b"tok"),
-                    (b"x-canvas-url", bad_url.encode()),
-                ],
-            }
-            await middleware(scope, AsyncMock(), AsyncMock())
-            assert captured_creds["set"] is False, f"Should have rejected URL: {bad_url}"
+        scope = {"type": "http", "headers": [(b"x-canvas-token", b"   ")]}
+        await middleware(scope, AsyncMock(), send)
+
+        assert app_called["value"] is False
+        assert send.call_args_list[0][0][0]["status"] == 401
 
     @pytest.mark.asyncio
-    async def test_accepts_valid_instructure_urls(self, middleware):
-        """Middleware accepts valid instructure.com HTTPS /api/v1 URLs."""
-        for good_url in [
-            "https://school.instructure.com/api/v1",
-            "https://my-university.instructure.com/api/v1",
-            "https://canvas.instructure.com/api/v1",
-        ]:
-            captured_creds: dict = {}
-
-            async def capture_app(scope, receive, send, _url=good_url):
-                creds = get_request_credentials()
-                if creds:
-                    captured_creds["url"] = creds.api_url
-
-            middleware.app = capture_app
-            scope = {
-                "type": "http",
-                "headers": [
-                    (b"x-canvas-token", b"tok"),
-                    (b"x-canvas-url", good_url.encode()),
-                ],
-            }
-            await middleware(scope, AsyncMock(), AsyncMock())
-            assert captured_creds.get("url") == good_url, f"Should have accepted URL: {good_url}"
-
-    @pytest.mark.asyncio
-    async def test_clears_credentials_after_request(self, middleware):
-        """Credentials are cleared even if the inner app raises."""
+    async def test_clears_context_after_error(self, middleware):
+        """Credentials AND the http-active marker are cleared even if the app raises."""
         async def failing_app(scope, receive, send):
             raise ValueError("boom")
 
         middleware.app = failing_app
 
-        scope = {
-            "type": "http",
-            "headers": [
-                (b"x-canvas-token", b"tok"),
-                (b"x-canvas-url", b"https://x.instructure.com/api/v1"),
-            ],
-        }
-        with pytest.raises(ValueError, match="boom"):
-            await middleware(scope, AsyncMock(), AsyncMock())
+        scope = {"type": "http", "headers": [(b"x-canvas-token", b"tok")]}
+        with patch(
+            "canvas_mcp.server.get_config",
+            return_value=_FakeConfig("https://canvas.illinois.edu/api/v1"),
+        ):
+            with pytest.raises(ValueError, match="boom"):
+                await middleware(scope, AsyncMock(), AsyncMock())
 
         # Must be cleaned up despite error
         assert get_request_credentials() is None
-
-    @pytest.mark.asyncio
-    async def test_no_headers_passes_through(self, middleware):
-        """Without Canvas headers, no credentials are set."""
-        captured_creds = {"set": False}
-
-        async def check_app(scope, receive, send):
-            captured_creds["set"] = get_request_credentials() is not None
-
-        middleware.app = check_app
-
-        scope = {"type": "http", "headers": []}
-        await middleware(scope, AsyncMock(), AsyncMock())
-        assert captured_creds["set"] is False
+        assert is_http_request_active() is False
 
     @pytest.mark.asyncio
     async def test_lifespan_passthrough(self, middleware):
@@ -538,3 +550,85 @@ class TestCLIArgs:
         args = parser.parse_args(["--transport", "streamable-http", "--port", "9000"])
         assert args.transport == "streamable-http"
         assert args.port == 9000
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed behavior: HTTP request with no per-request token
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosedNoToken:
+    """In HTTP mode, a missing per-request token must NEVER use server creds."""
+
+    @pytest.fixture(autouse=True)
+    def reset_context(self):
+        clear_http_request_context()
+        yield
+        clear_http_request_context()
+
+    @pytest.mark.asyncio
+    async def test_make_request_blocks_when_http_active_no_token(self):
+        """make_canvas_request returns an error (not server fallback) in HTTP mode w/o token."""
+        set_http_request_active(True)
+        assert get_request_credentials() is None
+
+        with patch("canvas_mcp.core.client._get_http_client") as mock_get_client:
+            from canvas_mcp.core.client import make_canvas_request
+
+            result = await make_canvas_request("get", "/users/self")
+
+            assert isinstance(result, dict) and "error" in result
+            # Global (server-token) client must NOT be used
+            mock_get_client.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_authenticated_client_raises_when_http_active_no_token(self):
+        """canvas_authenticated_client raises rather than using the server client."""
+        set_http_request_active(True)
+        assert get_request_credentials() is None
+
+        from canvas_mcp.core.client import canvas_authenticated_client
+
+        with pytest.raises(PermissionError):
+            async with canvas_authenticated_client():
+                pass
+
+    @pytest.mark.asyncio
+    async def test_authenticated_client_uses_per_request_token(self):
+        """canvas_authenticated_client builds a client with the caller's token."""
+        set_http_request_active(True)
+        set_request_credentials(
+            RequestCredentials(
+                api_token="caller-token",
+                api_url="https://canvas.illinois.edu/api/v1",
+            )
+        )
+
+        with patch("canvas_mcp.core.client.httpx.AsyncClient") as MockClient:
+            instance = AsyncMock()
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=instance)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+
+            from canvas_mcp.core.client import canvas_authenticated_client
+
+            async with canvas_authenticated_client() as client:
+                assert client is instance
+
+            call_kwargs = MockClient.call_args[1]
+            assert call_kwargs["headers"]["Authorization"] == "Bearer caller-token"
+
+    @pytest.mark.asyncio
+    async def test_stdio_mode_still_falls_back_to_global_client(self):
+        """Without an active HTTP request, the global (env) client is still used."""
+        # http NOT active -> stdio mode
+        assert is_http_request_active() is False
+        assert get_request_credentials() is None
+
+        from canvas_mcp.core.client import canvas_authenticated_client
+
+        with patch("canvas_mcp.core.client._get_http_client") as mock_get_client:
+            sentinel = object()
+            mock_get_client.return_value = sentinel
+            async with canvas_authenticated_client() as client:
+                assert client is sentinel
+            mock_get_client.assert_called_once()

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -18,8 +18,9 @@ from canvas_mcp.core.credentials import (
 class _FakeConfig:
     """Minimal stand-in for the config object the middleware reads."""
 
-    def __init__(self, canvas_api_url="https://canvas.illinois.edu/api/v1"):
+    def __init__(self, canvas_api_url="https://canvas.illinois.edu/api/v1", mcp_access_keys=frozenset()):
         self.canvas_api_url = canvas_api_url
+        self.mcp_access_keys = mcp_access_keys
 
 # ---------------------------------------------------------------------------
 # ContextVar credential tests
@@ -209,6 +210,96 @@ class TestCanvasCredentialMiddleware:
         scope = {"type": "lifespan"}
         await middleware(scope, AsyncMock(), AsyncMock())
         assert called["value"] is True
+
+
+class TestAccessKeyGate:
+    """Test the v1 MCP_ACCESS_KEYS header gate."""
+
+    @pytest.fixture
+    def middleware(self):
+        from canvas_mcp.server import CanvasCredentialMiddleware
+
+        return CanvasCredentialMiddleware(AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_valid_key_passes_through(self, middleware):
+        """A matching X-MCP-Access-Key lets the request proceed to creds."""
+        captured = {}
+
+        async def capture_app(scope, receive, send):
+            creds = get_request_credentials()
+            captured["token"] = creds.api_token if creds else None
+
+        middleware.app = capture_app
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"x-mcp-access-key", b"key-abc"),
+                (b"x-canvas-token", b"tok"),
+            ],
+        }
+        cfg = _FakeConfig(mcp_access_keys=frozenset({"key-abc", "key-def"}))
+        with patch("canvas_mcp.server.get_config", return_value=cfg):
+            await middleware(scope, AsyncMock(), AsyncMock())
+
+        assert captured["token"] == "tok"
+
+    @pytest.mark.asyncio
+    async def test_missing_key_returns_401_and_skips_canvas(self, middleware):
+        """No access key -> 401 before the Canvas token is even considered."""
+        app_called = {"value": False}
+
+        async def inner(scope, receive, send):
+            app_called["value"] = True
+
+        middleware.app = inner
+        send = AsyncMock()
+        scope = {
+            "type": "http",
+            "headers": [(b"x-canvas-token", b"tok")],  # valid canvas token, but no access key
+        }
+        cfg = _FakeConfig(mcp_access_keys=frozenset({"key-abc"}))
+        with patch("canvas_mcp.server.get_config", return_value=cfg):
+            await middleware(scope, AsyncMock(), send)
+
+        assert app_called["value"] is False
+        first_call = send.call_args_list[0][0][0]
+        assert first_call["status"] == 401
+        assert get_request_credentials() is None
+
+    @pytest.mark.asyncio
+    async def test_wrong_key_returns_401(self, middleware):
+        """A non-matching access key is rejected."""
+        send = AsyncMock()
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"x-mcp-access-key", b"wrong"),
+                (b"x-canvas-token", b"tok"),
+            ],
+        }
+        cfg = _FakeConfig(mcp_access_keys=frozenset({"key-abc"}))
+        with patch("canvas_mcp.server.get_config", return_value=cfg):
+            await middleware(scope, AsyncMock(), send)
+
+        assert send.call_args_list[0][0][0]["status"] == 401
+
+    @pytest.mark.asyncio
+    async def test_no_keys_configured_gate_disabled(self, middleware):
+        """With no MCP_ACCESS_KEYS, the gate is inactive (token gate still applies)."""
+        captured = {}
+
+        async def capture_app(scope, receive, send):
+            creds = get_request_credentials()
+            captured["token"] = creds.api_token if creds else None
+
+        middleware.app = capture_app
+        scope = {"type": "http", "headers": [(b"x-canvas-token", b"tok")]}
+        cfg = _FakeConfig(mcp_access_keys=frozenset())
+        with patch("canvas_mcp.server.get_config", return_value=cfg):
+            await middleware(scope, AsyncMock(), AsyncMock())
+
+        assert captured["token"] == "tok"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_files.py
+++ b/tests/tools/test_files.py
@@ -658,7 +658,7 @@ class TestDownloadCourseFile:
         with patch('canvas_mcp.tools.files.get_course_id') as mock_get_id, \
              patch('canvas_mcp.tools.files.get_course_code') as mock_get_code, \
              patch('canvas_mcp.tools.files.make_canvas_request') as mock_request, \
-             patch('canvas_mcp.tools.files._get_http_client') as mock_client:
+             patch('canvas_mcp.tools.files.canvas_authenticated_client') as mock_client:
 
             mock_get_id.return_value = "60366"
             mock_get_code.return_value = "badm_350_120251"
@@ -689,7 +689,11 @@ class TestDownloadCourseFile:
 
         mock_http = AsyncMock()
         mock_http.stream = MagicMock(return_value=mock_stream_cm)
-        mock_client.return_value = mock_http
+        # canvas_authenticated_client() is an async context manager yielding the client
+        client_cm = AsyncMock()
+        client_cm.__aenter__ = AsyncMock(return_value=mock_http)
+        client_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_client.return_value = client_cm
 
         return mock_http
 
@@ -834,7 +838,10 @@ class TestDownloadCourseFile:
 
         mock_http = AsyncMock()
         mock_http.stream = MagicMock(return_value=mock_stream_cm)
-        mock_download_api['_get_http_client'].return_value = mock_http
+        client_cm = AsyncMock()
+        client_cm.__aenter__ = AsyncMock(return_value=mock_http)
+        client_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_download_api['_get_http_client'].return_value = client_cm
 
         download_fn = get_tool_function('download_course_file')
         result = await download_fn("60366", 12345, save_directory=str(tmp_path))
@@ -851,7 +858,7 @@ class TestReadCourseFile:
         with patch('canvas_mcp.tools.files.get_course_id') as mock_get_id, \
              patch('canvas_mcp.tools.files.get_course_code') as mock_get_code, \
              patch('canvas_mcp.tools.files.make_canvas_request') as mock_request, \
-             patch('canvas_mcp.tools.files._get_http_client') as mock_client:
+             patch('canvas_mcp.tools.files.canvas_authenticated_client') as mock_client:
 
             mock_get_id.return_value = "60366"
             mock_get_code.return_value = "badm_350_120251"
@@ -881,7 +888,11 @@ class TestReadCourseFile:
 
         mock_http = AsyncMock()
         mock_http.stream = MagicMock(return_value=mock_stream_cm)
-        mock_client.return_value = mock_http
+        # canvas_authenticated_client() is an async context manager yielding the client
+        client_cm = AsyncMock()
+        client_cm.__aenter__ = AsyncMock(return_value=mock_http)
+        client_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_client.return_value = client_cm
 
         return mock_http
 
@@ -1022,7 +1033,10 @@ class TestReadCourseFile:
 
         mock_http = AsyncMock()
         mock_http.stream = MagicMock(return_value=mock_stream_cm)
-        mock_read_api['_get_http_client'].return_value = mock_http
+        client_cm = AsyncMock()
+        client_cm.__aenter__ = AsyncMock(return_value=mock_http)
+        client_cm.__aexit__ = AsyncMock(return_value=False)
+        mock_read_api['_get_http_client'].return_value = client_cm
 
         read_fn = get_tool_function('read_course_file')
         result = await read_fn("60366", 12345)


### PR DESCRIPTION
## Summary

Hardens the streamable-HTTP transport so a **hosted, multi-user** deployment runs every Canvas call under the **caller's own token**, never the server's. This is the app-layer prerequisite for the Gies/Azure SSO-gated deployment ([#115](https://github.com/vishalsachdev/canvas-mcp/issues/115)).

Designed + reviewed across three Codex passes (architecture GO, xhigh end-to-end plan, and a diff-level security review that caught the secure-by-default Dockerfile gap, now fixed).

## Credential model: token-only + server-pinned URL

- Middleware reads **only** `X-Canvas-Token`; `X-Canvas-URL` is **ignored** (logged). The Canvas API URL is pinned by `CANVAS_API_URL`, which removes the SSRF surface entirely.
  - This replaces the `*.instructure.com` allowlist regex from #118 — that regex rejected the `canvas.illinois.edu` vanity domain, which would have silently fallen back to the server token (mis-attributing TA actions to the operator — a FERPA/audit failure).
- Missing/blank token → **HTTP 401** before the app runs.
- **Startup guard:** HTTP mode exits if `CANVAS_API_TOKEN` is set, and requires `CANVAS_API_URL`.

## Fail-closed everywhere

New `is_http_request_active()` marker so the "no per-request creds → server env" fallback fires **only in stdio mode**. All Canvas-touching paths route through one new `canvas_authenticated_client()` resolver:

- `core/client.py` — `make_canvas_request` + the upload-redirect confirm path
- `tools/files.py` — `download_course_file` + `read_course_file` streams (previously used the server-token global client)
- `tools/code_execution.py` — `execute_typescript` uses the per-request token or refuses in HTTP mode (no longer injects the server token into the subprocess)

## Dockerfile

- Launches streamable-http on `${PORT:-${WEBSITES_PORT:-8819}}` (stdio is unreachable over ingress).
- Ships `EXECUTE_TYPESCRIPT_ENABLED=false` by default for this network-facing image (secure-by-default; opt in only behind real auth). *(Codex review P1 fix.)*

## Tests

- Rewrote middleware tests for token-only semantics: SSRF payload ignored, 401 on missing/blank token, context cleared on error.
- Added a fail-closed suite: HTTP-active-no-token blocks (global client never called); stdio still falls back.
- Updated file-tool mocks to the new context manager.
- **401 passed, 21 skipped**; ruff clean.

## Deploy note

Intended for `gies-canvas-mcp-staging` (App Service for Containers) with `CANVAS_API_URL` pinned, **no** `CANVAS_API_TOKEN`, behind Entra Easy Auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)