### PR TITLE
feat: self-service access-approval flow for the hosted (Entra-gated) server

### DIFF
--- a/env.template
+++ b/env.template
@@ -64,6 +64,18 @@ TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
 # ENTRA_AUTH_ENABLED=false
 # MCP_ENTRA_ALLOWED_OIDS=
 
+# --- Self-service access-approval flow (hosted instance only; off by default) ---
+# Requires the [hosted] extra:  uv pip install -e '.[hosted]'
+ACCESS_REQUEST_ENABLED=false
+ACCESS_TABLE_ACCOUNT=
+ACCESS_TABLE_NAME=accessoverlay
+ACS_ENDPOINT=
+ACS_SENDER=
+ACCESS_ADMIN_EMAILS=
+ACCESS_APPROVE_BASE_URL=
+ACCESS_TOKEN_SECRET=
+ACCESS_NOTIFY_COOLDOWN_HOURS=24
+
 # Optional Metadata
 INSTITUTION_NAME=Your Institution Name
 TIMEZONE=UTC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,13 @@ Issues = "https://github.com/vishalsachdev/canvas-mcp/issues"
 [project.scripts]
 canvas-mcp-server = "canvas_mcp.server:main"
 
+[project.optional-dependencies]
+hosted = [
+    "azure-data-tables>=12.5.0",
+    "azure-communication-email>=1.0.0",
+    "azure-identity>=1.17.0",
+]
+
 [tool.hatch.version]
 path = "src/canvas_mcp/__init__.py"
 

--- a/src/canvas_mcp/core/access/factory.py
+++ b/src/canvas_mcp/core/access/factory.py
@@ -17,6 +17,23 @@ def feature_ready(config) -> bool:
                 and getattr(config, "access_table_account", ""))
 
 
+def _entity_to_row(entity) -> dict:
+    """Convert an azure-data-tables entity to a plain row, surfacing the ETag.
+
+    azure-data-tables exposes the ETag via ``entity.metadata['etag']`` rather
+    than as an item, so a bare ``dict(entity)`` silently drops it. The store's
+    ``consume_pending`` needs ``row['etag']`` for the optimistic-concurrency
+    (single-use) guard, so copy it onto the row. Pure — no azure import — so it
+    is unit-testable without the optional ``[hosted]`` deps installed.
+    """
+    row = dict(entity)
+    meta = getattr(entity, "metadata", None) or {}
+    etag = meta.get("etag")
+    if etag:
+        row["etag"] = etag
+    return row
+
+
 class _AzureTableBackend:
     def __init__(self, table_client) -> None:
         self._t = table_client
@@ -24,7 +41,7 @@ class _AzureTableBackend:
     def get(self, pk, rk):
         from azure.core.exceptions import ResourceNotFoundError
         try:
-            return dict(self._t.get_entity(pk, rk))
+            return _entity_to_row(self._t.get_entity(pk, rk))
         except ResourceNotFoundError:
             return None
 
@@ -34,15 +51,19 @@ class _AzureTableBackend:
     def replace_if_unmodified(self, entity, etag):
         from azure.core import MatchConditions
         from azure.core.exceptions import HttpResponseError
+        # The ETag rides the match_condition param, not the row body; drop the
+        # synthetic "etag" item (added by _entity_to_row) so it is never
+        # persisted as a data column.
+        payload = {k: v for k, v in entity.items() if k != "etag"}
         try:
