### PR TITLE
ci(azure): auto-deploy prod on merge to main + staging-slot pipeline

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,54 @@
+name: Deploy to Azure — production
+
+# Auto-deploy: every push to main (i.e. every merged PR) builds the container
+# image, pushes it to ACR, and deploys it to the production slot of
+# gies-canvas-mcp. No manual gate — a merge to main IS the deploy trigger.
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'tools/**'
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+env:
+  REGISTRY: giescanvasmcpacr.azurecr.io
+  IMAGE: canvas-mcp
+  APP_NAME: gies-canvas-mcp
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image tag
+        id: tag
+        run: echo "tag=azure-gies-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to ACR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
+
+      - name: Deploy to production slot
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ env.APP_NAME }}
+          slot-name: Production
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_PROD }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,56 @@
+name: Deploy to Azure — staging slot
+
+# Push to the `staging` branch builds + ships to the staging deployment slot of
+# gies-canvas-mcp (host: gies-canvas-mcp-staging9b87.azurewebsites.net). Use this
+# to validate a build against real Entra/Azure config before it reaches main/prod.
+# Promote by merging `staging` -> `main` (which fires deploy-prod), or via an
+# Azure slot swap.
+on:
+  push:
+    branches: [staging]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - 'tools/**'
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: true
+
+env:
+  REGISTRY: giescanvasmcpacr.azurecr.io
+  IMAGE: canvas-mcp
+  APP_NAME: gies-canvas-mcp
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute image tag
+        id: tag
+        run: echo "tag=azure-gies-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to ACR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.ACR_USERNAME }}
+          password: ${{ secrets.ACR_PASSWORD }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
+
+      - name: Deploy to staging slot
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ env.APP_NAME }}
+          slot-name: staging
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE_STAGING }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
## What
Adds branch→slot container CI for the Azure hosted deployment, matching the MindForum house pattern.

| Workflow | Trigger | Target |
|----------|---------|--------|
| `deploy-prod.yml` | push to `main` (every merged PR) | Production slot of `gies-canvas-mcp` |
| `deploy-staging.yml` | push to `staging` branch | `staging` slot |

Both build the image from the repo `Dockerfile`, push to ACR (`giescanvasmcpacr`), and deploy via `azure/webapps-deploy@v3`.

## Auth model (no RBAC needed)
Uses **ACR admin creds** + **per-slot publish profiles** stored as GitHub secrets (`ACR_USERNAME`, `ACR_PASSWORD`, `AZURE_WEBAPP_PUBLISH_PROFILE_PROD`, `AZURE_WEBAPP_PUBLISH_PROFILE_STAGING`). This sidesteps the Owner-only `roleAssignments/write` wall — no service principal or `AcrPull` grant required.

## Behavior note
Auto-deploy is intentional and ungated: **a merge to `main` IS the prod deploy.** Replaces the manual `az acr build` flow. Safe to activate now — no DNS points at the prod app yet, so the first deploy has zero user blast radius (and refreshes the currently-stale deployed image to `main` HEAD, restoring the full tool set incl. `check_enrollment`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)