### PR TITLE
fix: normalize CANVAS_API_URL to canonical /api/v1 form

### DIFF
--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -22,6 +22,29 @@ def _parse_keys(raw: str) -> frozenset[str]:
     return frozenset(k for k in raw.replace(",", " ").split() if k)
 
 
+def _normalize_canvas_url(raw: str) -> str:
+    """Normalize ``CANVAS_API_URL`` to the canonical ``…/api/v1`` form.
+
+    Canvas REST endpoints live under ``/api/v1``. Users frequently enter just
+    the base host (e.g. ``https://canvas.school.edu``); requests without the
+    suffix make Canvas issue a 302 redirect to SSO login, which surfaces as a
+    misleading ``HTTP error: 302`` that looks like a bad token. Strip trailing
+    slashes and append ``/api/v1`` when missing so all of these forms resolve
+    to the same canonical URL:
+
+    - ``https://canvas.school.edu``         → ``https://canvas.school.edu/api/v1``
+    - ``https://canvas.school.edu/``        → ``https://canvas.school.edu/api/v1``
+    - ``https://canvas.school.edu/api/v1``  → unchanged
+    - ``https://canvas.school.edu/api/v1/`` → ``https://canvas.school.edu/api/v1``
+    """
+    url = raw.strip().rstrip("/")
+    if not url:
+        return ""
+    if not url.endswith("/api/v1"):
+        url = f"{url}/api/v1"
+    return url
+
+
 def _bool_env(name: str, default: bool) -> bool:
     value = os.getenv(name)
     if value is None:
@@ -61,7 +84,7 @@ class Config:
     def __init__(self) -> None:
         # Required configuration
         self.canvas_api_token = os.getenv("CANVAS_API_TOKEN", "")
-        self.canvas_api_url = os.getenv("CANVAS_API_URL", "")
+        self.canvas_api_url = _normalize_canvas_url(os.getenv("CANVAS_API_URL", ""))
 
         # Optional configuration with defaults
         self.mcp_server_name = os.getenv("MCP_SERVER_NAME", "canvas-api")
@@ -196,11 +219,9 @@ def validate_config() -> bool:
         log_error("Please set CANVAS_API_URL in your .env file")
         return False
 
