### PR TITLE
docs: include /api/v1 in Desktop Extension Canvas API URL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ If you use **Claude Desktop**, you can install Canvas MCP with one click — no 
 
 1. Download `canvas-mcp.mcpb` from the [latest release](https://github.com/vishalsachdev/canvas-mcp/releases/latest).
 2. Double-click the file (or drag it into Claude Desktop → Settings → Extensions).
-3. When prompted, enter your **Canvas API URL** (e.g. `https://canvas.youruniversity.edu`) and your **Canvas API token** (Canvas → Account → Settings → New Access Token). The token is stored in your OS keychain.
+3. When prompted, enter your **Canvas API URL** — this must include the `/api/v1` path (e.g. `https://canvas.youruniversity.edu/api/v1`) — and your **Canvas API token** (Canvas → Account → Settings → New Access Token). The token is stored in your OS keychain.
 
 The extension runs the server locally and calls Canvas with **your own** token — every action runs under your own Canvas role and audit trail. Requires Python 3.10+ (the bundled runtime manages dependencies automatically). For other clients, or to run from source, use the manual setup below.
 


### PR DESCRIPTION
## Problem

The **Install as a Claude Desktop Extension** section tells users to enter their Canvas API URL as `https://canvas.youruniversity.edu` (base host, no path).

The config layer does **not** normalize the URL:
- `core/config.py` only *logs a warning* when `CANVAS_API_URL` doesn't end with `/api/v1` — it never strips a trailing slash or appends the suffix.
- `env.template` already uses the `/api/v1` form (`https://your-institution.instructure.com/api/v1`).

So when a user follows the README example, the client hits paths like `/courses` directly. Canvas responds with a **302 redirect to SSO login**, and tools surface it as:

```
{"result":"Error fetching courses: HTTP error: 302, Text: "}
```

This reads like an auth/token failure, but the token is fine — the URL is just missing `/api/v1`. Hit this on a live `canvas.*.ac.uk` instance; adding the suffix fixed it immediately.

## Fix

Update the Desktop Extension URL example to include the `/api/v1` suffix and call it out explicitly, matching `env.template` and the validation in `core/config.py`.

Docs-only, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)