### PR TITLE
build(docker): install [hosted] extra for the access-approval flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ COPY README.md ./
 COPY env.template ./
 COPY src/ ./src/
 
-# Install dependencies using uv
-RUN uv pip install --system --no-cache -e .
+# Install dependencies using uv. The [hosted] extra (azure-data-tables,
+# azure-communication-email, azure-identity) is required by the hosted
+# access-approval flow; it is lazily imported, so stdio users are unaffected.
+RUN uv pip install --system --no-cache -e ".[hosted]"
 
 # Create non-root user for security
 RUN adduser --disabled-password --gecos '' mcp && \


### PR DESCRIPTION
## Summary
The hosted access-approval flow (#150) lazily imports `azure-data-tables` / `azure-communication-email` / `azure-identity`, but the image never installed the `[hosted]` extra — so enabling `ACCESS_REQUEST_ENABLED` on the current prod image would leave the feature degraded (store/email unavailable). One line: install `.[hosted]` in the Docker image.

stdio/self-hosted users are unaffected (the azure deps stay lazily imported and unused).

## Test plan
- [x] `docker build` succeeds locally
- [x] `docker run … python -c "import azure.data.tables, azure.identity, azure.communication.email; import canvas_mcp"` → OK (v1.4.0, fastmcp 2 image)

Merging auto-deploys prod via deploy-prod.yml; the ACCESS_* app settings get applied separately per the ops runbook.