### PR TITLE
ci(azure): point deploy workflows at canvas-mcp

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -19,7 +19,7 @@ concurrency:
 env:
   REGISTRY: giescanvasmcpacr.azurecr.io
   IMAGE: canvas-mcp
-  APP_NAME: gies-canvas-mcp
+  APP_NAME: canvas-mcp
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -21,7 +21,7 @@ concurrency:
 env:
   REGISTRY: giescanvasmcpacr.azurecr.io
   IMAGE: canvas-mcp
-  APP_NAME: gies-canvas-mcp
+  APP_NAME: canvas-mcp
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
Renames the deploy target from `gies-canvas-mcp` to the house-consistent bare name `canvas-mcp` (matches mindforum/uniquick/illinihunt). The campus CNAME already resolves to `canvas-mcp.azurewebsites.net`, so no ITP round-trip is needed. Merging auto-deploys to the new app (zero blast radius — nothing bound yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)