-    if not config.canvas_api_url.endswith("/api/v1"):
-        log_warning(
-            "CANVAS_API_URL should end with '/api/v1'",
-            current_url=config.canvas_api_url,
-        )
+    # CANVAS_API_URL is normalized to the canonical '…/api/v1' form in
+    # Config.__init__ (see _normalize_canvas_url), so no suffix check is needed
+    # here — any non-empty value is already well-formed.
 
     if config.ts_sandbox_mode not in VALID_SANDBOX_MODES:
         log_warning(

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -1,6 +1,7 @@
 """Configuration management for Canvas MCP server."""
 
 import os
+import re
 from urllib.parse import urlparse, urlunparse
 
 from dotenv import load_dotenv
@@ -41,6 +42,10 @@ def _normalize_canvas_url(raw: str) -> str:
     - ``https://canvas.school.edu/api/v1/foo``  → ``https://canvas.school.edu/api/v1``
     - ``https://canvas.school.edu/api/v1?x=1``  → ``https://canvas.school.edu/api/v1``
 
+    An explicit ``/api/v<N>`` version segment is preserved (only trailing
+    sub-paths after it are dropped), so a deliberately-set ``/api/v2`` is never
+    silently downgraded to ``/api/v1``.
+
     A scheme-less input (e.g. ``canvas.school.edu``) is returned unchanged so
     ``validate_config()`` can flag the missing ``https://`` rather than this
     silently producing a relative-path URL.
@@ -56,12 +61,12 @@ def _normalize_canvas_url(raw: str) -> str:
     if not parsed.scheme or not parsed.netloc:
         return url
 
-    marker = "/api/v1"
-    path = parsed.path
-    if marker in path:
-        path = path[: path.index(marker) + len(marker)]
-    else:
-        path = marker
+    # Preserve an existing ``/api/v<N>`` version segment (truncating any extra
+    # path after it), matching only at a segment boundary so a real version
+    # like ``/api/v2`` is kept rather than rewritten. When the path carries no
+    # version segment, append the canonical ``/api/v1``.
+    version = re.search(r"/api/v\d+(?=/|$)", parsed.path)
+    path = parsed.path[: version.end()] if version else "/api/v1"
     return urlunparse(parsed._replace(path=path, params="", query="", fragment=""))
 
 

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -37,7 +37,13 @@ def _normalize_canvas_url(raw: str) -> str:
     - ``https://canvas.school.edu/api/v1``  → unchanged
     - ``https://canvas.school.edu/api/v1/`` → ``https://canvas.school.edu/api/v1``
     """
-    url = raw.strip().rstrip("/")
+    url = raw.strip()
+    # An API base URL never carries a query string or fragment. Drop anything
+    # from the first '?' or '#' so a stray paste (…/api/v1?x=1) can't be
+    # transformed into a malformed '…/api/v1?x=1/api/v1'.
+    for sep in ("?", "#"):
+        url = url.split(sep, 1)[0]
+    url = url.rstrip("/")
     if not url:
         return ""
     if not url.endswith("/api/v1"):

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -1,6 +1,7 @@
 """Configuration management for Canvas MCP server."""
 
 import os
+from urllib.parse import urlparse, urlunparse
 
 from dotenv import load_dotenv
 
@@ -28,27 +29,40 @@ def _normalize_canvas_url(raw: str) -> str:
     Canvas REST endpoints live under ``/api/v1``. Users frequently enter just
     the base host (e.g. ``https://canvas.school.edu``); requests without the
     suffix make Canvas issue a 302 redirect to SSO login, which surfaces as a
-    misleading ``HTTP error: 302`` that looks like a bad token. Strip trailing
-    slashes and append ``/api/v1`` when missing so all of these forms resolve
-    to the same canonical URL:
+    misleading ``HTTP error: 302`` that looks like a bad token. Canonicalize
+    the path to exactly ``/api/v1`` (dropping any extra segments copied from a
+    browser, plus stray query strings / fragments) so all of these resolve to
+    the same URL:
 
-    - ``https://canvas.school.edu``         → ``https://canvas.school.edu/api/v1``
-    - ``https://canvas.school.edu/``        → ``https://canvas.school.edu/api/v1``
-    - ``https://canvas.school.edu/api/v1``  → unchanged
-    - ``https://canvas.school.edu/api/v1/`` → ``https://canvas.school.edu/api/v1``
+    - ``https://canvas.school.edu``             → ``https://canvas.school.edu/api/v1``
+    - ``https://canvas.school.edu/``            → ``https://canvas.school.edu/api/v1``
+    - ``https://canvas.school.edu/api/v1``      → unchanged
+    - ``https://canvas.school.edu/api/v1/``     → ``https://canvas.school.edu/api/v1``
+    - ``https://canvas.school.edu/api/v1/foo``  → ``https://canvas.school.edu/api/v1``
+    - ``https://canvas.school.edu/api/v1?x=1``  → ``https://canvas.school.edu/api/v1``
+
+    A scheme-less input (e.g. ``canvas.school.edu``) is returned unchanged so
+    ``validate_config()`` can flag the missing ``https://`` rather than this
+    silently producing a relative-path URL.
     """
     url = raw.strip()
-    # An API base URL never carries a query string or fragment. Drop anything
-    # from the first '?' or '#' so a stray paste (…/api/v1?x=1) can't be
-    # transformed into a malformed '…/api/v1?x=1/api/v1'.
-    for sep in ("?", "#"):
-        url = url.split(sep, 1)[0]
-    url = url.rstrip("/")
     if not url:
         return ""
-    if not url.endswith("/api/v1"):
-        url = f"{url}/api/v1"
-    return url
+
+    parsed = urlparse(url)
+    # Without a scheme, urlparse puts the host in ``path`` and leaves
+    # ``netloc`` empty — we can't reliably rebuild it, so leave it for the
+    # validator to warn about.
+    if not parsed.scheme or not parsed.netloc:
+        return url
+
+    marker = "/api/v1"
+    path = parsed.path
+    if marker in path:
+        path = path[: path.index(marker) + len(marker)]
+    else:
+        path = marker
+    return urlunparse(parsed._replace(path=path, params="", query="", fragment=""))
 
 
 def _bool_env(name: str, default: bool) -> bool:
@@ -227,7 +241,13 @@ def validate_config() -> bool:
 
     # CANVAS_API_URL is normalized to the canonical '…/api/v1' form in
     # Config.__init__ (see _normalize_canvas_url), so no suffix check is needed
-    # here — any non-empty value is already well-formed.
+    # here. A scheme-less value can't be normalized, though — warn so the user
+    # gets a clear diagnostic instead of a cryptic connection error.
+    if not config.canvas_api_url.startswith(("http://", "https://")):
+        log_warning(
+            "CANVAS_API_URL should start with 'https://'",
+            current_url=config.canvas_api_url,
+        )
 
     if config.ts_sandbox_mode not in VALID_SANDBOX_MODES:
         log_warning(

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse, urlunparse
 
 from dotenv import load_dotenv
 
-from .logging import log_error, log_warning
+from .logging import log_error, log_info, log_warning
 
 # Load environment variables from .env file
 load_dotenv()
@@ -241,12 +241,27 @@ def validate_config() -> bool:
 
     # CANVAS_API_URL is normalized to the canonical '…/api/v1' form in
     # Config.__init__ (see _normalize_canvas_url), so no suffix check is needed
-    # here. A scheme-less value can't be normalized, though — warn so the user
-    # gets a clear diagnostic instead of a cryptic connection error.
-    if not config.canvas_api_url.startswith(("http://", "https://")):
+    # here. A value that isn't a full https:// URL with a host can't be turned
+    # into a working endpoint, though — this covers plain http://, scheme-less
+    # hosts, and malformed triple-slash inputs (e.g. 'https:///host', whose
+    # empty netloc the normalizer leaves untouched). Warn so the user gets a
+    # clear diagnostic instead of a cryptic redirect or connection error.
+    if not config.canvas_api_url.startswith("https://") or not urlparse(
+        config.canvas_api_url
+    ).netloc:
         log_warning(
-            "CANVAS_API_URL should start with 'https://'",
+            "CANVAS_API_URL should be a full 'https://' URL including the host",
             current_url=config.canvas_api_url,
+        )
+
+    # Surface normalization: a user debugging a connection issue should be able
+    # to see that the effective URL differs from what they configured.
+    raw_url = os.getenv("CANVAS_API_URL", "").strip()
+    if raw_url and raw_url != config.canvas_api_url:
+        log_info(
+            "CANVAS_API_URL normalized to canonical form",
+            configured=raw_url,
+            effective=config.canvas_api_url,
         )
 
     if config.ts_sandbox_mode not in VALID_SANDBOX_MODES:

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -109,7 +109,10 @@ class Config:
     def __init__(self) -> None:
         # Required configuration
         self.canvas_api_token = os.getenv("CANVAS_API_TOKEN", "")
-        self.canvas_api_url = _normalize_canvas_url(os.getenv("CANVAS_API_URL", ""))
+        # Keep the raw value so validate_config() can report the normalization
+        # delta from the same read that produced canvas_api_url.
+        self.canvas_api_url_raw = os.getenv("CANVAS_API_URL", "").strip()
+        self.canvas_api_url = _normalize_canvas_url(self.canvas_api_url_raw)
 
         # Optional configuration with defaults
         self.mcp_server_name = os.getenv("MCP_SERVER_NAME", "canvas-api")
@@ -244,28 +247,31 @@ def validate_config() -> bool:
         log_error("Please set CANVAS_API_URL in your .env file")
         return False
 
-    # CANVAS_API_URL is normalized to the canonical '…/api/v1' form in
-    # Config.__init__ (see _normalize_canvas_url), so no suffix check is needed
-    # here. A value that isn't a full https:// URL with a host can't be turned
-    # into a working endpoint, though — this covers plain http://, scheme-less
-    # hosts, and malformed triple-slash inputs (e.g. 'https:///host', whose
-    # empty netloc the normalizer leaves untouched). Warn so the user gets a
-    # clear diagnostic instead of a cryptic redirect or connection error.
-    if not config.canvas_api_url.startswith("https://") or not urlparse(
-        config.canvas_api_url
-    ).netloc:
+    # Diagnose a CANVAS_API_URL that can't reach Canvas. The triple-slash case
+    # (e.g. 'https:///host') is the subtle one: it has a scheme but an empty
+    # netloc, so the normalizer leaves it untouched. Report the specific defect
+    # rather than a one-size-fits-all message.
+    parsed_url = urlparse(config.canvas_api_url)
+    if parsed_url.scheme not in ("http", "https"):
         log_warning(
-            "CANVAS_API_URL should be a full 'https://' URL including the host",
+            "CANVAS_API_URL should start with 'https://'",
+            current_url=config.canvas_api_url,
+        )
+    elif not parsed_url.netloc:
+        log_warning(
+            "CANVAS_API_URL is missing a hostname",
+            current_url=config.canvas_api_url,
+        )
+    elif parsed_url.scheme != "https":
+        log_warning(
+            "CANVAS_API_URL should use the 'https://' scheme",
             current_url=config.canvas_api_url,
         )
 
-    # Surface normalization: a user debugging a connection issue should be able
-    # to see that the effective URL differs from what they configured.
-    raw_url = os.getenv("CANVAS_API_URL", "").strip()
-    if raw_url and raw_url != config.canvas_api_url:
+    if config.canvas_api_url_raw and config.canvas_api_url_raw != config.canvas_api_url:
         log_info(
             "CANVAS_API_URL normalized to canonical form",
-            configured=raw_url,
+            configured=config.canvas_api_url_raw,
             effective=config.canvas_api_url,
         )
 

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -69,9 +69,11 @@ def test_reset_config_clears_invalid_env_caches(monkeypatch):
         # Over-specified path (copied from a browser) is truncated, not
         # double-appended into '…/courses/api/v1'.
         ("https://canvas.school.edu/api/v1/courses", "https://canvas.school.edu/api/v1"),
-        # Near-miss suffix is canonicalized to /api/v1 (path-aware, so it is
-        # never double-appended into '…/api/v10/api/v1').
-        ("https://canvas.school.edu/api/v10", "https://canvas.school.edu/api/v1"),
+        # An explicit version segment is preserved, not downgraded to /api/v1,
+        # and trailing sub-paths after it are dropped.
+        ("https://canvas.school.edu/api/v2", "https://canvas.school.edu/api/v2"),
+        ("https://canvas.school.edu/api/v2/foo", "https://canvas.school.edu/api/v2"),
+        ("https://canvas.school.edu/api/v10", "https://canvas.school.edu/api/v10"),
         # A Canvas install under a sub-path keeps that prefix.
         ("https://canvas.school.edu/lms/api/v1", "https://canvas.school.edu/lms/api/v1"),
         # Host:port is preserved.

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -59,6 +59,11 @@ def test_reset_config_clears_invalid_env_caches(monkeypatch):
         ("https://canvas.school.edu/api/v1/", "https://canvas.school.edu/api/v1"),
         # Surrounding whitespace is trimmed.
         ("  https://canvas.school.edu/api/v1  ", "https://canvas.school.edu/api/v1"),
+        # A stray query string is dropped before normalization (not duplicated).
+        ("https://canvas.school.edu?x=1", "https://canvas.school.edu/api/v1"),
+        ("https://canvas.school.edu/api/v1?x=1", "https://canvas.school.edu/api/v1"),
+        # A stray fragment is dropped too.
+        ("https://canvas.school.edu/api/v1#frag", "https://canvas.school.edu/api/v1"),
         # Empty / blank stays empty so validate_config() can flag it as missing.
         ("", ""),
         ("   ", ""),

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -78,6 +78,12 @@ def test_reset_config_clears_invalid_env_caches(monkeypatch):
         ("https://canvas.school.edu:8443", "https://canvas.school.edu:8443/api/v1"),
         # A scheme-less value is left untouched for validate_config() to flag.
         ("canvas.school.edu", "canvas.school.edu"),
+        # http:// is path-normalized but kept as-is; validate_config warns the
+        # scheme should be https://.
+        ("http://canvas.school.edu", "http://canvas.school.edu/api/v1"),
+        # Malformed triple-slash (empty netloc) is left untouched for
+        # validate_config() to flag rather than silently mangled.
+        ("https:///canvas.school.edu", "https:///canvas.school.edu"),
         # Empty / blank stays empty so validate_config() can flag it as missing.
         ("", ""),
         ("   ", ""),
@@ -97,6 +103,45 @@ def test_validate_config_warns_on_schemeless_url(monkeypatch):
         assert config_module.validate_config() is True
     messages = " ".join(str(call) for call in mock_warn.call_args_list)
     assert "https://" in messages
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://canvas.school.edu",      # plain http
+        "https:///canvas.school.edu",    # triple-slash, empty host
+    ],
+)
+def test_validate_config_warns_on_non_https_or_hostless_url(url, monkeypatch):
+    """http:// and malformed host-less URLs are accepted but warned about."""
+    monkeypatch.setenv("CANVAS_API_TOKEN", "test-token")
+    monkeypatch.setenv("CANVAS_API_URL", url)
+    config_module.reset_config()
+    with patch.object(config_module, "log_warning") as mock_warn:
+        assert config_module.validate_config() is True
+    messages = " ".join(str(call) for call in mock_warn.call_args_list)
+    assert "https://" in messages
+
+
+def test_validate_config_logs_normalization(monkeypatch):
+    """When normalization changes the URL, an info log surfaces the rewrite."""
+    monkeypatch.setenv("CANVAS_API_TOKEN", "test-token")
+    monkeypatch.setenv("CANVAS_API_URL", "https://canvas.school.edu")
+    config_module.reset_config()
+    with patch.object(config_module, "log_info") as mock_info:
+        assert config_module.validate_config() is True
+    logged = " ".join(str(call) for call in mock_info.call_args_list)
+    assert "https://canvas.school.edu/api/v1" in logged
+
+
+def test_validate_config_no_normalization_log_when_canonical(monkeypatch):
+    """An already-canonical URL produces no normalization info log."""
+    monkeypatch.setenv("CANVAS_API_TOKEN", "test-token")
+    monkeypatch.setenv("CANVAS_API_URL", "https://canvas.school.edu/api/v1")
+    config_module.reset_config()
+    with patch.object(config_module, "log_info") as mock_info:
+        assert config_module.validate_config() is True
+    assert not mock_info.called
 
 
 def test_config_normalizes_canvas_api_url(monkeypatch):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,5 +1,7 @@
 """Tests for configuration management (singleton lifecycle, env parsing)."""
 
