### PR TITLE
fix(http): fail closed when access-key gate is unconfigured + FERPA compliance docs

### DIFF
--- a/docs/SECURITY-COMPLIANCE.md
+++ b/docs/SECURITY-COMPLIANCE.md
@@ -1,0 +1,81 @@
+# Canvas MCP — Security & FERPA Compliance Evaluation
+
+**Status:** Draft for review by UIUC Privacy Office / GRC and Cybersecurity
+**Scope:** The hosted HTTP MCP deployment (`gies-canvas-mcp-staging`, Illinois Azure), recommended to staff/faculty for Canvas LMS workflows.
+**Date:** 2026-06-14
+**Owner:** Vishal Sachdev (vishal@illinois.edu)
+**Out of scope:** Canvas API token issuance/security (handled by a separate IT Services approval process).
+
+---
+
+## 1. What the system is
+
+A self-hosted [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server that lets an LLM client perform Canvas LMS tasks (grading, discussion facilitation, peer-review analytics, messaging) on behalf of an instructor or TA. Architecture as deployed/intended:
+
+- **Compute:** Azure Web App for Containers, **inside the University of Illinois Azure subscription/tenant** (`urbana-business-disruptionlab`).
+- **LLM:** the University's **Azure OpenAI Service, in-tenant** (enterprise agreement; data not used for training). **Not** consumer OpenAI/Anthropic APIs.
+- **Canvas access:** each caller sends **their own Canvas API token** (`X-Canvas-Token` header). The server holds **no** shared Canvas token; the Canvas API URL is server-pinned.
+- **Endpoint gate:** a shared static access key (`X-MCP-Access-Key`, constant-time compared) — one value per authorized person, individually revocable.
+- **Transport:** TLS terminated at Azure (`httpsOnly=true`).
+- **Code execution tool disabled** on the hosted image (`EXECUTE_TYPESCRIPT_ENABLED=false`).
+
+---
+
+## 2. Applicable policy (verified against primary U of I sources)
+
+| # | Requirement | Source |
+|---|-------------|--------|
+| F1 | U of I uses a **four-tier** data classification: High Risk / Sensitive / Internal / Public. FERPA student education records (grades, submissions, identifiable records) are **Sensitive** (2nd-highest). Elements such as SSN within a record escalate to **High Risk**. | [cybersecurity.illinois.edu/data-classification](https://www.cybersecurity.illinois.edu/data-classification/), [answers.uillinois.edu 63588](https://answers.uillinois.edu/page.php?id=63588) |
+| F2 | **Sensitive-tier controls:** no access without *specific authorization*; *selective / need-to-know* access only; any sharing requires a *legitimate, documented business need* **and** verification that the recipient is authorized **before** disclosure. | [answers.uillinois.edu 63588](https://answers.uillinois.edu/page.php?id=63588) |
+| F3 | Campus policy **FO-36** binds all University Data to the Institutional Data Security Standard (**DAT01**) for classification/handling, and requires identity, authentication, and authorization to conform to the Identity Management Standard (**IT05**) — i.e. campus identity (NetID/Entra). | [cam.illinois.edu/policies/fo-36](https://cam.illinois.edu/policies/fo-36/) |
+| F4 | FERPA "school official" exception: even designated officials must have a **legitimate educational interest** (need-to-know) before accessing education records without the student's written consent. Applies to TAs and to tooling acting on their behalf. | [vpaa.uillinois.edu FERPA](https://www.vpaa.uillinois.edu/resources/policies/ferpa_and_compliance), [studentprivacy.ed.gov](https://studentprivacy.ed.gov/) |
+
+## 3. Applicable policy — likely but UNVERIFIED (confirm with GRC/Privacy/Cybersecurity)
+
+> These are drawn from primary `.illinois.edu` sources but could **not** be independently confirmed in our research pass. They are the basis for the open questions in §6. Do not treat as settled.
+
+- **U1 — Approved-AI-tools framework** ([genai.illinois.edu/ai-apps](https://genai.illinois.edu/ai-apps/)): *Sensitive* data may be processed **only through University-approved tools**; **High Risk** regulated data must **never** be entered into **any** AI tool. An approved enterprise roster exists (Illinois ChatGPT, Microsoft Copilot, Google Gemini, etc.).
+- **U2 — Procurement / risk gate** (eff. July 1, 2025): a **Lightweight Risk Assessment (LRA)** plus **GRC and Privacy Office** review for services that host/access non-public university data.
+- **U3 — Centrally-managed Azure** requires **federated SSO + 2FA** via the central identity system.
+- **U4 — FERPA vendor / school-official-by-contract test** (4 parts: institutional service; designated official w/ legitimate interest; direct institutional control; use-limited, no re-disclosure).
+
+---
+
+## 4. Compliance evaluation (control-by-control)
+
+| As-built control | Verdict | Basis |
+|---|---|---|
+| Per-user Canvas token, fail-closed (no server-token fallback) | ✅ Aligned | F2, F4 — individual attribution + need-to-know at the Canvas layer |
+| In-tenant Azure compute + **in-tenant Azure OpenAI** | ✅ Aligned (pending U1 confirmation) | Keeps Sensitive data inside the University boundary; not third-party egress |
+| TLS in transit (`httpsOnly`) | ✅ Aligned | Encryption-in-transit expectation |
+| `execute_typescript` disabled on hosted image | ✅ Aligned | Removes arbitrary-code-exec surface on the network-facing service |
+| **Endpoint gate fails closed when unconfigured** | ✅ Fixed 2026-06-14 | Was warn-only; now refuses to start without `MCP_ACCESS_KEYS` unless `MCP_ALLOW_UNAUTHENTICATED=true` |
+| **Authentication = shared static key, no NetID/Entra identity** | ❌ **Gap (P0)** | F3 — IT05 requires campus-identity-based auth; a shared secret gives no individual attribution for the FERPA need-to-know determination and weakens audit |
+| Access logging / audit trail of who accessed which records | ⚠️ Partial | F2 expects auditable access + documented authorization basis per user |
+| Documented business-need / authorization basis per operator | ⚠️ Partial | F2 — needs a recorded authorization basis per TA/instructor |
+
+---
+
+## 5. Prioritized gap list
+
+- **P0 — Authentication identity (verified gap).** Replace the shared static access key with **NetID/Entra (Azure AD) SSO + 2FA** so each request carries a verified campus identity. This is the IT05/FO-36 conformance requirement (F3) and the single blocker for a campus-wide recommendation. *(Already on the roadmap as "Entra/OAuth v2" — this evaluation reclassifies it from enhancement to gate.)*
+- **P0 — Fail-closed the endpoint gate.** ✅ **Done 2026-06-14** (`fix/http-gate-fail-closed`). HTTP mode now exits unless `MCP_ACCESS_KEYS` is set or `MCP_ALLOW_UNAUTHENTICATED=true` is explicitly declared (the latter only for an Entra/Easy-Auth-fronted deployment).
+- **P1 — Audit trail + documented authorization.** Add per-user access logging and a recorded authorization basis per operator (F2).
+- **P1 — Bound to legitimate educational interest.** Ensure tooling cannot exceed the operator's scope or re-disclose; keep High Risk elements (SSNs, etc.) out of any AI tool entirely — use the built-in student-anonymization map for analytical outputs (F1, F4, U1).
+- **P1 — Institutional process.** Complete the LRA + GRC/Privacy review before campus-wide endorsement (U2), and confirm the in-tenant Azure OpenAI deployment is designated for Sensitive data (U1).
+
+---
+
+## 6. Open questions for Privacy Office / GRC / Cybersecurity
+
+1. **Azure OpenAI for FERPA data (U1):** Is processing Sensitive-tier student data through the University's **in-tenant** Azure OpenAI Service explicitly permitted under current generative-AI guidance and the Microsoft enterprise agreement/BAA? What designation or written assurance (e.g., data-not-used-for-training) attaches?
+2. **Procurement / review gate (U2):** Does a **self-hosted, in-tenant** build (vs. a third-party vendor purchase) trigger the **LRA** and GRC/Privacy review? If so, what is the intake path?
+3. **Authentication standard (F3/U3):** What does **IT05** concretely require for a service touching Sensitive data — NetID/Entra SSO + 2FA — and is a non-identity access key ever acceptable as a secondary gate?
+4. **Audit retention (F2/DAT01):** What access-logging and retention does DAT01/FO-36 mandate for Sensitive-tier access?
+5. **FERPA delegated access (U4):** With each operator using their own Canvas credentials and their own legitimate educational interest, is a separate school-official-by-contract designation required for the tooling, or is per-user delegation sufficient?
+
+---
+
+## 7. Methodology note
+
+Verified findings (§2) passed multi-source adversarial verification against official institutional primary sources. Items in §3 come from primary `.illinois.edu` sources but were not independently confirmed in this pass (verifier rate-limiting), so they are surfaced as questions rather than conclusions. The roster of approved GenAI tools and the LRA workflow change over time — **re-confirm at decision time.**

--- a/docs/compliance/email-cybersecurity.md
+++ b/docs/compliance/email-cybersecurity.md
@@ -1,0 +1,32 @@
+# Email — UIUC Cybersecurity (Technology Services)
+
+**To:** securitysupport@illinois.edu (Technology Services Security)
+**Cc:** —
+**Subject:** IT05 auth + DAT01 audit guidance for an in-tenant Azure app touching Sensitive (FERPA) data
+
+Hello,
+
+I run an internal Azure-hosted tool in Gies (inside the University's Azure subscription) that lets instructors and TAs perform Canvas work through the University's in-tenant Azure OpenAI Service. It touches Canvas student education records, which I understand are classified as Sensitive under our data classification. Before I recommend it more widely I want to align its authentication and logging with FO-36 / DAT01 / IT05.
+
+Current controls:
+
+• Compute and the Azure OpenAI model are both inside the U of I Azure tenant.
+• Each user calls Canvas with their own Canvas API token (no shared server token); TLS in transit; code-execution disabled.
+• The endpoint is currently gated by a per-person shared access key — it is NOT yet tied to NetID/Entra identity. I plan to move it to Entra ID (Azure AD) SSO.
+
+My questions on the standards:
+
+1. For a service touching Sensitive-tier data, what does IT05 concretely require for authentication — NetID/Entra SSO with 2FA? Is a non-identity shared access key ever acceptable as a secondary gate, or must every request carry a verified campus identity?
+
+2. I'm planning to front the endpoint with Entra ID (Azure AD) sign-in restricted to an allowlist of authorized staff. Does that satisfy the IT05 identity/authentication requirement for this data tier, and are there configuration specifics you'd want (conditional access, 2FA enforcement, group-based access)?
+
+3. What access-logging and retention does DAT01/FO-36 expect for Sensitive-tier access — e.g., per-user access records, retention period, where logs should live?
+
+4. Is there a security-review or risk-assessment step on your side you'd want completed before this is recommended campus-wide, and how should I initiate it?
+
+Happy to share a short internal compliance write-up that documents the architecture and these gaps, or to meet.
+
+Thank you,
+Vishal Sachdev
+Clinical Professor / Director, Disruption Lab — Gies College of Business
+vishal@illinois.edu

--- a/docs/compliance/email-cybersecurity.txt
+++ b/docs/compliance/email-cybersecurity.txt
@@ -1,0 +1,28 @@
+Subject: IT05 auth + DAT01 audit guidance for an in-tenant Azure app touching Sensitive (FERPA) data
+
+Hello,
+
+I run an internal Azure-hosted tool in Gies (inside the University's Azure subscription) that lets instructors and TAs perform Canvas work through the University's in-tenant Azure OpenAI Service. It touches Canvas student education records, which I understand are classified as Sensitive under our data classification. Before I recommend it more widely I want to align its authentication and logging with FO-36 / DAT01 / IT05.
+
+Current controls:
+
+• Compute and the Azure OpenAI model are both inside the U of I Azure tenant.
+• Each user calls Canvas with their own Canvas API token (no shared server token); TLS in transit; code-execution disabled.
+• The endpoint is currently gated by a per-person shared access key — it is NOT yet tied to NetID/Entra identity. I plan to move it to Entra ID (Azure AD) SSO.
+
+My questions on the standards:
+
+1. For a service touching Sensitive-tier data, what does IT05 concretely require for authentication — NetID/Entra SSO with 2FA? Is a non-identity shared access key ever acceptable as a secondary gate, or must every request carry a verified campus identity?
+
+2. I'm planning to front the endpoint with Entra ID (Azure AD) sign-in restricted to an allowlist of authorized staff. Does that satisfy the IT05 identity/authentication requirement for this data tier, and are there configuration specifics you'd want (conditional access, 2FA enforcement, group-based access)?
+
+3. What access-logging and retention does DAT01/FO-36 expect for Sensitive-tier access — e.g., per-user access records, retention period, where logs should live?
+
+4. Is there a security-review or risk-assessment step on your side you'd want completed before this is recommended campus-wide, and how should I initiate it?
+
+Happy to share a short internal compliance write-up that documents the architecture and these gaps, or to meet.
+
+Thank you,
+Vishal Sachdev
+Clinical Professor / Director, Disruption Lab — Gies College of Business
+vishal@illinois.edu

--- a/docs/compliance/email-privacy-grc.md
+++ b/docs/compliance/email-privacy-grc.md
@@ -1,0 +1,33 @@
+# Email — UIUC Privacy Office / GRC
+
+**To:** privacy@illinois.edu (Privacy Office); GRC intake (confirm address)
+**Cc:** —
+**Subject:** FERPA/GenAI review request — in-tenant Canvas MCP tool (Azure OpenAI) for staff/faculty
+
+Hello,
+
+I'm a faculty member in Gies College of Business. I've built an internal tool that helps instructors and TAs do routine Canvas work (grading with rubrics, discussion facilitation, peer-review analytics, reminders) through an AI assistant, and before recommending it more broadly to staff and faculty I want to confirm it clears FERPA and our generative-AI data-handling requirements.
+
+Architecture (kept deliberately inside the University boundary):
+
+• Hosted on Azure **inside the University of Illinois subscription/tenant** (Disruption Lab subscription) — not a third-party SaaS.
+• The AI model is the University's **in-tenant Azure OpenAI Service** (enterprise agreement, data not used for training) — not consumer ChatGPT/Claude.
+• Each user authenticates to Canvas with **their own Canvas API token**; the server holds no shared instructor token, so every action runs under that person's own Canvas role and audit trail.
+• TLS in transit; the code-execution feature is disabled on the hosted instance.
+
+I understand Canvas student education records are classified as Sensitive data, requiring specific authorization and a documented need-to-know. My questions:
+
+1. Is processing Sensitive-tier (FERPA) student data through the University's in-tenant Azure OpenAI Service permitted under current generative-AI guidance and the Microsoft enterprise agreement? Does it need a specific approved-tool designation or written data-handling assurance?
+
+2. Does a self-hosted, in-tenant build like this (as opposed to purchasing a third-party product) trigger the Lightweight Risk Assessment and a GRC/Privacy review? If so, what's the right intake path and what should I submit?
+
+3. With each operator using their own Canvas credentials under their own legitimate educational interest, is a separate FERPA "school official by contract" designation needed for the tooling itself, or is per-user delegation sufficient?
+
+4. What access-logging and retention do you expect for a service that touches Sensitive-tier records?
+
+I've written a short internal compliance evaluation that documents the controls and the open questions above, and I'm happy to send it or meet. I want to get this right before any wider rollout.
+
+Thank you,
+Vishal Sachdev
+Clinical Professor / Director, Disruption Lab — Gies College of Business
+vishal@illinois.edu

--- a/docs/compliance/email-privacy-grc.txt
+++ b/docs/compliance/email-privacy-grc.txt
@@ -1,0 +1,29 @@
+Subject: FERPA/GenAI review request — in-tenant Canvas MCP tool (Azure OpenAI) for staff/faculty
+
+Hello,
+
+I'm a faculty member in Gies College of Business. I've built an internal tool that helps instructors and TAs do routine Canvas work (grading with rubrics, discussion facilitation, peer-review analytics, reminders) through an AI assistant, and before recommending it more broadly to staff and faculty I want to confirm it clears FERPA and our generative-AI data-handling requirements.
+
+Architecture (kept deliberately inside the University boundary):
+
+• Hosted on Azure inside the University of Illinois subscription/tenant (Disruption Lab subscription) — not a third-party SaaS.
+• The AI model is the University's in-tenant Azure OpenAI Service (enterprise agreement, data not used for training) — not consumer ChatGPT/Claude.
+• Each user authenticates to Canvas with their own Canvas API token; the server holds no shared instructor token, so every action runs under that person's own Canvas role and audit trail.
+• TLS in transit; the code-execution feature is disabled on the hosted instance.
+
+I understand Canvas student education records are classified as Sensitive data, requiring specific authorization and a documented need-to-know. My questions:
+
+1. Is processing Sensitive-tier (FERPA) student data through the University's in-tenant Azure OpenAI Service permitted under current generative-AI guidance and the Microsoft enterprise agreement? Does it need a specific approved-tool designation or written data-handling assurance?
+
+2. Does a self-hosted, in-tenant build like this (as opposed to purchasing a third-party product) trigger the Lightweight Risk Assessment and a GRC/Privacy review? If so, what's the right intake path and what should I submit?
+
+3. With each operator using their own Canvas credentials under their own legitimate educational interest, is a separate FERPA "school official by contract" designation needed for the tooling itself, or is per-user delegation sufficient?
+
+4. What access-logging and retention do you expect for a service that touches Sensitive-tier records?
+
+I've written a short internal compliance evaluation that documents the controls and the open questions above, and I'm happy to send it or meet. I want to get this right before any wider rollout.
+
+Thank you,
+Vishal Sachdev
+Clinical Professor / Director, Disruption Lab — Gies College of Business
+vishal@illinois.edu

--- a/env.template
+++ b/env.template
@@ -45,6 +45,13 @@ TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
 # and do NOT set CANVAS_API_TOKEN — each caller sends their own X-Canvas-Token.
 # MCP_ACCESS_KEYS=
 
+# HTTP transport — fail-closed override (Optional; HTTP mode only)
+# Secure-by-default: in HTTP mode the server REFUSES to start if MCP_ACCESS_KEYS
+# is empty, because an ungated endpoint can read/write Canvas gradebooks. Only
+# set this to "true" when an external authenticator (Entra ID / Azure Easy Auth)
+# fronts the endpoint and you intend to disable the app-level key gate.
+# MCP_ALLOW_UNAUTHENTICATED=false
+
 # Optional Metadata
 INSTITUTION_NAME=Your Institution Name
 TIMEZONE=UTC

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -105,6 +105,12 @@ class Config:
         # auth). stdio mode ignores this entirely.
         self.mcp_access_keys = _parse_keys(os.getenv("MCP_ACCESS_KEYS", ""))
 
+        # Secure-by-default: in HTTP mode, an unconfigured key gate makes the
+        # server exit unless the operator EXPLICITLY opts into unauthenticated
+        # mode (i.e. external auth such as Entra/Easy Auth fronts the endpoint).
+        # This makes "fail open" impossible by omission — only by declaration.
+        self.mcp_allow_unauthenticated = _bool_env("MCP_ALLOW_UNAUTHENTICATED", False)
+
         # Optional metadata
         self.institution_name = os.getenv("INSTITUTION_NAME", "")
         self.timezone = os.getenv("TIMEZONE", "UTC")

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -302,11 +302,26 @@ def main() -> None:
             )
             sys.exit(1)
         if not config.mcp_access_keys:
-            log_warning(
-                "HTTP mode has no MCP_ACCESS_KEYS configured — the endpoint is NOT "
-                "key-gated. Anyone who can reach it and holds a Canvas token can connect. "
-                "Set MCP_ACCESS_KEYS or place the endpoint behind external authentication."
-            )
+            # Secure-by-default: refuse to start an ungated endpoint unless the
+            # operator has explicitly accepted that external auth fronts it.
+            # Student education records are FERPA "Sensitive" data (U of I DAT01)
+            # and must never be accessed without specific authorization, so a
+            # silent fail-open here is a compliance failure, not a warning.
+            if config.mcp_allow_unauthenticated:
+                log_warning(
+                    "HTTP mode has no MCP_ACCESS_KEYS, but MCP_ALLOW_UNAUTHENTICATED=true "
+                    "is set — assuming external authentication (e.g. Entra/Easy Auth) "
+                    "fronts this endpoint. The app-level key gate is DISABLED."
+                )
+            else:
+                log_error(
+                    "HTTP mode requires MCP_ACCESS_KEYS (the app-level auth gate). "
+                    "Refusing to start an unauthenticated endpoint that can read and "
+                    "write Canvas gradebooks. Set MCP_ACCESS_KEYS, or if an external "
+                    "authenticator (Entra/Easy Auth) fronts this endpoint, set "
+                    "MCP_ALLOW_UNAUTHENTICATED=true to opt in deliberately."
+                )
+                sys.exit(1)
     else:
         # stdio mode: .env credentials are required (single-user, env-based auth)
         if not validate_config():

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -723,3 +723,60 @@ class TestFailClosedNoToken:
             async with canvas_authenticated_client() as client:
                 assert client is sentinel
             mock_get_client.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Startup guard: HTTP mode fails closed when the key gate is unconfigured
+# ---------------------------------------------------------------------------
+
+
+class TestHttpAccessKeyStartupGuard:
+    """In HTTP mode, an unconfigured MCP_ACCESS_KEYS must refuse to start
+    unless MCP_ALLOW_UNAUTHENTICATED=true is explicitly set (external auth)."""
+
+    def _run_main(self, monkeypatch, env):
+        """Drive main() in HTTP mode with --config (exits before serving).
+
+        Returns the SystemExit raised by main() so the caller can assert the
+        exit code: 1 == guard tripped (fail closed), 0 == guard passed.
+        """
+        from canvas_mcp.core import config as config_module
+
+        # Clean slate: required HTTP env, no server token, plus test overrides.
+        monkeypatch.setenv("CANVAS_API_URL", "https://canvas.illinois.edu/api/v1")
+        monkeypatch.delenv("CANVAS_API_TOKEN", raising=False)
+        monkeypatch.delenv("MCP_ACCESS_KEYS", raising=False)
+        monkeypatch.delenv("MCP_ALLOW_UNAUTHENTICATED", raising=False)
+        for key, value in env.items():
+            monkeypatch.setenv(key, value)
+
+        config_module.reset_config()
+        monkeypatch.setattr(
+            "sys.argv",
+            ["canvas-mcp-server", "--transport", "streamable-http", "--config"],
+        )
+        from canvas_mcp.server import main
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        config_module.reset_config()
+        return exc_info.value
+
+    def test_no_keys_no_optin_exits_nonzero(self, monkeypatch):
+        """No MCP_ACCESS_KEYS and no opt-in -> fail closed (exit 1)."""
+        exc = self._run_main(monkeypatch, env={})
+        assert exc.code == 1
+
+    def test_no_keys_with_explicit_optin_starts(self, monkeypatch):
+        """No keys but MCP_ALLOW_UNAUTHENTICATED=true -> guard passes (exit 0)."""
+        exc = self._run_main(
+            monkeypatch, env={"MCP_ALLOW_UNAUTHENTICATED": "true"}
+        )
+        assert exc.code == 0
+
+    def test_keys_configured_starts(self, monkeypatch):
+        """MCP_ACCESS_KEYS configured -> guard passes regardless of opt-in (exit 0)."""
+        exc = self._run_main(
+            monkeypatch, env={"MCP_ACCESS_KEYS": "key-abc,key-def"}
+        )
+        assert exc.code == 0


### PR DESCRIPTION
## Summary

Two related changes from a security review of the hosted Canvas MCP deployment (#115):

1. **Code (P0 fix):** HTTP mode now **fails closed** when `MCP_ACCESS_KEYS` is unconfigured. Previously it only logged a warning and then started an ungated endpoint that can read/write Canvas gradebooks — a fail-open hole for FERPA "Sensitive" data.
2. **Docs:** a UIUC FERPA/information-security compliance evaluation + the GRC/Cybersecurity inquiry emails it generated.

## Code change

- New `MCP_ALLOW_UNAUTHENTICATED` env flag (default `false`).
- HTTP startup `sys.exit(1)` if `MCP_ACCESS_KEYS` is empty **unless** `MCP_ALLOW_UNAUTHENTICATED=true` is explicitly set (for endpoints fronted by external auth — Entra ID / Azure Easy Auth). Failing open is now only possible by deliberate declaration, never by omission.
- Documented in `env.template`.
- **3 new startup-guard tests** (fail-closed / explicit-opt-in / keys-configured). Full suite: **408 passed, 21 skipped**.
- `codex review --base main`: clean, no findings.

## Docs

- `docs/SECURITY-COMPLIANCE.md` — verified policy (four-tier classification, FERPA = Sensitive, FO-36 → DAT01/IT05, school-official need-to-know) separated from items needing institutional confirmation (Azure OpenAI permissibility, LRA/procurement gate, SSO+2FA). Control-by-control verdict + prioritized gap list.
- `docs/compliance/` — Privacy/GRC and Cybersecurity inquiry emails (`.md` record + paste-ready `.txt`). **Not yet sent** — recipient addresses + signature title need confirming before sending.

## Compliance takeaway

With in-tenant Azure OpenAI confirmed, the dominant residual gap is **authentication identity** (shared static key vs IT05's NetID/Entra requirement) — which maps onto the already-roadmapped **Entra/OAuth v2** work, reclassifying it from enhancement to the gate for campus-wide rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)