### PR TITLE
fix(courses): honor CANVAS_ROLE in list_courses (re-land of #130)

### DIFF
--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -514,6 +514,10 @@ def main() -> None:
     if role not in ("student", "educator", "all"):
         log_warning(f"Unknown role '{role}', defaulting to 'all'")
         role = "all"
+    # Make the resolved role authoritative so runtime tool behavior (e.g.
+    # list_courses reading get_config().canvas_role) matches the registered
+    # profile even when the CLI --role flag overrides the CANVAS_ROLE env var.
+    config.canvas_role = role
     log_info(f"Tool profile: {role}")
     register_all_tools(mcp, role=role)
 

--- a/src/canvas_mcp/tools/courses.py
+++ b/src/canvas_mcp/tools/courses.py
@@ -13,6 +13,7 @@ from ..core.cache import (
     id_to_course_code_cache,
 )
 from ..core.client import fetch_all_paginated_results, make_canvas_request
+from ..core.config import get_config
 from ..core.dates import format_date
 from ..core.validation import validate_params
 
@@ -79,7 +80,17 @@ def register_course_tools(mcp: FastMCP):
         }
 
         if not include_all:
-            params["enrollment_type"] = "teacher"
+            # Scope to the user's *current* enrollments. enrollment_state="active"
+            # is Canvas's canonical "current" signal; the course state[] filter
+            # below cannot distinguish current from past at institutions that
+            # never flip finished courses to workflow_state="completed".
+            params["enrollment_state"] = "active"
+            # Educators keep teacher-only scoping (unchanged behavior). Students
+            # and the "all" profile see every active enrollment, which is what a
+            # Shared tool should return — the old unconditional teacher filter
+            # returned nothing for students.
+            if get_config().canvas_role == "educator":
+                params["enrollment_type"] = "teacher"
 
         if include_concluded:
             params["state[]"] = ["available", "completed"]

--- a/tests/tools/test_courses.py
+++ b/tests/tools/test_courses.py
@@ -2,6 +2,7 @@
 Tests for course-related MCP tools.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -47,6 +48,75 @@ LONG_SYLLABUS_HTML = (
     "<h3>Grading Policy</h3>"
     "<p>Final exam is weighted at 40% of the total grade.</p>"
 )
+
+
+class TestListCoursesParams:
+    """list_courses must honor CANVAS_ROLE and use enrollment_state for 'current'.
+
+    Chamberlain (and many institutions) never flip finished courses to
+    workflow_state=completed, so filtering on state[] cannot distinguish a
+    current course from a past one. enrollment_state=active is the canonical
+    signal. The Shared tool must also not hard-filter to teacher enrollments,
+    which returns nothing for students.
+    """
+
+    @staticmethod
+    async def _call_and_get_params(role="all", **kwargs):
+        """Invoke list_courses with a mocked API and return the params it sent."""
+        with patch(
+            "canvas_mcp.tools.courses.fetch_all_paginated_results",
+            new_callable=AsyncMock,
+        ) as mock_fetch, patch(
+            "canvas_mcp.tools.courses.get_config",
+            return_value=SimpleNamespace(canvas_role=role),
+            create=True,
+        ):
+            mock_fetch.return_value = [
+                {"id": 1, "name": "Current Course", "course_code": "NR101"}
+            ]
+            list_courses = get_tool_function("list_courses")
+            assert list_courses is not None
+            await list_courses(**kwargs)
+            assert mock_fetch.await_count == 1
+            args, _ = mock_fetch.call_args
+            return args[1]  # params dict
+
+    @pytest.mark.asyncio
+    async def test_student_default_uses_enrollment_state_active(self):
+        """Default (student/all): scope to active enrollments, no teacher filter."""
+        params = await self._call_and_get_params(role="student")
+        assert params.get("enrollment_state") == "active"
+        assert "enrollment_type" not in params
+
+    @pytest.mark.asyncio
+    async def test_all_role_default_uses_enrollment_state_active(self):
+        """Role 'all' behaves like student: active enrollments, no teacher filter."""
+        params = await self._call_and_get_params(role="all")
+        assert params.get("enrollment_state") == "active"
+        assert "enrollment_type" not in params
+
+    @pytest.mark.asyncio
+    async def test_educator_role_keeps_teacher_filter(self):
+        """Educator: preserve teacher-only behavior, AND scope to active."""
+        params = await self._call_and_get_params(role="educator")
+        assert params.get("enrollment_type") == "teacher"
+        assert params.get("enrollment_state") == "active"
+
+    @pytest.mark.asyncio
+    async def test_include_all_returns_full_history(self):
+        """include_all=True drops role/active scoping; state[] still defaults to
+        ['available'] (use include_concluded to also surface past courses)."""
+        params = await self._call_and_get_params(role="student", include_all=True)
+        assert "enrollment_type" not in params
+        assert "enrollment_state" not in params
+
+    @pytest.mark.asyncio
+    async def test_include_concluded_adds_completed_state(self):
+        """include_concluded=True surfaces completed courses too."""
+        params = await self._call_and_get_params(
+            role="student", include_all=True, include_concluded=True
+        )
+        assert "completed" in params.get("state[]", [])
 
 
 class TestStripHtmlTags:


### PR DESCRIPTION
## Summary

Re-lands **#130 by @Promithius-DR** onto current `main`. The original PR became un-mergeable (`dirty`) after #137 merged — both added an identical `get_tool_function` test helper to `tests/tools/test_courses.py`. Since #130 is on a fork I can't push to, this branch carries the same change with that one conflict resolved (kept main's helper + #137's `LONG_SYLLABUS_HTML`, added #130's `TestListCoursesParams`). **Full credit to @Promithius-DR** (co-authored).

## The fix (unchanged from #130)

`list_courses` is a **Shared** tool but its default path unconditionally set `enrollment_type=teacher`, so a **student got "No courses found."** It also relied on the course `state[]` filter, which can't distinguish a current course from a past one at institutions that never flip finished courses to `workflow_state=completed` (e.g. Chamberlain).

- Reads the already-configured `CANVAS_ROLE` and uses Canvas's canonical **`enrollment_state=active`** for the default "current" view.
- **student / all** → active enrollments across all roles (no teacher filter).
- **educator** → keeps `enrollment_type=teacher`, now also scoped to active.
- `include_all` / `include_concluded` remain full-history escape hatches.
- Propagates the resolved `--role` into `config.canvas_role` (`server.py`) so runtime behavior matches the registered profile.

## Verification
- All 28 `test_courses.py` tests pass (5 new role-param tests from #130 + #137's syllabus tests together); full suite **488 passed**, ruff clean.

Closes #130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFjk1cYguBELgcBjXv3sRD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PFjk1cYguBELgcBjXv3sRD)_