+from unittest.mock import patch
+
 import pytest
 
 import canvas_mcp.core.config as config_module
@@ -64,6 +66,13 @@ def test_reset_config_clears_invalid_env_caches(monkeypatch):
         ("https://canvas.school.edu/api/v1?x=1", "https://canvas.school.edu/api/v1"),
         # A stray fragment is dropped too.
         ("https://canvas.school.edu/api/v1#frag", "https://canvas.school.edu/api/v1"),
+        # Over-specified path (copied from a browser) is truncated, not
+        # double-appended into '…/courses/api/v1'.
+        ("https://canvas.school.edu/api/v1/courses", "https://canvas.school.edu/api/v1"),
+        # Host:port is preserved.
+        ("https://canvas.school.edu:8443", "https://canvas.school.edu:8443/api/v1"),
+        # A scheme-less value is left untouched for validate_config() to flag.
+        ("canvas.school.edu", "canvas.school.edu"),
         # Empty / blank stays empty so validate_config() can flag it as missing.
         ("", ""),
         ("   ", ""),
@@ -71,6 +80,18 @@ def test_reset_config_clears_invalid_env_caches(monkeypatch):
 )
 def test_normalize_canvas_url(raw, expected):
     assert _normalize_canvas_url(raw) == expected
+
+
+def test_validate_config_warns_on_schemeless_url(monkeypatch):
+    """A scheme-less CANVAS_API_URL is accepted but warns instead of silently
+    producing a relative-path URL."""
+    monkeypatch.setenv("CANVAS_API_TOKEN", "test-token")
+    monkeypatch.setenv("CANVAS_API_URL", "canvas.school.edu")
+    config_module.reset_config()
+    with patch.object(config_module, "log_warning") as mock_warn:
+        assert config_module.validate_config() is True
+    messages = " ".join(str(call) for call in mock_warn.call_args_list)
+    assert "https://" in messages
 
 
 def test_config_normalizes_canvas_api_url(monkeypatch):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,6 +1,9 @@
 """Tests for configuration management (singleton lifecycle, env parsing)."""
 