-            self._t.update_entity(entity, mode="replace", etag=etag,
+            self._t.update_entity(payload, mode="replace", etag=etag,
                                   match_condition=MatchConditions.IfNotModified)
         except HttpResponseError as exc:
             raise ConcurrencyConflict(str(exc)) from exc
 
     def query(self, pk):
         flt = "PartitionKey eq '%s'" % pk.replace("'", "''")
-        return [dict(e) for e in self._t.query_entities(flt)]
+        return [_entity_to_row(e) for e in self._t.query_entities(flt)]
 
     def delete(self, pk, rk):
         self._t.delete_entity(pk, rk)

--- a/src/canvas_mcp/core/access/factory.py
+++ b/src/canvas_mcp/core/access/factory.py
@@ -1,0 +1,83 @@
+"""Lazy builders for the Azure-backed store + ACS sender.
+
+Azure imports happen INSIDE the functions, so importing this module never
+requires the optional ``[hosted]`` dependencies. Callers must guard with
+``feature_ready(config)`` before building.
+"""
+
+from __future__ import annotations
+
+from ..logging import log_error
+from .store import AccessStore, ConcurrencyConflict
+
+
+def feature_ready(config) -> bool:
+    return bool(getattr(config, "access_request_enabled", False)
+                and getattr(config, "access_token_secret", "")
+                and getattr(config, "access_table_account", ""))
+
+
+class _AzureTableBackend:
+    def __init__(self, table_client) -> None:
+        self._t = table_client
+
+    def get(self, pk, rk):
+        from azure.core.exceptions import ResourceNotFoundError
+        try:
+            return dict(self._t.get_entity(pk, rk))
+        except ResourceNotFoundError:
+            return None
+
+    def upsert(self, entity):
+        self._t.upsert_entity(entity)
+
+    def replace_if_unmodified(self, entity, etag):
+        from azure.core import MatchConditions
+        from azure.core.exceptions import HttpResponseError
+        try:
+            self._t.update_entity(entity, mode="replace", etag=etag,
+                                  match_condition=MatchConditions.IfNotModified)
+        except HttpResponseError as exc:
+            raise ConcurrencyConflict(str(exc)) from exc
+
+    def query(self, pk):
+        flt = "PartitionKey eq '%s'" % pk.replace("'", "''")
+        return [dict(e) for e in self._t.query_entities(flt)]
+
+    def delete(self, pk, rk):
+        self._t.delete_entity(pk, rk)
+
+
+def build_store(config) -> AccessStore | None:
+    if not feature_ready(config):
+        return None
+    try:
+        from azure.data.tables import TableServiceClient
+        from azure.identity import DefaultAzureCredential
+        endpoint = f"https://{config.access_table_account}.table.core.windows.net"
+        svc = TableServiceClient(endpoint=endpoint, credential=DefaultAzureCredential())
+        svc.create_table_if_not_exists(config.access_table_name)
+        table = svc.get_table_client(config.access_table_name)
+        return AccessStore(_AzureTableBackend(table))
+    except Exception as exc:
+        log_error(f"access store unavailable: {exc}")
+        return None
+
+
+def build_email_sender(config):
+    if not (config.acs_endpoint and config.acs_sender):
+        return None
+
+    async def send(recipients, subject, html, plain):
+        from azure.communication.email import EmailClient
+        from azure.identity import DefaultAzureCredential
+        client = EmailClient(config.acs_endpoint, DefaultAzureCredential())
+        message = {
+            "senderAddress": config.acs_sender,
+            "content": {"subject": subject, "html": html, "plainText": plain},
+            "recipients": {"to": [{"address": a} for a in recipients]},
+        }
+        poller = client.begin_send(message)
+        poller.result()
+
+    return send

--- a/src/canvas_mcp/core/access/factory.py
+++ b/src/canvas_mcp/core/access/factory.py
@@ -88,14 +88,20 @@ def build_store(config) -> AccessStore | None:
 def build_email_sender(config):
     if not (config.acs_endpoint and config.acs_sender):
         return None
-
-    async def send(recipients, subject, html, plain):
+    # Build the credential + client ONCE here (not per send). Azure imports stay
+    # inside this function body (never module top-level), so the base install
+    # without the [hosted] extra is unaffected; degrade to None on any failure.
+    try:
         import asyncio
         from azure.communication.email import EmailClient
         from azure.identity import DefaultAzureCredential
+        client = EmailClient(config.acs_endpoint, DefaultAzureCredential())
+    except Exception as exc:
+        log_error(f"access email sender unavailable: {exc}")
+        return None
 
+    async def send(recipients, subject, html, plain):
         def _send():
-            client = EmailClient(config.acs_endpoint, DefaultAzureCredential())
             message = {
                 "senderAddress": config.acs_sender,
                 "content": {"subject": subject, "html": html, "plainText": plain},

--- a/src/canvas_mcp/core/access/factory.py
+++ b/src/canvas_mcp/core/access/factory.py
@@ -69,15 +69,20 @@ def build_email_sender(config):
         return None
 
     async def send(recipients, subject, html, plain):
+        import asyncio
         from azure.communication.email import EmailClient
         from azure.identity import DefaultAzureCredential
-        client = EmailClient(config.acs_endpoint, DefaultAzureCredential())
-        message = {
-            "senderAddress": config.acs_sender,
-            "content": {"subject": subject, "html": html, "plainText": plain},
-            "recipients": {"to": [{"address": a} for a in recipients]},
-        }
-        poller = client.begin_send(message)
-        poller.result()
+
+        def _send():
+            client = EmailClient(config.acs_endpoint, DefaultAzureCredential())
+            message = {
+                "senderAddress": config.acs_sender,
+                "content": {"subject": subject, "html": html, "plainText": plain},
+                "recipients": {"to": [{"address": a} for a in recipients]},
+            }
+            client.begin_send(message).result()
+
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, _send)
 
     return send

--- a/src/canvas_mcp/core/access/notify.py
+++ b/src/canvas_mcp/core/access/notify.py
@@ -1,0 +1,56 @@
+"""Compose + send the admin access-request email. No Azure import here."""
+
+from __future__ import annotations
+
+from html import escape
+
+from ..logging import log_error, log_info
+from .store import AccessStore, Requester
+from .tokens import mint_token
+
+
+def build_request_email(req: Requester, approve_url: str) -> dict:
+    subject = f"Canvas MCP access request — {req.display_name or req.upn}"
+    html = f"""\
+<div style="font-family:sans-serif;max-width:560px">
+  <p>Someone signed in to the hosted Canvas MCP but is <b>not on the allowlist yet</b>.
+     They authenticated with NetID + Duo, so their identity is verified.</p>
+  <p><b>{escape(req.display_name)}</b><br>
+     {escape(req.upn)}<br>
+     <code>{escape(req.oid)}</code></p>
+  <p><a href="{escape(approve_url)}"
+        style="background:#1d4ed8;color:#fff;padding:11px 20px;border-radius:8px;
+               text-decoration:none">Approve access</a></p>
+  <p style="color:#b45309;font-size:13px">This link is single-use and expires in 24 hours.
+     Approving opens a confirmation page; the grant applies only after you click Confirm.</p>
+</div>"""
+    plain = (f"Canvas MCP access request\n\n{req.display_name} <{req.upn}>\n"
+             f"OID: {req.oid}\n\nApprove: {approve_url}\n"
+             f"(single-use, expires in 24h; confirm on the page to grant)")
+    return {"subject": subject, "html": html, "plain": plain}
+
+
+async def notify_access_request(
+    *, store: AccessStore, requester: Requester, secret: str,
+    approve_base_url: str, admin_emails: list[str], cooldown_hours: int,
+    ttl_seconds: int, send_email, jti: str, now: int, now_iso: str,
+) -> bool:
+    """Dedup, mint a token, build the email, and send it. Never raises."""
+    try:
+        if not (secret and approve_base_url and admin_emails):
+            log_error("access notify skipped: feature not fully configured")
+            return False
+        exp = now + ttl_seconds
+        should = store.note_request(
+            requester, jti=jti, exp=exp, now_iso=now_iso, cooldown_hours=cooldown_hours)
+        if not should:
+            return False
+        token = mint_token(oid=requester.oid, jti=jti, exp=exp, secret=secret)
+        approve_url = f"{approve_base_url}/admin/access/approve?token={token}"
+        msg = build_request_email(requester, approve_url)
+        await send_email(admin_emails, msg["subject"], msg["html"], msg["plain"])
+        log_info("access request email sent", entra_oid=requester.oid)
+        return True
+    except Exception as exc:  # fire-and-forget: must never break the request path
+        log_error(f"access notify failed: {exc}")
+        return False

--- a/src/canvas_mcp/core/access/routes.py
+++ b/src/canvas_mcp/core/access/routes.py
@@ -1,0 +1,77 @@
+"""ASGI handlers + HTML for the approve (GET) and confirm (POST) endpoints."""
+
+from __future__ import annotations
+
+from html import escape
+from urllib.parse import parse_qs
+
+from ..audit import log_access_change
+from .store import AccessStore, Requester
+from .tokens import verify_token
+
+_WRAP = ("<!doctype html><meta charset=utf-8>"
+         "<body style='font-family:sans-serif;max-width:480px;margin:48px auto;text-align:center'>")
+
+
+def render_confirm_page(req: Requester, token: str) -> str:
+    return (_WRAP + "<h2>Grant Canvas MCP access?</h2>"
+            f"<p><b>{escape(req.display_name)}</b><br>{escape(req.upn)}<br>"
+            f"<code>{escape(req.oid)}</code></p>"
+            "<form method='post' action='/admin/access/confirm'>"
+            f"<input type='hidden' name='token' value='{escape(token)}'>"
+            "<button style='background:#1d4ed8;color:#fff;padding:11px 20px;"
+            "border:0;border-radius:8px;font-size:15px'>Confirm grant</button></form>"
+            "<p style='color:#64748b;font-size:12px'>single-use · expires in 24h</p>")
+
+
+def render_success_page(req: Requester) -> str:
+    return (_WRAP + "<h2>Access granted</h2>"
+            f"<p><b>{escape(req.display_name)}</b> ({escape(req.upn)}) can now use Canvas MCP.</p>"
+            "<p style='color:#64748b'>Their client connects within ~30s — no restart needed.</p>")
+
+
+def render_invalid_page() -> str:
+    return (_WRAP + "<h2>This approval link is no longer valid</h2>"
+            "<p>It may have expired or already been used. No changes were made.</p>"
+            "<p>If this person still needs access, ask them to reconnect.</p>")
+
+
+async def _send_html(send, html: str, status: int = 200) -> None:
+    await send({"type": "http.response.start", "status": status,
+                "headers": [(b"content-type", b"text/html; charset=utf-8")]})
+    await send({"type": "http.response.body", "body": html.encode()})
+
+
+def _requester_from_pending(row: dict | None, oid: str) -> Requester:
+    row = row or {}
+    return Requester(oid=oid, upn=row.get("upn", ""), display_name=row.get("displayName", ""))
+
+
+async def handle_approve(query_string: bytes, send, *, store: AccessStore,
+                         secret: str, now: int) -> None:
+    token = (parse_qs(query_string.decode()).get("token") or [""])[0]
+    claims = verify_token(token, secret=secret, now=now)
+    if not claims:
+        await _send_html(send, render_invalid_page())
+        return
+    pending = store.get_pending(claims.oid)
+    if not pending or pending.get("status") != "pending" or pending.get("tokenJti") != claims.jti:
+        await _send_html(send, render_invalid_page())
+        return
+    await _send_html(send, render_confirm_page(_requester_from_pending(pending, claims.oid), token))
+
+
+async def handle_confirm(body: bytes, send, *, store: AccessStore,
+                         secret: str, now: int) -> None:
+    token = (parse_qs(body.decode()).get("token") or [""])[0]
+    claims = verify_token(token, secret=secret, now=now)
+    if not claims:
+        await _send_html(send, render_invalid_page())
+        return
+    req = _requester_from_pending(store.get_pending(claims.oid), claims.oid)
+    if not store.consume_pending(claims.oid, claims.jti):
+        await _send_html(send, render_invalid_page())
+        return
+    store.grant(req, jti=claims.jti)
+    log_access_change("grant", req.oid, upn=req.upn or None)
+    await _send_html(send, render_success_page(req))

--- a/src/canvas_mcp/core/access/routes.py
+++ b/src/canvas_mcp/core/access/routes.py
@@ -6,6 +6,7 @@ from html import escape
 from urllib.parse import parse_qs
 
 from ..audit import log_access_change
+from ..logging import log_error
 from .store import AccessStore, Requester
 from .tokens import verify_token
 
@@ -34,6 +35,13 @@ def render_invalid_page() -> str:
     return (_WRAP + "<h2>This approval link is no longer valid</h2>"
             "<p>It may have expired or already been used. No changes were made.</p>"
             "<p>If this person still needs access, ask them to reconnect.</p>")
+
+
+def render_retry_page() -> str:
+    return (_WRAP + "<h2>Approval didn&#x27;t complete</h2>"
+            "<p>A temporary error stopped the grant from being saved. Nothing was "
+            "consumed — click Confirm again, or ask the person to reconnect for a "
+            "fresh approval link.</p>")
 
 
 async def _send_html(send, html: str, status: int = 200) -> None:
@@ -68,10 +76,32 @@ async def handle_confirm(body: bytes, send, *, store: AccessStore,
     if not claims:
         await _send_html(send, render_invalid_page())
         return
-    req = _requester_from_pending(store.get_pending(claims.oid), claims.oid)
-    if not store.consume_pending(claims.oid, claims.jti):
+    # Validate the token against the live pending request WITHOUT consuming it
+    # yet, so a downstream write failure leaves the token retriable.
+    pending = store.get_pending(claims.oid)
+    if (not pending or pending.get("status") != "pending"
+            or pending.get("tokenJti") != claims.jti):
         await _send_html(send, render_invalid_page())
         return
-    store.grant(req, jti=claims.jti)
+    req = _requester_from_pending(pending, claims.oid)
+
+    # Grant FIRST — the actual authorization, an idempotent upsert. If this write
+    # fails, nothing has been consumed, so the SAME link still works on retry,
+    # instead of a token spent with no access granted.
+    try:
+        store.grant(req, jti=claims.jti)
+    except Exception as exc:
+        log_error(f"access grant write failed for {req.oid}: {exc}")
+        await _send_html(send, render_retry_page())
+        return
+
+    # Mark the token single-use consumed. Best-effort: the user is already
+    # granted, so a failure here at worst lets this token re-grant the SAME oid
+    # (a harmless idempotent no-op).
+    try:
+        store.consume_pending(claims.oid, claims.jti)
+    except Exception as exc:
+        log_error(f"access token consume failed after grant for {req.oid}: {exc}")
+
     log_access_change("grant", req.oid, upn=req.upn or None)
     await _send_html(send, render_success_page(req))

--- a/src/canvas_mcp/core/access/store.py
+++ b/src/canvas_mcp/core/access/store.py
@@ -7,6 +7,7 @@ module (and its tests) never import azure directly. The real backend lives in
 
 from __future__ import annotations
 
+import calendar
 import time
 from dataclasses import dataclass
 
@@ -137,8 +138,11 @@ class AccessStore:
         if not row or row.get("status") != "pending" or row.get("tokenJti") != jti:
             return False
         row["status"] = "granted"
+        # Use .get so a row that somehow lacks an ETag (e.g. written by another
+        # client) degrades to a rejected optimistic-write (ConcurrencyConflict)
+        # rather than a KeyError → 500.
         try:
-            self._backend.replace_if_unmodified(row, row["etag"])
+            self._backend.replace_if_unmodified(row, row.get("etag", ""))
         except ConcurrencyConflict:
             return False
         return True
@@ -153,8 +157,11 @@ def _within_cooldown(last_iso: str, now_iso: str, hours: int) -> bool:
         return False
     fmt = "%Y-%m-%dT%H:%M:%SZ"
     try:
-        last = time.mktime(time.strptime(last_iso, fmt))
-        now = time.mktime(time.strptime(now_iso, fmt))
+        # timegm interprets the struct_time as UTC (the timestamps are UTC
+        # ISO-8601); mktime would treat them as local time and skew by the DST
+        # offset when the two straddle a transition.
+        last = calendar.timegm(time.strptime(last_iso, fmt))
+        now = calendar.timegm(time.strptime(now_iso, fmt))
     except (ValueError, TypeError):
         return False
     return (now - last) < hours * 3600

--- a/src/canvas_mcp/core/access/store.py
+++ b/src/canvas_mcp/core/access/store.py
@@ -1,0 +1,160 @@
+"""Runtime-mutable overlay allowlist on a Table backend.
+
+The Azure Table client is wrapped behind a tiny backend protocol so this
+module (and its tests) never import azure directly. The real backend lives in
+``factory.py`` and is built lazily only when the feature is enabled.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+
+GRANT_PK = "grant"
+PENDING_PK = "pending"
+
+
+class ConcurrencyConflict(Exception):
+    """An ETag-guarded replace lost a race (someone else updated the row)."""
+
+
+@dataclass(frozen=True)
+class Requester:
+    oid: str
+    upn: str
+    display_name: str
+
+
+@dataclass(frozen=True)
+class Grant:
+    oid: str
+    upn: str
+    display_name: str
+    granted_utc: str
+
+
+class InMemoryBackend:
+    """Reference + test backend. Dict keyed by (PartitionKey, RowKey)."""
+
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, str], dict] = {}
+        self._etag = 0
+
+    def _bump(self) -> str:
+        self._etag += 1
+        return f"etag-{self._etag}"
+
+    def get(self, pk: str, rk: str) -> dict | None:
+        row = self._rows.get((pk, rk))
+        return dict(row) if row else None
+
+    def upsert(self, entity: dict) -> None:
+        entity = dict(entity)
+        entity["etag"] = self._bump()
+        self._rows[(entity["PartitionKey"], entity["RowKey"])] = entity
+
+    def replace_if_unmodified(self, entity: dict, etag: str) -> None:
+        key = (entity["PartitionKey"], entity["RowKey"])
+        current = self._rows.get(key)
+        if current is None or current.get("etag") != etag:
+            raise ConcurrencyConflict("etag mismatch")
+        entity = dict(entity)
+        entity["etag"] = self._bump()
+        self._rows[key] = entity
+
+    def query(self, pk: str) -> list[dict]:
+        return [dict(r) for (p, _), r in self._rows.items() if p == pk]
+
+    def delete(self, pk: str, rk: str) -> None:
+        self._rows.pop((pk, rk), None)
+
+
+class AccessStore:
+    def __init__(self, backend, *, cache_ttl_seconds: int = 30, clock=time.time) -> None:
+        self._backend = backend
+        self._ttl = cache_ttl_seconds
+        self._clock = clock
+        self._cache: dict[str, bool] = {}
+        self._cache_at: dict[str, float] = {}
+
+    # --- authorization read path (hot) ---
+    def is_granted(self, oid: str) -> bool:
+        now = self._clock()
+        if self._ttl and oid in self._cache and now - self._cache_at[oid] < self._ttl:
+            return self._cache[oid]
+        granted = self._backend.get(GRANT_PK, oid) is not None
+        self._cache[oid] = granted
+        self._cache_at[oid] = now
+        return granted
+
+    def grant(self, req: Requester, *, jti: str) -> None:
+        self._backend.upsert({
+            "PartitionKey": GRANT_PK, "RowKey": req.oid,
+            "upn": req.upn, "displayName": req.display_name,
+            "grantedUtc": _utcnow_iso(self._clock), "tokenJti": jti,
+            "source": "self-service",
+        })
+        self._cache.pop(req.oid, None)
+
+    def revoke(self, oid: str) -> bool:
+        if self._backend.get(GRANT_PK, oid) is None:
+            return False
+        self._backend.delete(GRANT_PK, oid)
+        self._cache.pop(oid, None)
+        return True
+
+    def list_grants(self) -> list[Grant]:
+        return [
+            Grant(oid=r["RowKey"], upn=r.get("upn", ""),
+                  display_name=r.get("displayName", ""),
+                  granted_utc=r.get("grantedUtc", ""))
+            for r in self._backend.query(GRANT_PK)
+        ]
+
+    # --- request/dedup + single-use consume ---
+    def note_request(self, req: Requester, *, jti: str, exp: int,
+                     now_iso: str, cooldown_hours: int) -> bool:
+        existing = self._backend.get(PENDING_PK, req.oid)
+        if existing and existing.get("status") == "pending":
+            last = existing.get("lastNotifiedUtc", "")
+            if _within_cooldown(last, now_iso, cooldown_hours):
+                return False  # suppress duplicate notify
+        self._backend.upsert({
+            "PartitionKey": PENDING_PK, "RowKey": req.oid,
+            "upn": req.upn, "displayName": req.display_name,
+            "firstSeenUtc": existing.get("firstSeenUtc", now_iso) if existing else now_iso,
+            "lastNotifiedUtc": now_iso,
+            "notifyCount": (existing.get("notifyCount", 0) if existing else 0) + 1,
+            "status": "pending", "tokenJti": jti, "tokenExp": exp,
+        })
+        return True
+
+    def get_pending(self, oid: str) -> dict | None:
+        return self._backend.get(PENDING_PK, oid)
+
+    def consume_pending(self, oid: str, jti: str) -> bool:
+        row = self._backend.get(PENDING_PK, oid)
+        if not row or row.get("status") != "pending" or row.get("tokenJti") != jti:
+            return False
+        row["status"] = "granted"
+        try:
+            self._backend.replace_if_unmodified(row, row["etag"])
+        except ConcurrencyConflict:
+            return False
+        return True
+
+
+def _utcnow_iso(clock) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(clock()))
+
+
+def _within_cooldown(last_iso: str, now_iso: str, hours: int) -> bool:
+    if not last_iso:
+        return False
+    fmt = "%Y-%m-%dT%H:%M:%SZ"
+    try:
+        last = time.mktime(time.strptime(last_iso, fmt))
+        now = time.mktime(time.strptime(now_iso, fmt))
+    except (ValueError, TypeError):
+        return False
+    return (now - last) < hours * 3600

--- a/src/canvas_mcp/core/access/tokens.py
+++ b/src/canvas_mcp/core/access/tokens.py
@@ -1,0 +1,50 @@
+"""Signed, single-use approval tokens (stdlib only — no I/O, no Azure)."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class TokenClaims:
+    oid: str
+    jti: str
+    exp: int  # unix seconds
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64u_decode(s: str) -> bytes:
+    return base64.urlsafe_b64decode(s + "=" * (-len(s) % 4))
+
+
+def _sign(payload_b64: str, secret: str) -> str:
+    sig = hmac.new(secret.encode(), payload_b64.encode(), hashlib.sha256).digest()
+    return _b64u(sig)
+
+
+def mint_token(*, oid: str, jti: str, exp: int, secret: str) -> str:
+    payload = _b64u(json.dumps({"oid": oid, "jti": jti, "exp": exp}).encode())
+    return f"{payload}.{_sign(payload, secret)}"
+
+
+def verify_token(token: str, *, secret: str, now: int) -> TokenClaims | None:
+    """Return claims if the token is well-formed, untampered, and unexpired."""
+    try:
+        payload_b64, sig = token.split(".", 1)
+        expected = _sign(payload_b64, secret)
+        if not hmac.compare_digest(sig, expected):
+            return None
+        data = json.loads(_b64u_decode(payload_b64))
+        exp = int(data["exp"])
+        if exp <= now:
+            return None
+        return TokenClaims(oid=str(data["oid"]), jti=str(data["jti"]), exp=exp)
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError):
+        return None

--- a/src/canvas_mcp/core/audit.py
+++ b/src/canvas_mcp/core/audit.py
@@ -169,6 +169,34 @@ def log_code_execution(
     _emit(event)
 
 
+def log_access_change(
+    action: str,
+    oid: str,
+    *,
+    upn: str | None = None,
+    source: str = "self-service",
+) -> None:
+    """Audit an authorization-allowlist change (grant/revoke/deny).
+
+    Args:
+        action: "grant", "revoke", or "deny".
+        oid: The affected Entra object ID.
+        upn: Optional user principal name (recorded in the audit log only).
+        source: How the change was made (default the self-service email flow).
+    """
+    if not _access_events_enabled:
+        return
+    event: dict[str, Any] = {
+        "event_type": "access_change",
+        "action": action,
+        "entra_oid": oid,
+    }
+    if upn:
+        event["upn"] = upn
+    event["source"] = source
+    _emit(event)
+
+
 def reset_audit_state() -> None:
     """Reset audit module state. For testing only."""
     global _access_events_enabled, _execution_events_enabled, _initialized

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -174,6 +174,29 @@ class Config:
         self.entra_auth_enabled = _bool_env("ENTRA_AUTH_ENABLED", False)
         self.mcp_entra_allowed_oids = _parse_keys(os.getenv("MCP_ENTRA_ALLOWED_OIDS", ""))
 
+        # --- Self-service access-approval flow (hosted-only; off by default) ---
+        # Feature flag. When false (default) the gate behaves exactly as before
+        # and the /admin/access/* routes 404. See internal access-approval spec.
+        self.access_request_enabled = _bool_env("ACCESS_REQUEST_ENABLED", False)
+        # Azure Table Storage overlay (managed-identity auth; no keys).
+        self.access_table_account = os.getenv("ACCESS_TABLE_ACCOUNT", "")
+        self.access_table_name = os.getenv("ACCESS_TABLE_NAME", "accessoverlay")
+        # Azure Communication Services email.
+        self.acs_endpoint = os.getenv("ACS_ENDPOINT", "")
+        self.acs_sender = os.getenv("ACS_SENDER", "")
+        # Admin notification recipients (comma/space separated).
+        self.access_admin_emails = [
+            e.strip()
+            for e in os.getenv("ACCESS_ADMIN_EMAILS", "").replace(",", " ").split()
+            if e.strip()
+        ]
+        # Public base URL used to build approval links (no trailing slash).
+        self.access_approve_base_url = os.getenv("ACCESS_APPROVE_BASE_URL", "").rstrip("/")
+        # HMAC secret for approval tokens; empty disables the feature (fail-closed).
+        self.access_token_secret = os.getenv("ACCESS_TOKEN_SECRET", "")
+        # Suppress re-emailing the admin for the same OID within this window.
+        self.access_notify_cooldown_hours = _int_env("ACCESS_NOTIFY_COOLDOWN_HOURS", 24)
+
         # Optional metadata
         self.institution_name = os.getenv("INSTITUTION_NAME", "")
         self.timezone = os.getenv("TIMEZONE", "UTC")

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -384,6 +384,34 @@ def test_connection() -> bool:
         return False
 
 
+def _cmd_list_grants(args) -> int:
+    """List self-service access grants from the overlay store. Returns an exit code."""
+    store = _access_store(get_config())
+    if store is None:
+        print("Access store unavailable (check ACCESS_* config + az login).")
+        return 1
+    grants = store.list_grants()
+    if not grants:
+        print("No self-service grants.")
+        return 0
+    for g in grants:
+        print(f"{g.oid}\t{g.display_name}\t{g.upn}\t{g.granted_utc}")
+    return 0
+
+
+def _cmd_revoke(args) -> int:
+    """Revoke one self-service access grant by Entra OID. Returns an exit code."""
+    store = _access_store(get_config())
+    if store is None:
+        print("Access store unavailable (check ACCESS_* config + az login).")
+        return 1
+    if store.revoke(args.revoke):
+        print(f"revoked {args.revoke}")
+        return 0
+    print(f"oid not found: {args.revoke}")
+    return 1
+
+
 def main() -> None:
     """Main entry point for the Canvas MCP server."""
     parser = argparse.ArgumentParser(
@@ -422,11 +450,29 @@ def main() -> None:
         default=None,
         help="Tool profile: student (~31 tools), educator (~86 tools), all (default: all)"
     )
+    parser.add_argument(
+        "--list-grants",
+        action="store_true",
+        help="List self-service access grants (hosted; needs az login) and exit"
+    )
+    parser.add_argument(
+        "--revoke",
+        metavar="OID",
+        help="Revoke a self-service access grant by Entra OID and exit"
+    )
 
     args = parser.parse_args()
     is_http = args.transport == "streamable-http"
 
     config = get_config()
+
+    # Admin access-approval commands talk only to the overlay store (Azure, via
+    # az login) — not Canvas — so dispatch them before the Canvas-credential /
+    # HTTP-mode validation below, which they don't need.
+    if args.list_grants:
+        raise SystemExit(_cmd_list_grants(args))
+    if args.revoke:
+        raise SystemExit(_cmd_revoke(args))
 
     # HTTP mode: the Canvas URL is server-pinned and per-user tokens arrive via
     # X-Canvas-Token. A server token must NOT be set, or a missing request token

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -129,10 +129,23 @@ _ADMIN_APPROVE_PATH = "/admin/access/approve"
 _ADMIN_CONFIRM_PATH = "/admin/access/confirm"
 
 
+_overlay_store = None
+
+
 def _access_store(config):
-    """Build the overlay store lazily (None when feature not ready/unavailable)."""
-    from .core.access.factory import build_store
-    return build_store(config)
+    """Build the overlay store once and reuse it across requests.
+
+    The store's ``is_granted`` TTL cache is per-instance, so it only works if
+    the instance survives between requests — rebuilding per request also re-ran
+    ``create_table_if_not_exists`` and a fresh credential/client every time.
+    Returns None until it can be built (feature off / azure unavailable), and
+    retries on the next call so a transient build failure self-heals.
+    """
+    global _overlay_store
+    if _overlay_store is None:
+        from .core.access.factory import build_store
+        _overlay_store = build_store(config)
+    return _overlay_store
 
 
 def _schedule_notify(config, store, requester) -> None:

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -19,6 +19,8 @@ import base64
 import hmac
 import json
 import sys
+import time
+import uuid
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -73,6 +75,16 @@ async def _send_json_error(send: Any, status: int, message: str) -> None:
     await send({"type": "http.response.body", "body": body})
 
 
+async def _read_body(receive) -> bytes:
+    body = b""
+    while True:
+        msg = await receive()
+        body += msg.get("body", b"")
+        if not msg.get("more_body", False):
+            break
+    return body
+
+
 def _access_key_ok(presented: str, allowed: frozenset[str]) -> bool:
     """Constant-time check of a presented access key against the allowed set."""
     if not presented:
@@ -113,6 +125,34 @@ def _client_principal_claims(headers: dict[bytes, bytes]) -> dict[str, str]:
         return {}
 
 
+_ADMIN_APPROVE_PATH = "/admin/access/approve"
+_ADMIN_CONFIRM_PATH = "/admin/access/confirm"
+
+
+def _access_store(config):
+    """Build the overlay store lazily (None when feature not ready/unavailable)."""
+    from .core.access.factory import build_store
+    return build_store(config)
+
+
+def _schedule_notify(config, store, requester) -> None:
+    """Fire-and-forget admin email; never blocks or breaks the request path."""
+    from .core.access.factory import build_email_sender
+    from .core.access.notify import notify_access_request
+    sender = build_email_sender(config)
+    if sender is None:
+        return
+    now = int(time.time())
+    now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now))
+    asyncio.create_task(notify_access_request(
+        store=store, requester=requester, secret=config.access_token_secret,
+        approve_base_url=config.access_approve_base_url,
+        admin_emails=config.access_admin_emails,
+        cooldown_hours=config.access_notify_cooldown_hours,
+        ttl_seconds=24 * 3600, send_email=sender,
+        jti=uuid.uuid4().hex, now=now, now_iso=now_iso))
+
+
 class CanvasCredentialMiddleware:
     """ASGI middleware that extracts the caller's Canvas token from headers.
 
@@ -139,11 +179,34 @@ class CanvasCredentialMiddleware:
             await self.app(scope, receive, send)
             return
 
+        config = get_config()
+        path = scope.get("path", "")
+
+        # --- Admin access-approval routes (intercepted before any token gate) ---
+        if path in (_ADMIN_APPROVE_PATH, _ADMIN_CONFIRM_PATH):
+            from .core.access.factory import feature_ready
+            if not (config.access_request_enabled and feature_ready(config)):
+                await _send_json_error(send, 404, "Not found")
+                return
+            store = _access_store(config)
+            if store is None:
+                await _send_json_error(send, 503, "Access service unavailable")
+                return
+            from .core.access import routes
+            now = int(time.time())
+            if path == _ADMIN_APPROVE_PATH:
+                await routes.handle_approve(scope.get("query_string", b""), send,
+                                            store=store, secret=config.access_token_secret, now=now)
+            else:
+                body = await _read_body(receive)
+                await routes.handle_confirm(body, send, store=store,
+                                            secret=config.access_token_secret, now=now)
+            return
+
         set_http_request_active(True)
         try:
             # Parse headers from ASGI scope (list of [name, value] byte pairs)
             headers = dict(scope.get("headers", []))
-            config = get_config()
 
             if config.entra_auth_enabled:
                 # Entra platform-auth path: Azure App Service has already validated
@@ -156,7 +219,22 @@ class CanvasCredentialMiddleware:
                 if not oid:
                     await _send_json_error(send, 401, "Missing verified Entra identity")
                     return
-                if config.mcp_entra_allowed_oids and oid not in config.mcp_entra_allowed_oids:
+                in_env = oid in config.mcp_entra_allowed_oids
+                in_overlay = False
+                store = None
+                if not in_env and config.access_request_enabled:
+                    store = _access_store(config)
+                    in_overlay = store.is_granted(oid) if store else False
+                if config.mcp_entra_allowed_oids and not (in_env or in_overlay):
+                    if config.access_request_enabled and store is not None:
+                        claims_for_req = _client_principal_claims(headers)
+                        from .core.access.store import Requester
+                        requester = Requester(
+                            oid=oid,
+                            upn=claims_for_req.get("preferred_username")
+                            or claims_for_req.get("upn", ""),
+                            display_name=claims_for_req.get("name", ""))
+                        _schedule_notify(config, store, requester)
                     await _send_json_error(send, 403, "Identity not authorized for this MCP server")
                     return
                 claims = _client_principal_claims(headers)

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -226,16 +226,23 @@ class CanvasCredentialMiddleware:
                     store = _access_store(config)
                     in_overlay = store.is_granted(oid) if store else False
                 if config.mcp_entra_allowed_oids and not (in_env or in_overlay):
-                    if config.access_request_enabled and store is not None:
-                        claims_for_req = _client_principal_claims(headers)
-                        from .core.access.store import Requester
-                        requester = Requester(
-                            oid=oid,
-                            upn=claims_for_req.get("preferred_username")
-                            or claims_for_req.get("upn", ""),
-                            display_name=claims_for_req.get("name", ""))
-                        _schedule_notify(config, store, requester)
+                    # Send the deny FIRST, so scheduling the access-request email
+                    # can never delay or break the 403 (auth boundary: respond,
+                    # then notify). The notify is additionally guarded so a
+                    # scheduling error degrades to "no email", never a dropped 403.
                     await _send_json_error(send, 403, "Identity not authorized for this MCP server")
+                    if config.access_request_enabled and store is not None:
+                        try:
+                            claims_for_req = _client_principal_claims(headers)
+                            from .core.access.store import Requester
+                            requester = Requester(
+                                oid=oid,
+                                upn=claims_for_req.get("preferred_username")
+                                or claims_for_req.get("upn", ""),
+                                display_name=claims_for_req.get("name", ""))
+                            _schedule_notify(config, store, requester)
+                        except Exception as exc:
+                            log_error(f"access-request notify scheduling failed: {exc}")
                     return
                 claims = _client_principal_claims(headers)
                 # Log only the stable, opaque identifiers (oid GUID, scope, client

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -148,6 +148,12 @@ def _access_store(config):
     return _overlay_store
 
 
+def reset_overlay_store() -> None:
+    """Discard the memoized overlay store (test isolation; mirrors reset_config)."""
+    global _overlay_store
+    _overlay_store = None
+
+
 def _schedule_notify(config, store, requester) -> None:
     """Fire-and-forget admin email; never blocks or breaks the request path."""
     from .core.access.factory import build_email_sender

--- a/tests/core/access/test_factory.py
+++ b/tests/core/access/test_factory.py
@@ -22,3 +22,30 @@ def test_feature_ready_false_when_disabled_or_unconfigured():
 
 def test_build_store_returns_none_when_not_ready():
     assert factory.build_store(_cfg(access_request_enabled=False)) is None
+
+
+def test_entity_to_row_surfaces_etag_from_metadata():
+    """Azure exposes the ETag on entity.metadata, not as an item; the row must
+    carry it so the store's single-use ETag guard works on the real backend.
+
+    Regression guard for the cross-backend seam bug where dict(entity) dropped
+    the ETag (InMemoryBackend kept it as a key, so tests hid the KeyError that
+    consume_pending would raise against the live Azure backend)."""
+    class _FakeEntity(dict):
+        def __init__(self, data, etag):
+            super().__init__(data)
+            self.metadata = {"etag": etag}
+
+    ent = _FakeEntity(
+        {"PartitionKey": "pending", "RowKey": "oid-1", "status": "pending"},
+        etag='W/"abc123"',
+    )
+    row = factory._entity_to_row(ent)
+    assert row["etag"] == 'W/"abc123"'                 # surfaced from .metadata
+    assert row["RowKey"] == "oid-1" and row["status"] == "pending"
+    assert "etag" not in dict(ent)                     # bare dict() drops it — the bug
+
+
+def test_entity_to_row_no_metadata_is_safe():
+    """A row without metadata/etag (e.g. plain dict) must not raise."""
+    assert factory._entity_to_row({"RowKey": "x"}) == {"RowKey": "x"}

--- a/tests/core/access/test_factory.py
+++ b/tests/core/access/test_factory.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+from canvas_mcp.core.access import factory
+
+
+def _cfg(**kw):
+    base = dict(access_request_enabled=True, access_token_secret="s",
+                access_table_account="acct", access_table_name="t",
+                acs_endpoint="https://acs", acs_sender="x@d", access_admin_emails=["a@x"])
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_feature_ready_true_when_configured():
+    assert factory.feature_ready(_cfg()) is True
+
+
+def test_feature_ready_false_when_disabled_or_unconfigured():
+    assert factory.feature_ready(_cfg(access_request_enabled=False)) is False
+    assert factory.feature_ready(_cfg(access_token_secret="")) is False
+    assert factory.feature_ready(_cfg(access_table_account="")) is False
+
+
+def test_build_store_returns_none_when_not_ready():
+    assert factory.build_store(_cfg(access_request_enabled=False)) is None

--- a/tests/core/access/test_import_isolation.py
+++ b/tests/core/access/test_import_isolation.py
@@ -1,36 +1,82 @@
-import builtins
-import importlib
-import pytest
+"""Regression guard: the base install must import the access package and the
+server WITHOUT the optional ``[hosted]`` Azure dependencies.
+
+This runs in a SUBPROCESS with a fresh interpreter rather than reloading
+modules in-process. Reloading (`importlib.reload`) mutates the already-imported
+modules' globals in place, which rebinds shared classes (e.g. ``TokenClaims``,
+``ConcurrencyConflict``) and pollutes class identity for every other test in the
+session. A subprocess isolates that completely — and is a stronger check, since
+it exercises a genuine cold import with ``azure`` blocked, not a reload of
+modules that were already imported normally.
+"""
+
+import subprocess
+import sys
+import textwrap
 
 
-def test_core_modules_import_without_azure(monkeypatch):
-    """Simulate azure not installed: importing access modules must still work."""
-    real_import = builtins.__import__
-
-    def blocked(name, *args, **kwargs):
-        if name.startswith("azure"):
-            raise ImportError(f"simulated missing dependency: {name}")
-        return real_import(name, *args, **kwargs)
-
-    monkeypatch.setattr(builtins, "__import__", blocked)
-    for mod in ("canvas_mcp.core.access.tokens", "canvas_mcp.core.access.store",
-                "canvas_mcp.core.access.notify", "canvas_mcp.core.access.routes",
-                "canvas_mcp.core.access.factory", "canvas_mcp.server"):
-        importlib.reload(importlib.import_module(mod))  # must not raise
+def _run(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+    )
 
 
-def test_factory_build_store_returns_none_without_azure(monkeypatch):
-    import builtins
-    from types import SimpleNamespace
-    from canvas_mcp.core.access import factory
-    real_import = builtins.__import__
+def test_core_modules_import_without_azure():
+    """All access modules + the server import cold with azure unavailable."""
+    result = _run(
+        """
+        import builtins
+        _real = builtins.__import__
 
