### PR TITLE
fix(courses): honor CANVAS_ROLE in list_courses, scope to active enrollments

### DIFF
--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -514,6 +514,10 @@ def main() -> None:
     if role not in ("student", "educator", "all"):
         log_warning(f"Unknown role '{role}', defaulting to 'all'")
         role = "all"
+    # Make the resolved role authoritative so runtime tool behavior (e.g.
+    # list_courses reading get_config().canvas_role) matches the registered
+    # profile even when the CLI --role flag overrides the CANVAS_ROLE env var.
+    config.canvas_role = role
     log_info(f"Tool profile: {role}")
     register_all_tools(mcp, role=role)
 

--- a/src/canvas_mcp/tools/courses.py
+++ b/src/canvas_mcp/tools/courses.py
@@ -12,6 +12,7 @@ from ..core.cache import (
     id_to_course_code_cache,
 )
 from ..core.client import fetch_all_paginated_results, make_canvas_request
+from ..core.config import get_config
 from ..core.dates import format_date
 from ..core.validation import validate_params
 
@@ -52,7 +53,17 @@ def register_course_tools(mcp: FastMCP):
         }
 
         if not include_all:
-            params["enrollment_type"] = "teacher"
+            # Scope to the user's *current* enrollments. enrollment_state="active"
+            # is Canvas's canonical "current" signal; the course state[] filter
+            # below cannot distinguish current from past at institutions that
+            # never flip finished courses to workflow_state="completed".
+            params["enrollment_state"] = "active"
+            # Educators keep teacher-only scoping (unchanged behavior). Students
+            # and the "all" profile see every active enrollment, which is what a
+            # Shared tool should return — the old unconditional teacher filter
+            # returned nothing for students.
+            if get_config().canvas_role == "educator":
+                params["enrollment_type"] = "teacher"
 
         if include_concluded:
             params["state[]"] = ["available", "completed"]

--- a/tests/tools/test_courses.py
+++ b/tests/tools/test_courses.py
@@ -2,11 +2,104 @@
 Tests for course-related MCP tools.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from canvas_mcp.tools.courses import strip_html_tags
+
+
+def get_tool_function(tool_name: str):
+    """Get a registered course tool closure by name (no MCP runtime needed)."""
+    from mcp.server.fastmcp import FastMCP
+
+    from canvas_mcp.tools.courses import register_course_tools
+
+    mcp = FastMCP("test")
+    captured_functions = {}
+    original_tool = mcp.tool
+
+    def capturing_tool(*args, **kwargs):
+        decorator = original_tool(*args, **kwargs)
+
+        def wrapper(fn):
+            captured_functions[fn.__name__] = fn
+            return decorator(fn)
+
+        return wrapper
+
+    mcp.tool = capturing_tool
+    register_course_tools(mcp)
+    return captured_functions.get(tool_name)
+
+
+class TestListCoursesParams:
+    """list_courses must honor CANVAS_ROLE and use enrollment_state for 'current'.
+
+    Chamberlain (and many institutions) never flip finished courses to
+    workflow_state=completed, so filtering on state[] cannot distinguish a
+    current course from a past one. enrollment_state=active is the canonical
+    signal. The Shared tool must also not hard-filter to teacher enrollments,
+    which returns nothing for students.
+    """
+
+    @staticmethod
+    async def _call_and_get_params(role="all", **kwargs):
+        """Invoke list_courses with a mocked API and return the params it sent."""
+        with patch(
+            "canvas_mcp.tools.courses.fetch_all_paginated_results",
+            new_callable=AsyncMock,
+        ) as mock_fetch, patch(
+            "canvas_mcp.tools.courses.get_config",
+            return_value=SimpleNamespace(canvas_role=role),
+            create=True,
+        ):
+            mock_fetch.return_value = [
+                {"id": 1, "name": "Current Course", "course_code": "NR101"}
+            ]
+            list_courses = get_tool_function("list_courses")
+            assert list_courses is not None
+            await list_courses(**kwargs)
+            assert mock_fetch.await_count == 1
+            args, _ = mock_fetch.call_args
+            return args[1]  # params dict
+
+    @pytest.mark.asyncio
+    async def test_student_default_uses_enrollment_state_active(self):
+        """Default (student/all): scope to active enrollments, no teacher filter."""
+        params = await self._call_and_get_params(role="student")
+        assert params.get("enrollment_state") == "active"
+        assert "enrollment_type" not in params
+
+    @pytest.mark.asyncio
+    async def test_all_role_default_uses_enrollment_state_active(self):
+        """Role 'all' behaves like student: active enrollments, no teacher filter."""
+        params = await self._call_and_get_params(role="all")
+        assert params.get("enrollment_state") == "active"
+        assert "enrollment_type" not in params
+
+    @pytest.mark.asyncio
+    async def test_educator_role_keeps_teacher_filter(self):
+        """Educator: preserve teacher-only behavior, AND scope to active."""
+        params = await self._call_and_get_params(role="educator")
+        assert params.get("enrollment_type") == "teacher"
+        assert params.get("enrollment_state") == "active"
+
+    @pytest.mark.asyncio
+    async def test_include_all_returns_full_history(self):
+        """include_all=True is the escape hatch: no role/active filtering."""
+        params = await self._call_and_get_params(role="student", include_all=True)
+        assert "enrollment_type" not in params
+        assert "enrollment_state" not in params
+
+    @pytest.mark.asyncio
+    async def test_include_concluded_adds_completed_state(self):
+        """include_concluded=True surfaces completed courses too."""
+        params = await self._call_and_get_params(
+            role="student", include_all=True, include_concluded=True
+        )
+        assert "completed" in params.get("state[]", [])
 
 
 class TestStripHtmlTags:

--- a/tests/tools/test_courses.py
+++ b/tests/tools/test_courses.py
@@ -88,7 +88,8 @@ class TestListCoursesParams:
 
     @pytest.mark.asyncio
     async def test_include_all_returns_full_history(self):
-        """include_all=True is the escape hatch: no role/active filtering."""
+        """include_all=True drops role/active scoping; state[] still defaults to
+        ['available'] (use include_concluded to also surface past courses)."""
         params = await self._call_and_get_params(role="student", include_all=True)
         assert "enrollment_type" not in params
         assert "enrollment_state" not in params


### PR DESCRIPTION
## Problem

`list_courses` is a **Shared** tool, but its default path unconditionally set `enrollment_type=teacher`. For a student that returns **"No courses found"** — the tool is effectively educator-only despite being shared.

It also scopes results with the course `state[]` filter (`available` / `completed`). That can't distinguish a *current* course from a *past* one at institutions that never flip finished courses to `workflow_state=completed`. Chamberlain, for example, leaves **every** course `available` indefinitely, so a student's entire enrollment history (40+ courses) comes back with no way to isolate the current term.

## Fix

Read the already-configured `CANVAS_ROLE` (it previously only gated tool registration, never reached `list_courses`) and use Canvas's canonical **`enrollment_state=active`** signal for the default "current" view:

- **student / all** → active enrollments across all roles (no teacher filter)
- **educator** → unchanged behavior: keeps `enrollment_type=teacher`, now also scoped to active enrollments (so educators get current-vs-past correctness too)
- `include_all` / `include_concluded` remain escape hatches for full history

This is intentionally minimal and reuses the existing role abstraction rather than adding new API surface. Teacher output is a superset-safe no-op by default (still `enrollment_type=teacher`).

## Verification

- **Live Canvas (Chamberlain student account):** the default call previously returned **0** courses; with the fix it returns exactly the current-term courses and correctly omits last-session courses. Confirmed end-to-end through the real tool function, not just the param builder.
- **Tests:** 5 new unit tests assert the params sent per role (student/all → `enrollment_state=active`, no teacher filter; educator → both; `include_all`/`include_concluded` history paths). Full course suite green; `ruff` clean.

## Notes

No new tool, no signature change, no docs/manifest changes required. Pure behavior fix to an existing Shared tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)