+import pytest
+
 import canvas_mcp.core.config as config_module
+from canvas_mcp.core.config import _normalize_canvas_url
 
 
 def test_get_config_returns_cached_singleton():
@@ -41,3 +44,33 @@ def test_reset_config_clears_invalid_env_caches(monkeypatch):
 
     config_module.get_config()  # valid now -> nothing recorded
     assert "API_TIMEOUT" not in config_module._INVALID_INT_ENV_VARS
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Base host (the common footgun) gets the suffix appended.
+        ("https://canvas.school.edu", "https://canvas.school.edu/api/v1"),
+        # Trailing slash is stripped before appending.
+        ("https://canvas.school.edu/", "https://canvas.school.edu/api/v1"),
+        # Already-canonical form is unchanged.
+        ("https://canvas.school.edu/api/v1", "https://canvas.school.edu/api/v1"),
+        # Canonical form with a trailing slash is normalized.
+        ("https://canvas.school.edu/api/v1/", "https://canvas.school.edu/api/v1"),
+        # Surrounding whitespace is trimmed.
+        ("  https://canvas.school.edu/api/v1  ", "https://canvas.school.edu/api/v1"),
+        # Empty / blank stays empty so validate_config() can flag it as missing.
+        ("", ""),
+        ("   ", ""),
+    ],
+)
+def test_normalize_canvas_url(raw, expected):
+    assert _normalize_canvas_url(raw) == expected
+
+
+def test_config_normalizes_canvas_api_url(monkeypatch):
+    """CANVAS_API_URL from the environment is normalized on Config build."""
+    monkeypatch.setenv("CANVAS_API_TOKEN", "test-token")
+    monkeypatch.setenv("CANVAS_API_URL", "https://canvas.school.edu")
+    config_module.reset_config()
+    assert config_module.get_config().canvas_api_url == "https://canvas.school.edu/api/v1"

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -95,34 +95,38 @@ def test_normalize_canvas_url(raw, expected):
     assert _normalize_canvas_url(raw) == expected
 
 
