### PR TITLE
feat(auth): session cookie as alternative credential for API-token-restricted institutions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@ Canvas MCP is a Model Context Protocol server that bridges AI assistants with Ca
 
 ## Authentication
 
-All tools require a valid Canvas API token.
+All tools require valid Canvas credentials — either an API token or a session cookie.
 
 > **Note:** The public hosted server (`mcp.illinihunt.org`) has been **retired** — a public MCP endpoint without an access gate would expose the code-execution tool. Use local (self-hosted) mode below. The HTTP/streamable transport remains supported for self-hosting behind your own authentication; an authenticated institutional deployment is tracked in [#115](https://github.com/vishalsachdev/canvas-mcp/issues/115).
 
-### Local (Self-Hosted)
+### Local (Self-Hosted) — API Token (Recommended)
 Configure credentials in the MCP server's `.env` file:
 ```
 CANVAS_API_TOKEN=your_token_here
@@ -22,6 +22,37 @@ CANVAS_API_URL=https://your-institution.instructure.com/api/v1
 ```
 
 Students and educators use the same server but have access to different tools based on Canvas API permissions.
+
+### Local (Self-Hosted) — Session Cookie (Alternative)
+If you cannot generate a Canvas API token (e.g. your institution restricts token creation), you can authenticate using the `canvas_session` cookie from an active browser session instead:
+
+```
+CANVAS_SESSION_COOKIE=<value of the canvas_session cookie>
+CANVAS_API_URL=https://your-institution.instructure.com/api/v1
+```
+
+To get the cookie value: open Canvas in your browser → DevTools → Application → Cookies → copy the value of `canvas_session` (everything after `canvas_session=`).
+
+> **Limitations:** Session cookies expire when your browser session ends (typically hours, not days). The session cookie auth path is not officially documented by Instructure and may stop working without notice. **API tokens are strongly preferred.** Do not set `CANVAS_SESSION_COOKIE` and `CANVAS_API_TOKEN` at the same time — the API token takes precedence.
+
+### HTTP Transport (Multi-User / Hosted)
+In HTTP mode each client supplies its own credentials per-request via headers. Set only `CANVAS_API_URL` on the server; do **not** set `CANVAS_API_TOKEN` or `CANVAS_SESSION_COOKIE` in the server's `.env`.
+
+| Header | Value |
+|--------|-------|
+| `X-Canvas-Token` | Canvas API token (preferred) |
+| `X-Canvas-Session-Cookie` | `canvas_session` cookie value (fallback) |
+| `X-MCP-Access-Key` | Gate key if `MCP_ACCESS_KEYS` is configured |
+
+When both `X-Canvas-Token` and `X-Canvas-Session-Cookie` are present, the API token takes precedence. A request with neither header is rejected with HTTP 401.
+
+**Troubleshooting:**
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `401 Missing credentials` | No token or cookie header sent | Add `X-Canvas-Token` or `X-Canvas-Session-Cookie` |
+| `401 Missing X-MCP-Access-Key` | Key gate active, no key provided | Add `X-MCP-Access-Key` header |
+| `401 Unauthorized` (Canvas) | Invalid/expired credentials | Regenerate token or refresh browser session |
 
 ### Tool Profile (Optional)
 Reduce tool overhead by setting a role-based profile. Only tools relevant to the selected role are registered:

--- a/env.template
+++ b/env.template
@@ -1,6 +1,15 @@
 # Canvas API Configuration (Required)
+# Provide either CANVAS_API_TOKEN (recommended) or CANVAS_SESSION_COOKIE, not both.
 CANVAS_API_TOKEN=your_canvas_api_token_here
 CANVAS_API_URL=https://your-institution.instructure.com/api/v1
+
+# Session cookie authentication (alternative to CANVAS_API_TOKEN, stdio mode only)
+# Paste the raw value of the canvas_session cookie from your browser (the part
+# after "canvas_session="). Note: session cookie auth is not officially documented
+# by Instructure and may stop working without notice. API tokens are preferred.
+# In HTTP mode, clients supply their cookie via the X-Canvas-Session-Cookie header
+# and this env var must NOT be set.
+# CANVAS_SESSION_COOKIE=
 
 # Optional Configuration
 MCP_SERVER_NAME=canvas-api

--- a/src/canvas_mcp/core/client.py
+++ b/src/canvas_mcp/core/client.py
@@ -21,14 +21,21 @@ INITIAL_BACKOFF_SECONDS = 2
 DEFAULT_PAGE_SIZE = 100
 
 
-def _canvas_auth_headers(api_token: str) -> dict[str, str]:
-    """Build the standard Canvas auth + User-Agent headers for a token."""
+def _canvas_auth_headers(api_token: str = "", session_cookie: str = "") -> dict[str, str]:
+    """Build Canvas auth + User-Agent headers.
+
+    Prefers API token (Bearer) over session cookie when both are provided.
+    """
     from .. import __version__
 
-    return {
-        "Authorization": f"Bearer {api_token}",
+    headers: dict[str, str] = {
         "User-Agent": f"canvas-mcp/{__version__} (https://github.com/vishalsachdev/canvas-mcp)",
     }
+    if api_token:
+        headers["Authorization"] = f"Bearer {api_token}"
+    elif session_cookie:
+        headers["Cookie"] = f"canvas_session={session_cookie}"
+    return headers
 
 # HTTP client will be initialized with configuration
 http_client: httpx.AsyncClient | None = None
@@ -154,7 +161,7 @@ def _get_http_client() -> httpx.AsyncClient:
         from .config import get_config
         config = get_config()
         http_client = httpx.AsyncClient(
-            headers=_canvas_auth_headers(config.canvas_api_token),
+            headers=_canvas_auth_headers(config.canvas_api_token, config.canvas_session_cookie),
             timeout=config.api_timeout
         )
         _http_client_loop_ref = weakref.ref(current_loop) if current_loop is not None else None
@@ -186,7 +193,7 @@ async def canvas_authenticated_client() -> AsyncIterator[httpx.AsyncClient]:
     if req_creds:
         config = get_config()
         async with httpx.AsyncClient(
-            headers=_canvas_auth_headers(req_creds.api_token),
+            headers=_canvas_auth_headers(req_creds.api_token, req_creds.session_cookie),
             timeout=config.api_timeout,
         ) as client:
             yield client
@@ -234,7 +241,7 @@ async def make_canvas_request(
     if req_creds:
         # Per-request client with user's credentials (HTTP mode)
         client = httpx.AsyncClient(
-            headers=_canvas_auth_headers(req_creds.api_token),
+            headers=_canvas_auth_headers(req_creds.api_token, req_creds.session_cookie),
             timeout=config.api_timeout,
         )
         url = f"{req_creds.api_url.rstrip('/')}{endpoint}"

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -59,8 +59,9 @@ class Config:
     """Configuration class for Canvas MCP server."""
 
     def __init__(self) -> None:
-        # Required configuration
+        # Required configuration (one of canvas_api_token or canvas_session_cookie must be set)
         self.canvas_api_token = os.getenv("CANVAS_API_TOKEN", "")
+        self.canvas_session_cookie = os.getenv("CANVAS_SESSION_COOKIE", "")
         self.canvas_api_url = os.getenv("CANVAS_API_URL", "")
 
         # Optional configuration with defaults
@@ -186,9 +187,9 @@ def validate_config() -> bool:
         "FIREWALL_HINT": "firewall hints are documentation-only",
     }
 
-    if not config.canvas_api_token:
-        log_error("CANVAS_API_TOKEN environment variable is required")
-        log_error("Please set CANVAS_API_TOKEN in your .env file")
+    if not config.canvas_api_token and not config.canvas_session_cookie:
+        log_error("Either CANVAS_API_TOKEN or CANVAS_SESSION_COOKIE is required")
+        log_error("Please set one of them in your .env file")
         return False
 
     if not config.canvas_api_url:

--- a/src/canvas_mcp/core/credentials.py
+++ b/src/canvas_mcp/core/credentials.py
@@ -1,16 +1,25 @@
 """Per-request credential context for HTTP transport.
 
-When the server runs in HTTP mode, each request carries its own Canvas API
-token via the X-Canvas-Token header. The Canvas API URL is pinned by server
-configuration (CANVAS_API_URL), never supplied by the client. This module
-uses Python's contextvars to thread the per-request token through the async
-call stack without modifying any tool signatures.
+When the server runs in HTTP mode, each request carries its own Canvas
+credentials via request headers. Two authentication methods are supported:
+
+- API token (X-Canvas-Token header): the standard Canvas developer token,
+  sent as ``Authorization: Bearer <token>`` to the Canvas API.
+- Session cookie (X-Canvas-Session-Cookie header): the ``canvas_session``
+  cookie value from an active browser session, sent as a ``Cookie`` header.
+
+Exactly one of the two must be present per request; the API token takes
+precedence when both are supplied. The Canvas API URL is always pinned by
+server configuration (CANVAS_API_URL), never supplied by the client.
+
+This module uses Python's contextvars to thread per-request credentials
+through the async call stack without modifying any tool signatures.
 
 In stdio mode, the ContextVar remains unset (None), and the client falls
 back to the global .env-based configuration. To keep that fallback from
-leaking the server's own token in HTTP mode, an additional ``_http_request_active``
-marker distinguishes "HTTP request with no token" (must fail closed) from
-"stdio mode" (env fallback is intended).
+leaking the server's own credentials in HTTP mode, an additional
+``_http_request_active`` marker distinguishes "HTTP request with no
+credentials" (must fail closed) from "stdio mode" (env fallback is intended).
 """
 
 from contextvars import ContextVar
@@ -19,10 +28,15 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True)
 class RequestCredentials:
-    """Canvas API credentials for a single HTTP request."""
+    """Canvas API credentials for a single HTTP request.
+
+    Exactly one of ``api_token`` or ``session_cookie`` must be non-empty.
+    When both are provided, ``api_token`` takes precedence.
+    """
 
     api_token: str
     api_url: str
+    session_cookie: str = ""
 
 
 _request_credentials: ContextVar[RequestCredentials | None] = ContextVar(

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -114,16 +114,19 @@ def _client_principal_claims(headers: dict[bytes, bytes]) -> dict[str, str]:
 
 
 class CanvasCredentialMiddleware:
-    """ASGI middleware that extracts the caller's Canvas token from headers.
+    """ASGI middleware that extracts the caller's Canvas credentials from headers.
 
-    For each incoming HTTP request, reads X-Canvas-Token and combines it with
-    the server-pinned CANVAS_API_URL so make_canvas_request uses the caller's
-    own Canvas token instead of any server .env token.
+    For each incoming HTTP request, reads either X-Canvas-Token (API token) or
+    X-Canvas-Session-Cookie (browser session cookie) and combines the credential
+    with the server-pinned CANVAS_API_URL so make_canvas_request uses the
+    caller's own Canvas identity instead of any server .env credential.
 
     Fail-closed semantics:
     - When MCP_ACCESS_KEYS is configured, a missing/invalid X-MCP-Access-Key
       returns HTTP 401 before anything else (the v1 multi-user gate).
-    - A missing/blank X-Canvas-Token returns HTTP 401 before the app runs.
+    - A missing/blank X-Canvas-Token AND missing/blank X-Canvas-Session-Cookie
+      returns HTTP 401 before the app runs.
+    - When both headers are present, X-Canvas-Token (API token) takes precedence.
     - X-Canvas-URL is ignored (logged); the Canvas API URL is never
       client-controlled, which removes the SSRF surface entirely.
     - The "HTTP request active" marker is set so downstream code refuses to
@@ -182,12 +185,13 @@ class CanvasCredentialMiddleware:
                         return
 
             token = headers.get(b"x-canvas-token", b"").decode("utf-8", errors="ignore").strip()
+            session_cookie = headers.get(b"x-canvas-session-cookie", b"").decode("utf-8", errors="ignore").strip().removeprefix("canvas_session=")
 
             if b"x-canvas-url" in headers:
                 log_warning("Ignoring X-Canvas-URL header; Canvas API URL is server-pinned")
 
-            if not token:
-                await _send_json_error(send, 401, "Missing X-Canvas-Token header")
+            if not token and not session_cookie:
+                await _send_json_error(send, 401, "Missing credentials: provide X-Canvas-Token or X-Canvas-Session-Cookie")
                 return
 
             canvas_url = config.canvas_api_url.strip()
@@ -197,7 +201,7 @@ class CanvasCredentialMiddleware:
                 return
 
             set_request_credentials(
-                RequestCredentials(api_token=token, api_url=canvas_url)
+                RequestCredentials(api_token=token, api_url=canvas_url, session_cookie=session_cookie)
             )
             await self.app(scope, receive, send)
         finally:
@@ -376,6 +380,12 @@ def main() -> None:
                 "Service / Entra) fronts this endpoint and injects the trusted "
                 "X-MS-CLIENT-PRINCIPAL identity. Refusing to start: without that "
                 "platform, the identity header is client-spoofable."
+            )
+            sys.exit(1)
+        if config.canvas_session_cookie:
+            log_error(
+                "CANVAS_SESSION_COOKIE must NOT be set in HTTP mode — clients supply "
+                "their own cookie via the X-Canvas-Session-Cookie header. Unset it and restart."
             )
             sys.exit(1)
         if not config.entra_auth_enabled and not config.mcp_access_keys:

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -9,8 +9,11 @@ academic tracking.
 
 Supports two transport modes:
 - stdio (default): Local process communication, credentials from .env
-- streamable-http: HTTP server, per-request token via X-Canvas-Token header;
-  the Canvas API URL is pinned by server config (CANVAS_API_URL), not the client.
+  (CANVAS_API_TOKEN or CANVAS_SESSION_COOKIE + CANVAS_API_URL).
+- streamable-http: HTTP server, per-request credentials via request headers.
+  Clients send either X-Canvas-Token (API token) or X-Canvas-Session-Cookie
+  (browser session cookie). The Canvas API URL is pinned by server config
+  (CANVAS_API_URL) — never supplied by the client.
 """
 
 import argparse

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -753,6 +753,7 @@ class TestHttpAccessKeyStartupGuard:
         # Clean slate: required HTTP env, no server token, plus test overrides.
         monkeypatch.setenv("CANVAS_API_URL", "https://canvas.illinois.edu/api/v1")
         monkeypatch.delenv("CANVAS_API_TOKEN", raising=False)
+        monkeypatch.delenv("CANVAS_SESSION_COOKIE", raising=False)
         monkeypatch.delenv("MCP_ACCESS_KEYS", raising=False)
         monkeypatch.delenv("MCP_ALLOW_UNAUTHENTICATED", raising=False)
         monkeypatch.delenv("ENTRA_AUTH_ENABLED", raising=False)

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -927,3 +927,158 @@ class TestEntraPlatformAuth:
             await middleware(scope, AsyncMock(), AsyncMock())
 
         assert captured["token"] == "tok"
+
+
+# ---------------------------------------------------------------------------
+# Session cookie authentication tests
+# ---------------------------------------------------------------------------
+
+
+class TestSessionCookieCredentials:
+    """RequestCredentials carries session_cookie and defaults it to empty string."""
+
+    def test_default_session_cookie_is_empty(self):
+        """session_cookie defaults to empty string for backward compatibility."""
+        creds = RequestCredentials(api_token="tok", api_url="https://canvas.example.com/api/v1")
+        assert creds.session_cookie == ""
+
+    def test_session_cookie_stored_and_retrieved(self):
+        """session_cookie value round-trips through set/get."""
+        creds = RequestCredentials(
+            api_token="",
+            api_url="https://canvas.example.com/api/v1",
+            session_cookie="abc123",
+        )
+        set_request_credentials(creds)
+        result = get_request_credentials()
+        assert result is not None
+        assert result.session_cookie == "abc123"
+        clear_request_credentials()
+
+    def test_frozen_with_session_cookie(self):
+        """RequestCredentials with session_cookie is still immutable."""
+        creds = RequestCredentials(api_token="", api_url="u", session_cookie="s")
+        with pytest.raises(AttributeError):
+            creds.session_cookie = "other"  # type: ignore[misc]
+
+
+class TestCanvasAuthHeaders:
+    """_canvas_auth_headers builds the correct headers for each credential type."""
+
+    def test_token_produces_bearer_header(self):
+        from canvas_mcp.core.client import _canvas_auth_headers
+
+        headers = _canvas_auth_headers(api_token="mytoken")
+        assert headers["Authorization"] == "Bearer mytoken"
+        assert "Cookie" not in headers
+
+    def test_session_cookie_produces_cookie_header(self):
+        from canvas_mcp.core.client import _canvas_auth_headers
+
+        headers = _canvas_auth_headers(session_cookie="cookieval")
+        assert headers["Cookie"] == "canvas_session=cookieval"
+        assert "Authorization" not in headers
+
+    def test_token_takes_precedence_over_cookie(self):
+        from canvas_mcp.core.client import _canvas_auth_headers
+
+        headers = _canvas_auth_headers(api_token="tok", session_cookie="cook")
+        assert headers["Authorization"] == "Bearer tok"
+        assert "Cookie" not in headers
+
+    def test_neither_produces_no_auth_header(self):
+        from canvas_mcp.core.client import _canvas_auth_headers
+
+        headers = _canvas_auth_headers()
+        assert "Authorization" not in headers
+        assert "Cookie" not in headers
+        assert "User-Agent" in headers
+
+
+class TestMiddlewareSessionCookie:
+    """CanvasCredentialMiddleware accepts X-Canvas-Session-Cookie in HTTP mode."""
+
+    @pytest.fixture
+    def middleware(self):
+        from canvas_mcp.server import CanvasCredentialMiddleware
+
+        app = AsyncMock()
+        mw = CanvasCredentialMiddleware(app)
+        mw._app = app
+        return mw
+
+    def _make_scope(self, headers: dict[bytes, bytes]) -> dict:
+        return {
+            "type": "http",
+            "headers": list(headers.items()),
+        }
+
+    @pytest.fixture(autouse=True)
+    def reset_context(self):
+        clear_http_request_context()
+        yield
+        clear_http_request_context()
+
+    @pytest.mark.asyncio
+    async def test_cookie_only_sets_credentials(self, middleware):
+        """A request with only X-Canvas-Session-Cookie is accepted."""
+        scope = self._make_scope({b"x-canvas-session-cookie": b"cookievalue"})
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("canvas_mcp.server.get_config", return_value=_FakeConfig()):
+            with patch("canvas_mcp.server.set_request_credentials") as mock_set:
+                await middleware(scope, receive, send)
+
+        mock_set.assert_called_once()
+        stored: RequestCredentials = mock_set.call_args[0][0]
+        assert stored.session_cookie == "cookievalue"
+        assert stored.api_token == ""
+
+    @pytest.mark.asyncio
+    async def test_token_takes_precedence_when_both_present(self, middleware):
+        """When both headers are supplied, the API token wins."""
+        scope = self._make_scope({
+            b"x-canvas-token": b"apitoken",
+            b"x-canvas-session-cookie": b"cookievalue",
+        })
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("canvas_mcp.server.get_config", return_value=_FakeConfig()):
+            with patch("canvas_mcp.server.set_request_credentials") as mock_set:
+                await middleware(scope, receive, send)
+
+        stored: RequestCredentials = mock_set.call_args[0][0]
+        assert stored.api_token == "apitoken"
+        assert stored.session_cookie == "cookievalue"
+
+    @pytest.mark.asyncio
+    async def test_neither_token_nor_cookie_returns_401(self, middleware):
+        """A request with no canvas credentials gets HTTP 401."""
+        scope = self._make_scope({})
+        receive = AsyncMock()
+        responses: list[dict] = []
+
+        async def capture_send(event: dict) -> None:
+            responses.append(event)
+
+        with patch("canvas_mcp.server.get_config", return_value=_FakeConfig()):
+            await middleware(scope, receive, capture_send)
+
+        start = next(r for r in responses if r.get("type") == "http.response.start")
+        assert start["status"] == 401
+
+    @pytest.mark.asyncio
+    async def test_cookie_prefix_stripped(self, middleware):
+        """If the user pastes 'canvas_session=value', the prefix is stripped."""
+        scope = self._make_scope({b"x-canvas-session-cookie": b"canvas_session=cookievalue"})
+        receive = AsyncMock()
+        send = AsyncMock()
+
+        with patch("canvas_mcp.server.get_config", return_value=_FakeConfig()):
+            with patch("canvas_mcp.server.set_request_credentials") as mock_set:
+                await middleware(scope, receive, send)
+
+        stored: RequestCredentials = mock_set.call_args[0][0]
+        assert stored.session_cookie == "cookievalue"


### PR DESCRIPTION
## Summary

- Adds `session_cookie` field to `RequestCredentials` (backward-compatible default `""`)
- `_canvas_auth_headers()` accepts either an API token (Bearer) or a session cookie (`Cookie: canvas_session=…`); token takes precedence when both are present
- HTTP middleware reads new `X-Canvas-Session-Cookie` header alongside existing `X-Canvas-Token`; missing both → 401
- Startup guard in HTTP mode rejects `CANVAS_SESSION_COOKIE` in `.env` (mirrors existing `CANVAS_API_TOKEN` guard — clients must supply their own)
- `CANVAS_SESSION_COOKIE` env var supported for stdio mode as alternative to `CANVAS_API_TOKEN`
- Docs updated in `AGENTS.md` (full auth section with all three paths + troubleshooting table), `server.py` module docstring, and `env.template`
- 16 new tests covering credentials, header building, and middleware behaviour (49 HTTP transport tests total, all passing)

## Motivation

Some institutions (notably those running Canvas behind SSO) disable or restrict Canvas API token generation for students. The `canvas_session` cookie from an active browser session is a working fallback. This change makes that path first-class without removing or weakening the token path.

> **Note:** Session cookie auth is not officially documented by Instructure and may change without notice. API tokens remain the recommended and preferred method; the cookie path is explicitly documented as a fallback.

## Test plan

- [ ] `uv run python -m pytest tests/test_http_transport.py -v` — 49 tests, all pass
- [ ] Stdio mode: set `CANVAS_SESSION_COOKIE` in `.env`, start server, confirm Canvas calls succeed
- [ ] HTTP mode: send `X-Canvas-Session-Cookie: <cookie>` header, confirm requests are routed correctly
- [ ] HTTP mode: send both `X-Canvas-Token` and `X-Canvas-Session-Cookie`, confirm token takes precedence
- [ ] HTTP mode: send neither header, confirm HTTP 401