### PR TITLE
refactor: rename canvas_api_url_raw to canvas_api_url_configured

### DIFF
--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -109,10 +109,11 @@ class Config:
     def __init__(self) -> None:
         # Required configuration
         self.canvas_api_token = os.getenv("CANVAS_API_TOKEN", "")
-        # Keep the raw value so validate_config() can report the normalization
-        # delta from the same read that produced canvas_api_url.
-        self.canvas_api_url_raw = os.getenv("CANVAS_API_URL", "").strip()
-        self.canvas_api_url = _normalize_canvas_url(self.canvas_api_url_raw)
+        # Keep the configured (pre-normalization) value so validate_config()
+        # can report the normalization delta from the same read that produced
+        # canvas_api_url. Whitespace-trimmed, matching the normalizer's input.
+        self.canvas_api_url_configured = os.getenv("CANVAS_API_URL", "").strip()
+        self.canvas_api_url = _normalize_canvas_url(self.canvas_api_url_configured)
 
         # Optional configuration with defaults
         self.mcp_server_name = os.getenv("MCP_SERVER_NAME", "canvas-api")
@@ -268,10 +269,13 @@ def validate_config() -> bool:
             current_url=config.canvas_api_url,
         )
 
-    if config.canvas_api_url_raw and config.canvas_api_url_raw != config.canvas_api_url:
+    if (
+        config.canvas_api_url_configured
+        and config.canvas_api_url_configured != config.canvas_api_url
+    ):
         log_info(
             "CANVAS_API_URL normalized to canonical form",
-            configured=config.canvas_api_url_raw,
+            configured=config.canvas_api_url_configured,
             effective=config.canvas_api_url,
         )
 


### PR DESCRIPTION
## Summary

Follow-up to #148, addressing one of the two optional items flagged in its final review round.

The `Config.canvas_api_url_raw` attribute is stored as `os.getenv("CANVAS_API_URL", "").strip()` — the `_raw` name implies a verbatim env value, but whitespace is already trimmed. Renaming to `canvas_api_url_configured` signals it's the *processed* (pre-normalization) input, so a future caller won't mistake it for the truly-unmodified string.

## Changes

- Rename `canvas_api_url_raw` → `canvas_api_url_configured` (the `Config.__init__` assignment and its sole consumer in `validate_config()`'s normalization-delta info log).
- No behavioral change; `tests/core/` green (39 passed, 2 skipped).

## Not included

The other flagged item — bumping the normalization log from INFO to WARNING — was **left as-is intentionally**. A bare host is now a supported input form (the point of #148 + docs #143), so warning on every startup for input we transparently handle would be noise; the genuinely-broken cases (missing scheme / host / `http://`) already emit WARNINGs. Happy to revisit if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4yuxB6FGEG2ZgUpuxVWS5)_