-def test_validate_config_warns_on_schemeless_url(monkeypatch):
-    """A scheme-less CANVAS_API_URL is accepted but warns instead of silently
-    producing a relative-path URL."""
-    monkeypatch.setenv("CANVAS_API_TOKEN", "test-token")
-    monkeypatch.setenv("CANVAS_API_URL", "canvas.school.edu")
-    config_module.reset_config()
-    with patch.object(config_module, "log_warning") as mock_warn:
-        assert config_module.validate_config() is True
-    messages = " ".join(str(call) for call in mock_warn.call_args_list)
-    assert "https://" in messages
-
-
 @pytest.mark.parametrize(
-    "url",
+    "url,expected_fragment",
     [
-        "http://canvas.school.edu",      # plain http
-        "https:///canvas.school.edu",    # triple-slash, empty host
+        # Scheme-less: the defect is the missing scheme, not a missing host.
+        ("canvas.school.edu", "https://"),
+        # Plain http:// with a valid host: warn specifically about the scheme.
+        ("http://canvas.school.edu", "scheme"),
+        # Triple-slash (scheme present, empty host): warn about the hostname.
+        ("https:///canvas.school.edu", "hostname"),
     ],
 )
-def test_validate_config_warns_on_non_https_or_hostless_url(url, monkeypatch):
-    """http:// and malformed host-less URLs are accepted but warned about."""
+def test_validate_config_warns_with_specific_diagnostic(url, expected_fragment, monkeypatch):
+    """A bad CANVAS_API_URL is accepted but warned about with a message that
+    names the actual defect (scheme vs. missing host)."""
     monkeypatch.setenv("CANVAS_API_TOKEN", "test-token")
     monkeypatch.setenv("CANVAS_API_URL", url)
     config_module.reset_config()
     with patch.object(config_module, "log_warning") as mock_warn:
         assert config_module.validate_config() is True
     messages = " ".join(str(call) for call in mock_warn.call_args_list)