-    def blocked(name, *args, **kwargs):
-        if name.startswith("azure"):
-            raise ImportError("no azure")
-        return real_import(name, *args, **kwargs)
+        def _blocked(name, globals=None, locals=None, fromlist=(), level=0):
+            # Block only ABSOLUTE azure-SDK imports (level 0), faithfully
+            # simulating "the [hosted] azure libs are not installed". Relative
+            # imports (level > 0) like pydantic_settings' own `.azure` submodule
+            # must pass through untouched.
+            if level == 0 and (name == "azure" or name.startswith("azure.")):
+                raise ImportError("simulated missing dependency: " + name)
+            return _real(name, globals, locals, fromlist, level)
 
-    monkeypatch.setattr(builtins, "__import__", blocked)
-    cfg = SimpleNamespace(access_request_enabled=True, access_token_secret="s",
-                          access_table_account="acct", access_table_name="t")
-    assert factory.build_store(cfg) is None  # degrades, does not raise
+        builtins.__import__ = _blocked
+
+        import canvas_mcp.core.access.tokens          # noqa: F401
+        import canvas_mcp.core.access.store           # noqa: F401
+        import canvas_mcp.core.access.notify          # noqa: F401
+        import canvas_mcp.core.access.routes          # noqa: F401
+        import canvas_mcp.core.access.factory         # noqa: F401
+        import canvas_mcp.server                      # noqa: F401
+        print("IMPORTS-OK")
+        """
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    assert "IMPORTS-OK" in result.stdout
+
+
+def test_factory_build_store_returns_none_without_azure():
+    """build_store degrades to None (never raises) when azure is absent."""
+    result = _run(
+        """
+        import builtins
+        _real = builtins.__import__
+
+        def _blocked(name, globals=None, locals=None, fromlist=(), level=0):
+            if level == 0 and (name == "azure" or name.startswith("azure.")):
+                raise ImportError("no azure")
+            return _real(name, globals, locals, fromlist, level)
+
+        builtins.__import__ = _blocked
+
+        from types import SimpleNamespace
+        from canvas_mcp.core.access import factory
+        cfg = SimpleNamespace(
+            access_request_enabled=True, access_token_secret="s",
+            access_table_account="acct", access_table_name="t",
+        )
+        assert factory.build_store(cfg) is None
+        print("DEGRADES-OK")
+        """
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+    assert "DEGRADES-OK" in result.stdout

--- a/tests/core/access/test_import_isolation.py
+++ b/tests/core/access/test_import_isolation.py
@@ -1,0 +1,36 @@
+import builtins
+import importlib
+import pytest
+
+
+def test_core_modules_import_without_azure(monkeypatch):
+    """Simulate azure not installed: importing access modules must still work."""
+    real_import = builtins.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name.startswith("azure"):
+            raise ImportError(f"simulated missing dependency: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked)
+    for mod in ("canvas_mcp.core.access.tokens", "canvas_mcp.core.access.store",
+                "canvas_mcp.core.access.notify", "canvas_mcp.core.access.routes",
+                "canvas_mcp.core.access.factory", "canvas_mcp.server"):
+        importlib.reload(importlib.import_module(mod))  # must not raise
+
+
+def test_factory_build_store_returns_none_without_azure(monkeypatch):
+    import builtins
+    from types import SimpleNamespace
+    from canvas_mcp.core.access import factory
+    real_import = builtins.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name.startswith("azure"):
+            raise ImportError("no azure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked)
+    cfg = SimpleNamespace(access_request_enabled=True, access_token_secret="s",
+                          access_table_account="acct", access_table_name="t")
+    assert factory.build_store(cfg) is None  # degrades, does not raise

--- a/tests/core/access/test_notify.py
+++ b/tests/core/access/test_notify.py
@@ -1,0 +1,39 @@
+import pytest
+from canvas_mcp.core.access.notify import build_request_email, notify_access_request
+from canvas_mcp.core.access.store import AccessStore, InMemoryBackend, Requester
+
+REQ = Requester(oid="oid-1", upn="j@x.edu", display_name="Jane Doe")
+
+
+def test_email_contains_identity_and_link():
+    msg = build_request_email(REQ, "https://h.edu/admin/access/approve?token=abc")
+    assert "Jane Doe" in msg["html"] and "j@x.edu" in msg["html"]
+    assert "token=abc" in msg["html"]
+    assert "Jane Doe" in msg["subject"]
+    assert "j@x.edu" in msg["plain"]
+
+
+@pytest.mark.asyncio
+async def test_notify_sends_once_and_dedups():
+    store = AccessStore(InMemoryBackend(), cache_ttl_seconds=0)
+    sent = []
+    async def fake_send(recipients, subject, html, plain):
+        sent.append((recipients, subject))
+    kw = dict(store=store, requester=REQ, secret="s",
+              approve_base_url="https://h.edu", admin_emails=["a@x.edu"],
+              cooldown_hours=24, ttl_seconds=86400, send_email=fake_send)
+    assert await notify_access_request(jti="j1", now=0, now_iso="2026-06-29T00:00:00Z", **kw) is True
+    assert await notify_access_request(jti="j2", now=60, now_iso="2026-06-29T00:01:00Z", **kw) is False
+    assert len(sent) == 1 and sent[0][0] == ["a@x.edu"]
+
+
+@pytest.mark.asyncio
+async def test_notify_swallows_send_failure():
+    store = AccessStore(InMemoryBackend(), cache_ttl_seconds=0)
+    async def boom(*a, **k):
+        raise RuntimeError("ACS down")
+    ok = await notify_access_request(
+        jti="j1", now=0, now_iso="2026-06-29T00:00:00Z", store=store, requester=REQ,
+        secret="s", approve_base_url="https://h.edu", admin_emails=["a@x.edu"],
+        cooldown_hours=24, ttl_seconds=86400, send_email=boom)
+    assert ok is False  # did not raise

--- a/tests/core/access/test_routes.py
+++ b/tests/core/access/test_routes.py
@@ -1,0 +1,68 @@
+import pytest
+from unittest.mock import AsyncMock
+import canvas_mcp.core.audit as audit
+from canvas_mcp.core.access import routes
+from canvas_mcp.core.access.store import AccessStore, InMemoryBackend, Requester
+from canvas_mcp.core.access.tokens import mint_token
+
+REQ = Requester(oid="oid-1", upn="j@x.edu", display_name="Jane Doe")
+SECRET = "s"
+
+
+def _seeded_store():
+    s = AccessStore(InMemoryBackend(), cache_ttl_seconds=0)
+    s.note_request(REQ, jti="j1", exp=1000, now_iso="2026-06-29T00:00:00Z", cooldown_hours=24)
+    return s
+
+
+async def _collect(send):
+    # send is an AsyncMock; return concatenated body bytes + first status
+    status = send.call_args_list[0][0][0]["status"]
+    body = b"".join(c[0][0].get("body", b"") for c in send.call_args_list if "body" in c[0][0])
+    return status, body.decode()
+
+
+@pytest.mark.asyncio
+async def test_approve_get_renders_confirm_for_valid_token():
+    store = _seeded_store()
+    token = mint_token(oid="oid-1", jti="j1", exp=1000, secret=SECRET)
+    send = AsyncMock()
+    await routes.handle_approve(f"token={token}".encode(), send, store=store, secret=SECRET, now=1)
+    status, html = await _collect(send)
+    assert status == 200 and "Jane Doe" in html and "Confirm" in html
+    assert store.is_granted("oid-1") is False  # GET must NOT grant
+
+
+@pytest.mark.asyncio
+async def test_approve_get_invalid_token_is_generic():
+    store = _seeded_store()
+    send = AsyncMock()
+    await routes.handle_approve(b"token=garbage", send, store=store, secret=SECRET, now=1)
+    status, html = await _collect(send)
+    assert status == 200 and "no longer valid" in html and "Jane Doe" not in html
+
+
+@pytest.mark.asyncio
+async def test_confirm_post_grants_and_audits(monkeypatch):
+    store = _seeded_store()
+    events = []
+    monkeypatch.setattr(audit, "_access_events_enabled", True)
+    monkeypatch.setattr(audit, "_emit", lambda e: events.append(e))
+    token = mint_token(oid="oid-1", jti="j1", exp=1000, secret=SECRET)
+    send = AsyncMock()
+    await routes.handle_confirm(f"token={token}".encode(), send, store=store, secret=SECRET, now=1)
+    status, html = await _collect(send)
+    assert status == 200 and "granted" in html.lower()
+    assert store.is_granted("oid-1") is True
+    assert events and events[0]["action"] == "grant" and events[0]["entra_oid"] == "oid-1"
+
+
+@pytest.mark.asyncio
+async def test_confirm_post_rejects_replayed_token():
+    store = _seeded_store()
+    token = mint_token(oid="oid-1", jti="j1", exp=1000, secret=SECRET)
+    await routes.handle_confirm(f"token={token}".encode(), AsyncMock(), store=store, secret=SECRET, now=1)
+    send2 = AsyncMock()
+    await routes.handle_confirm(f"token={token}".encode(), send2, store=store, secret=SECRET, now=1)
+    _, html = await _collect(send2)
+    assert "no longer valid" in html  # single-use enforced

--- a/tests/core/access/test_routes.py
+++ b/tests/core/access/test_routes.py
@@ -66,3 +66,38 @@ async def test_confirm_post_rejects_replayed_token():
     await routes.handle_confirm(f"token={token}".encode(), send2, store=store, secret=SECRET, now=1)
     _, html = await _collect(send2)
     assert "no longer valid" in html  # single-use enforced
+
+
+@pytest.mark.asyncio
+async def test_confirm_grant_failure_is_retriable(monkeypatch):
+    """A transient grant-write failure must NOT consume the token: the admin
+    gets a retry page (not a 500, not a spent token), and the SAME link then
+    works on retry once the write succeeds."""
+    store = _seeded_store()
+    token = mint_token(oid="oid-1", jti="j1", exp=1000, secret=SECRET)
+
+    calls = {"n": 0}
+    real_grant = store.grant
+
+    def flaky_grant(req, *, jti):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("azure write failed")
+        return real_grant(req, jti=jti)
+
+    monkeypatch.setattr(store, "grant", flaky_grant)
+
+    # First Confirm: grant throws -> retry page, nothing granted, token NOT consumed
+    send1 = AsyncMock()
+    await routes.handle_confirm(f"token={token}".encode(), send1, store=store, secret=SECRET, now=1)
+    status1, html1 = await _collect(send1)
+    assert status1 == 200 and "temporary error" in html1.lower()   # retry page, no 500
+    assert store.is_granted("oid-1") is False                       # not granted
+    assert store.get_pending("oid-1")["status"] == "pending"        # token retriable
+
+    # Second Confirm with the SAME token: grant now succeeds -> granted + success
+    send2 = AsyncMock()
+    await routes.handle_confirm(f"token={token}".encode(), send2, store=store, secret=SECRET, now=1)
+    status2, html2 = await _collect(send2)
+    assert status2 == 200 and "granted" in html2.lower()
+    assert store.is_granted("oid-1") is True

--- a/tests/core/access/test_store.py
+++ b/tests/core/access/test_store.py
@@ -1,4 +1,3 @@
-import pytest
 from canvas_mcp.core.access.store import (
     AccessStore, InMemoryBackend, Requester, ConcurrencyConflict,
 )
@@ -47,8 +46,7 @@ def test_consume_pending_is_single_use():
 def test_consume_pending_loses_etag_race(monkeypatch):
     s = _store()
     s.note_request(REQ, jti="j1", exp=1000, now_iso="2026-06-29T00:00:00Z", cooldown_hours=24)
-    # Force the backend replace to lose the race exactly once.
-    orig = s._backend.replace_if_unmodified
+    # Force the backend replace to lose the race.
     def racing(entity, etag):
         raise ConcurrencyConflict("stale etag")
     monkeypatch.setattr(s._backend, "replace_if_unmodified", racing)

--- a/tests/core/access/test_store.py
+++ b/tests/core/access/test_store.py
@@ -1,0 +1,55 @@
+import pytest
+from canvas_mcp.core.access.store import (
+    AccessStore, InMemoryBackend, Requester, ConcurrencyConflict,
+)
+
+REQ = Requester(oid="oid-1", upn="j@x.edu", display_name="Jane Doe")
+
+
+def _store(ttl=0):
+    # ttl=0 -> no caching, so tests see writes immediately
+    return AccessStore(InMemoryBackend(), cache_ttl_seconds=ttl)
+
+
+def test_grant_then_is_granted_and_listed():
+    s = _store()
+    assert s.is_granted("oid-1") is False
+    s.grant(REQ, jti="j1")
+    assert s.is_granted("oid-1") is True
+    grants = s.list_grants()
+    assert len(grants) == 1 and grants[0].oid == "oid-1" and grants[0].upn == "j@x.edu"
+
+
+def test_revoke_removes_grant():
+    s = _store()
+    s.grant(REQ, jti="j1")
+    assert s.revoke("oid-1") is True
+    assert s.is_granted("oid-1") is False
+    assert s.revoke("oid-1") is False  # already gone
+
+
+def test_note_request_dedups_within_cooldown():
+    s = _store()
+    assert s.note_request(REQ, jti="j1", exp=1000, now_iso="2026-06-29T00:00:00Z",
+                          cooldown_hours=24) is True   # first time -> notify
+    assert s.note_request(REQ, jti="j2", exp=2000, now_iso="2026-06-29T01:00:00Z",
+                          cooldown_hours=24) is False  # within cooldown -> suppress
+
+
+def test_consume_pending_is_single_use():
+    s = _store()
+    s.note_request(REQ, jti="j1", exp=1000, now_iso="2026-06-29T00:00:00Z", cooldown_hours=24)
+    assert s.consume_pending("oid-1", "j1") is True   # first consume wins
+    assert s.consume_pending("oid-1", "j1") is False  # already consumed
+    assert s.consume_pending("oid-1", "wrong-jti") is False  # jti mismatch
+
+
+def test_consume_pending_loses_etag_race(monkeypatch):
+    s = _store()
+    s.note_request(REQ, jti="j1", exp=1000, now_iso="2026-06-29T00:00:00Z", cooldown_hours=24)
+    # Force the backend replace to lose the race exactly once.
+    orig = s._backend.replace_if_unmodified
+    def racing(entity, etag):
+        raise ConcurrencyConflict("stale etag")
+    monkeypatch.setattr(s._backend, "replace_if_unmodified", racing)
+    assert s.consume_pending("oid-1", "j1") is False  # conflict -> not consumed

--- a/tests/core/access/test_tokens.py
+++ b/tests/core/access/test_tokens.py
@@ -1,0 +1,27 @@
+from canvas_mcp.core.access.tokens import mint_token, verify_token, TokenClaims
+
+SECRET = "test-secret-key"
+
+
+def test_roundtrip_valid_token():
+    t = mint_token(oid="oid-1", jti="j1", exp=1000, secret=SECRET)
+    claims = verify_token(t, secret=SECRET, now=999)
+    assert claims == TokenClaims(oid="oid-1", jti="j1", exp=1000)
+
+
+def test_expired_token_rejected():
+    t = mint_token(oid="oid-1", jti="j1", exp=1000, secret=SECRET)
+    assert verify_token(t, secret=SECRET, now=1000) is None  # exp must be > now
+    assert verify_token(t, secret=SECRET, now=1001) is None
+
+
+def test_tampered_signature_rejected():
+    t = mint_token(oid="oid-1", jti="j1", exp=1000, secret=SECRET)
+    assert verify_token(t, secret="wrong-secret", now=1) is None
+    assert verify_token(t[:-2] + ("AA" if not t.endswith("AA") else "BB"),
+                        secret=SECRET, now=1) is None
+
+
+def test_garbage_input_returns_none_not_raise():
+    for junk in ("", "no-dot", "a.b.c", "@@@.@@@"):
+        assert verify_token(junk, secret=SECRET, now=1) is None

--- a/tests/core/test_audit_access.py
+++ b/tests/core/test_audit_access.py
@@ -1,0 +1,36 @@
+import pytest
+import canvas_mcp.core.audit as audit
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    audit.reset_audit_state()
+    yield
+    audit.reset_audit_state()
+
+
+def test_grant_event_emitted_when_enabled(monkeypatch):
+    events = []
+    monkeypatch.setattr(audit, "_access_events_enabled", True)
+    monkeypatch.setattr(audit, "_emit", lambda e: events.append(e))
+    audit.log_access_change("grant", "oid-1", upn="j@x.edu")
+    assert events == [{
+        "event_type": "access_change", "action": "grant",
+        "entra_oid": "oid-1", "upn": "j@x.edu", "source": "self-service",
+    }]
+
+
+def test_no_event_when_disabled(monkeypatch):
+    events = []
+    monkeypatch.setattr(audit, "_access_events_enabled", False)
+    monkeypatch.setattr(audit, "_emit", lambda e: events.append(e))
+    audit.log_access_change("grant", "oid-1")
+    assert events == []
+
+
+def test_upn_omitted_when_none(monkeypatch):
+    events = []
+    monkeypatch.setattr(audit, "_access_events_enabled", True)
+    monkeypatch.setattr(audit, "_emit", lambda e: events.append(e))
+    audit.log_access_change("revoke", "oid-2")
+    assert "upn" not in events[0] and events[0]["action"] == "revoke"

--- a/tests/core/test_config_access.py
+++ b/tests/core/test_config_access.py
@@ -1,0 +1,38 @@
+import pytest
+from canvas_mcp.core.config import get_config, reset_config
+
+
+@pytest.fixture(autouse=True)
+def _clean_config():
+    reset_config()
+    yield
+    reset_config()
+
+
+def test_access_defaults_are_disabled(monkeypatch):
+    for var in ("ACCESS_REQUEST_ENABLED", "ACCESS_TABLE_ACCOUNT", "ACS_ENDPOINT",
+                "ACS_SENDER", "ACCESS_ADMIN_EMAILS", "ACCESS_APPROVE_BASE_URL",
+                "ACCESS_TOKEN_SECRET"):
+        monkeypatch.delenv(var, raising=False)
+    cfg = get_config()
+    assert cfg.access_request_enabled is False
+    assert cfg.access_admin_emails == []
+    assert cfg.access_table_name == "accessoverlay"
+    assert cfg.access_notify_cooldown_hours == 24
+
+
+def test_access_settings_parse_from_env(monkeypatch):
+    monkeypatch.setenv("ACCESS_REQUEST_ENABLED", "true")
+    monkeypatch.setenv("ACCESS_ADMIN_EMAILS", "a@x.edu, b@x.edu")
+    monkeypatch.setenv("ACCESS_APPROVE_BASE_URL", "https://h.edu/")
+    monkeypatch.setenv("ACCESS_NOTIFY_COOLDOWN_HOURS", "6")
+    cfg = get_config()
+    assert cfg.access_request_enabled is True
+    assert cfg.access_admin_emails == ["a@x.edu", "b@x.edu"]
+    assert cfg.access_approve_base_url == "https://h.edu"  # trailing slash stripped
+    assert cfg.access_notify_cooldown_hours == 6
+
+
+def test_admin_emails_blank_yields_empty_list(monkeypatch):
+    monkeypatch.setenv("ACCESS_ADMIN_EMAILS", "   ")
+    assert get_config().access_admin_emails == []

--- a/tests/test_cli_access.py
+++ b/tests/test_cli_access.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from canvas_mcp.server import _cmd_list_grants, _cmd_revoke
+from canvas_mcp.core.access.store import AccessStore, InMemoryBackend, Requester
+
+
+def _store_with_one():
+    s = AccessStore(InMemoryBackend(), cache_ttl_seconds=0)
+    s.grant(Requester("oid-1", "j@x.edu", "Jane Doe"), jti="j1")
+    return s
+
+
+def test_list_grants_prints_rows(capsys):
+    with patch("canvas_mcp.server._access_store", return_value=_store_with_one()):
+        rc = _cmd_list_grants(SimpleNamespace())
+    out = capsys.readouterr().out
+    assert rc == 0 and "oid-1" in out and "Jane Doe" in out
+
+
+def test_revoke_removes_and_reports(capsys):
+    store = _store_with_one()
+    with patch("canvas_mcp.server._access_store", return_value=store):
+        rc = _cmd_revoke(SimpleNamespace(revoke="oid-1"))
+    assert rc == 0 and store.is_granted("oid-1") is False
+    assert "revoked" in capsys.readouterr().out.lower()
+
+
+def test_revoke_unknown_oid_reports_not_found(capsys):
+    with patch("canvas_mcp.server._access_store", return_value=_store_with_one()):
+        rc = _cmd_revoke(SimpleNamespace(revoke="nope"))
+    assert rc == 1 and "not found" in capsys.readouterr().out.lower()

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -24,11 +24,13 @@ class _FakeConfig:
         mcp_access_keys=frozenset(),
         entra_auth_enabled=False,
         mcp_entra_allowed_oids=frozenset(),
+        access_request_enabled=False,
     ):
         self.canvas_api_url = canvas_api_url
         self.mcp_access_keys = mcp_access_keys
         self.entra_auth_enabled = entra_auth_enabled
         self.mcp_entra_allowed_oids = mcp_entra_allowed_oids
+        self.access_request_enabled = access_request_enabled
 
 # ---------------------------------------------------------------------------
 # ContextVar credential tests
@@ -927,3 +929,85 @@ class TestEntraPlatformAuth:
             await middleware(scope, AsyncMock(), AsyncMock())
 
         assert captured["token"] == "tok"
+
+
+# ---------------------------------------------------------------------------
+# Self-service access-approval overlay: gate union + admin route intercept
+# ---------------------------------------------------------------------------
+
+
+class TestAccessOverlayGate:
+    @pytest.fixture
+    def middleware(self):
+        from canvas_mcp.server import CanvasCredentialMiddleware
+        return CanvasCredentialMiddleware(AsyncMock())
+
+    def _cfg(self, **kw):
+        # Minimal config double with feature enabled + an in-memory store.
+        from types import SimpleNamespace
+        base = dict(entra_auth_enabled=True, mcp_entra_allowed_oids=frozenset({"oid-env"}),
+                    canvas_api_url="https://c.edu/api/v1", mcp_access_keys=frozenset(),
+                    access_request_enabled=True, access_token_secret="s",
+                    access_table_account="acct", access_admin_emails=["a@x"],
+                    access_approve_base_url="https://h.edu", acs_endpoint="https://acs",
+                    acs_sender="x@d", access_notify_cooldown_hours=24)
+        base.update(kw)
+        return SimpleNamespace(**base)
+
+    @pytest.mark.asyncio
+    async def test_overlay_oid_is_authorized(self, middleware):
+        from canvas_mcp.core.access.store import AccessStore, InMemoryBackend, Requester
+        store = AccessStore(InMemoryBackend(), cache_ttl_seconds=0)
+        store.grant(Requester("oid-new", "j@x", "Jane"), jti="j1")
+        captured = {}
+        async def inner(scope, receive, send):
+            captured["ran"] = True
+        middleware.app = inner
+        scope = {"type": "http", "path": "/mcp", "headers": [
+            (b"x-ms-client-principal-id", b"oid-new"),
+            (b"x-ms-client-principal", _principal_header({"scp": "x"})),
+            (b"x-canvas-token", b"tok")]}
+        with patch("canvas_mcp.server.get_config", return_value=self._cfg()), \
+             patch("canvas_mcp.server._access_store", return_value=store):
+            await middleware(scope, AsyncMock(), AsyncMock())
+        assert captured.get("ran") is True  # overlay grant -> allowed
+
+    @pytest.mark.asyncio
+    async def test_unlisted_oid_403_and_schedules_notify(self, middleware):
+        from canvas_mcp.core.access.store import AccessStore, InMemoryBackend
+        store = AccessStore(InMemoryBackend(), cache_ttl_seconds=0)
+        send = AsyncMock()
+        scope = {"type": "http", "path": "/mcp", "headers": [
+            (b"x-ms-client-principal-id", b"oid-unknown"),
+            (b"x-ms-client-principal", _principal_header(
+                {"scp": "x", "name": "Stranger", "preferred_username": "s@x.edu"})),
+            (b"x-canvas-token", b"tok")]}
+        with patch("canvas_mcp.server.get_config", return_value=self._cfg()), \
+             patch("canvas_mcp.server._access_store", return_value=store), \
+             patch("canvas_mcp.server._schedule_notify") as sched:
+            await middleware(scope, AsyncMock(), send)
+        assert send.call_args_list[0][0][0]["status"] == 403
+        sched.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_approve_path_served_without_canvas_token(self, middleware):
+        from canvas_mcp.core.access.store import AccessStore, InMemoryBackend
+        store = AccessStore(InMemoryBackend(), cache_ttl_seconds=0)
+        send = AsyncMock()
+        scope = {"type": "http", "path": "/admin/access/approve",
+                 "query_string": b"token=garbage", "headers": []}
+        with patch("canvas_mcp.server.get_config", return_value=self._cfg()), \
+             patch("canvas_mcp.server._access_store", return_value=store):
+            await middleware(scope, AsyncMock(), send)
+        status = send.call_args_list[0][0][0]["status"]
+        assert status == 200  # served by route handler, not the 401 token gate
+
+    @pytest.mark.asyncio
+    async def test_admin_path_404_when_feature_disabled(self, middleware):
+        send = AsyncMock()
+        scope = {"type": "http", "path": "/admin/access/approve",
+                 "query_string": b"", "headers": []}
+        with patch("canvas_mcp.server.get_config",
+                   return_value=self._cfg(access_request_enabled=False)):
+            await middleware(scope, AsyncMock(), send)
+        assert send.call_args_list[0][0][0]["status"] == 404


### PR DESCRIPTION
## Summary

Adds an opt-in, hosted-only **self-service access-approval** flow. When an authenticated-but-unlisted Entra identity hits the authorization gate (today: a hard `403`), the server emails an admin a signed one-click approval; approving grants that identity access **at runtime, with no app restart**.

This removes the onboarding friction where a would-be user is silently blocked until they reach an operator out-of-band — while preserving the deny-by-default posture and the Entra/Duo identity binding.

**Off by default.** The whole feature is gated behind `ACCESS_REQUEST_ENABLED` plus an optional `[hosted]` dependency extra, so the open-source stdio product is unaffected.

## How it works

1. An unlisted (but NetID+Duo-authenticated) identity → `403`, and the server fires a **deduped, fire-and-forget** email to the admin with the requester's verified identity.
2. The email links to a confirmation page (`GET /admin/access/approve`) carrying an HMAC-signed, single-use, 24h token. That page is read-only / **prefetch-safe** — it grants nothing.
3. The admin clicks **Confirm** (`POST /admin/access/confirm`) → token verified + consumed (single-use via ETag) → the OID is granted in a runtime overlay store → audit event written.
4. The requester's next reconnect is authorized (≤30s cache TTL). No restart.

## Design

- **Allowlist model:** the existing `MCP_ENTRA_ALLOWED_OIDS` env var stays the authoritative seed; new approvals land in a runtime-mutable Azure Table overlay. The gate authorizes on `oid ∈ env ∪ overlay`.
- **Link security:** HMAC-SHA256 over `{oid, jti, exp}`, single-use, 24h expiry, scoped to one identity; the grant commits only on the confirmation **POST** (defeats mail-scanner/link-prefetch auto-clicks). Invalid/expired/forged tokens all render an identical generic page (no info leak).
- **No secrets in the app:** Azure Table + ACS email both authenticate via the web app's **managed identity** — no keys or connection strings.
- **Fail-closed:** store unreachable → env-set only (never opens access); feature flag or HMAC secret unset → fully disabled, admin routes `404`.
- **Lazy deps:** every `azure-*` import is lazy (confined to `core/access/factory.py`, inside function bodies); a subprocess regression test enforces that the base install imports without the `[hosted]` extra.
- **Admin tooling:** `canvas-mcp-server --list-grants` / `--revoke <oid>`.

## What's added

New sub-package `src/canvas_mcp/core/access/`:
- `tokens.py` — HMAC mint/verify (stdlib only)
- `store.py` — overlay allowlist + in-memory backend (single-use ETag, dedup cooldown)
- `notify.py` — admin-email composition + fire-and-forget orchestration
- `routes.py` — approve/confirm ASGI handlers + pages
- `factory.py` — lazy Azure store + ACS sender builders

Plus a contained change to `CanvasCredentialMiddleware` (gate union + path intercept), new settings in `core/config.py`, a `log_access_change` audit event, and the `[hosted]` optional-deps group.

## Testing

TDD throughout — **554 passed, 21 skipped** (`uv run python -m pytest tests/`). New tests cover the token crypto, the overlay store's single-use/ETag-race/dedup, the routes (prefetch-safe GET, single-use confirm, generic-error no-leak), the lazy-import isolation (subprocess, azure-blocked cold import), the middleware gate (env/overlay/403+notify/disabled-404), and the CLI.

## Operator setup

The one-time Azure setup (managed identity, Storage table, ACS sender, Easy Auth excluded paths, app settings) lives in an operator-only runbook kept out of the repo. The `[hosted]` extra installs the azure libraries; nothing is required for the default stdio install.
