### PR TITLE
docs: fix dead Troubleshooting anchor found during clean-room onboarding test

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Built on **FastMCP** with async `httpx`, `pydantic` validation, and `python-dote
 
 If you encounter issues:
 
-1. **Server Won't Start** - Verify your [Configuration](#configuration) setup: `.env` file, virtual environment path, and dependencies
+1. **Server Won't Start** - Verify your [Local Installation](#local-installation) setup: `.env` file, virtual environment path, and dependencies
 2. **Authentication Errors** - Check your Canvas API token validity and permissions
 3. **Connection Issues** - Verify Canvas API URL correctness and network access
 4. **Debugging** - Check your MCP client's console logs (e.g., Claude Desktop's developer console) or run server manually for error output


### PR DESCRIPTION
## What

Ran the README onboarding flow from a clean, disposable environment (fresh `git clone` of tracked files only — no `.env`, no `.venv`, no carried-over state) to verify it works end-to-end for a first-time user.

## Result

The documented "Local Installation → Verification" path **works end-to-end**:

| Step (README) | Result |
|---|---|
| `python3 -m venv .venv` / `pip install -e .` | ✅ installs canvas-mcp 1.4.0 |
| `cp env.template .env` | ✅ |
| `canvas-mcp-server --config` | ✅ prints config |
| `canvas-mcp-server` (stdio) | ✅ server starts, registers **90 tools** (matches README claim) |
| `canvas-mcp-server --test` | ⚠️ credential-gated — fails only with template placeholders (`domain not found`); expected, requires the user's real Canvas token + URL |

## Gap found & fixed

The Troubleshooting section linked to `[Configuration](#configuration)`, but **no heading generates that anchor** (the headings are `### 2. Configure Environment` and `### 3. MCP Client Configuration`). The link was dead.

Repointed it to `#local-installation` — the section that actually documents the three things the line references (`.env` file, virtualenv path, dependencies).

## Verification

Re-ran the full onboarding from a second fresh clone after the fix: uninterrupted run reached ready state (install → config → server up with 90 tools), the anchor now resolves to `## Local Installation` (line 283), and 0 stale `#configuration` links remain.

## Remaining blockers (not addressed here)

- `canvas-mcp-server --test` cannot be fully verified without real Canvas credentials — this is the intended user-supplied boundary, not a doc defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ12QZaDvcmz2koe8tLthU)_