-    assert "https://" in messages
+    assert expected_fragment in messages
+
+
+def test_validate_config_no_warning_for_valid_https_url(monkeypatch):
+    """A well-formed https:// URL produces no URL warning."""
+    monkeypatch.setenv("CANVAS_API_TOKEN", "test-token")
+    monkeypatch.setenv("CANVAS_API_URL", "https://canvas.school.edu/api/v1")
+    config_module.reset_config()
+    with patch.object(config_module, "log_warning") as mock_warn:
+        assert config_module.validate_config() is True
+    messages = " ".join(str(call) for call in mock_warn.call_args_list)
+    assert "CANVAS_API_URL" not in messages
 
 
 def test_validate_config_logs_normalization(monkeypatch):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -69,6 +69,11 @@ def test_reset_config_clears_invalid_env_caches(monkeypatch):
         # Over-specified path (copied from a browser) is truncated, not
         # double-appended into '…/courses/api/v1'.
         ("https://canvas.school.edu/api/v1/courses", "https://canvas.school.edu/api/v1"),
+        # Near-miss suffix is canonicalized to /api/v1 (path-aware, so it is
+        # never double-appended into '…/api/v10/api/v1').
+        ("https://canvas.school.edu/api/v10", "https://canvas.school.edu/api/v1"),
+        # A Canvas install under a sub-path keeps that prefix.
+        ("https://canvas.school.edu/lms/api/v1", "https://canvas.school.edu/lms/api/v1"),
         # Host:port is preserved.
         ("https://canvas.school.edu:8443", "https://canvas.school.edu:8443/api/v1"),
         # A scheme-less value is left untouched for validate_config() to flag.


### PR DESCRIPTION
## Summary

Follow-up to the docs fix in #143. Where #143 corrected the README example, this fixes the **underlying config layer** so the `/api/v1` suffix is guaranteed regardless of how `CANVAS_API_URL` is supplied.

Previously `core/config.py` consumed `CANVAS_API_URL` verbatim and only *logged a warning* when it lacked `/api/v1`. A user entering just the base host (e.g. `https://canvas.school.edu`) hits a 302 SSO redirect that tools surface as a misleading `HTTP error: 302` — looking like a token failure when the URL is the real problem.

## Changes

- New `_normalize_canvas_url()` helper, applied in `Config.__init__`: trim whitespace, strip trailing slash(es), append `/api/v1` when missing. Empty/blank stays empty so `validate_config()` still flags a missing URL.
- Removed the now-redundant suffix warning in `validate_config()` (normalization guarantees the suffix for any non-empty URL).
- Centralized so every consumer benefits — stdio, HTTP-mode pinning (`server.py`), and the code-execution sandbox.

## Normalization

| Input | Result |
|---|---|
| `https://canvas.school.edu` | `…/api/v1` |
| `https://canvas.school.edu/` | `…/api/v1` |
| `https://canvas.school.edu/api/v1` | unchanged |
| `https://canvas.school.edu/api/v1/` | `…/api/v1` |
| `` (empty/blank) | `` (flagged by validate_config) |

## Tests

Added parametrized coverage for `_normalize_canvas_url()` and an end-to-end check that `Config` normalizes the env value. `tests/core/` + `tests/test_http_transport.py` pass (59 passed, 2 skipped).

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4yuxB6FGEG2ZgUpuxVWS5)_