### PR TITLE
Add update_discussion_topic tool (#154)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ Course management, grading, and analytics. Requires instructor/TA role.
 | `send_conversation` | Message students |
 | `send_peer_review_reminders` | Automated reminder workflow |
 | `create_announcement` | Post course announcements |
+| `update_discussion_topic` | Edit discussion or announcement title/body and settings |
 
 ### Shared Tools (Students & Educators)
 Content access tools available to all authenticated users.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ Reduce tool overhead by setting a role-based profile. Only tools relevant to the
 ```
 # In .env:
 CANVAS_ROLE=student    # ~32 tools (student + shared)
-CANVAS_ROLE=educator   # ~87 tools (educator + shared)
-CANVAS_ROLE=all        # All 92 tools (default)
+CANVAS_ROLE=educator   # ~88 tools (educator + shared)
+CANVAS_ROLE=all        # All 93 tools (default)
 ```
 
 Or via CLI flag: `canvas-mcp-server --role student` (CLI flag takes precedence over env var).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`get_syllabus` tool** — returns the complete Canvas Syllabus tab content without truncation (the overview tools only expose a ~1000-character preview, hiding later sections like grading policies and weighting). Supports `output_format` (`text`/`html`/`both`) and an optional `max_chars` cap that is explicitly marked when applied ([#134](https://github.com/vishalsachdev/canvas-mcp/issues/134)).
 - **`create_rubric_from_csv` tool** — create a rubric from a CSV string via Canvas's native rubric CSV import endpoint, polling the import job to completion. A simpler alternative to the criteria-JSON `create_rubric` API ([#119](https://github.com/vishalsachdev/canvas-mcp/issues/119)).
+- **`update_discussion_topic` tool** — educator-only partial update of an existing discussion topic or announcement (title, message, published/pinned/locked, `delayed_post_at`/`lock_at`, `require_initial_post`) via `PUT /courses/:id/discussion_topics/:topic_id`, mirroring the `update_assignment` pattern ([#154](https://github.com/vishalsachdev/canvas-mcp/issues/154)).
 
 ### Changed
 - **Migrated to standalone `fastmcp` 2.x** from the frozen FastMCP 1.0 bundled in the MCP SDK (`mcp.server.fastmcp`). No user-facing changes: same tools, same transports, HTTP endpoint unchanged at `/mcp` ([#145](https://github.com/vishalsachdev/canvas-mcp/issues/145)).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,7 @@ See: [Issue #56](https://github.com/vishalsachdev/canvas-mcp/issues/56) for comp
 - [x] Claude Desktop Extension (`.mcpb`) — scaffolded, distributed via GitHub Releases (auto-attached on tag), README install section; shipped in v1.4.0
 - [x] Release **v1.4.0** — GitHub + PyPI + MCP Registry + hosted server + website all live
 - [x] PR #150: self-service access-approval flow for the hosted server — merged 2026-07-01
+- [ ] PR #155: `update_discussion_topic` (#154) — draft open; merge → auto-deploy to hosted
 - [ ] Issue #145 / PR #152: fastmcp 2.x migration — **PR 1 of 2 merged 2026-07-02** (code migration, 560 tests green); PR 2 (Azure staging/Entra validation) still open
 - [ ] Backlog triage (module templates, bulk creation, page versioning)
 - [ ] Issue #106: 186 mypy errors uncovered by adding mypy to dev deps — incremental cleanup, module by module
@@ -199,20 +200,14 @@ these local-only files publicly; `docs/.assetsignore` is now a backstop).
 ## Session Log
 > Full history: [internal/session-history.md](./internal/session-history.md)
 
-### 2026-07-03 — Canvas token renewed + verified; SBC 511 launch audit queued
-- Canvas API token renewed (user applied via KB form) and verified: `canvas-mcp-server --test` passes
-  (authenticated as Vishal Sachdev). Also swapped the token inside `~/.claude.json` — the hosted-server
-  MCP entry passes it as an `X-Canvas-Token` header to `mcp-remote`, which is **separate from `.env`**
-  and was still carrying the expired token (the running bridge process holds the header from spawn
-  time, so a session restart is needed before the `canvas` MCP server picks it up).
-- Started a launch-readiness audit (canvas-course-audit skill) — target confirmed as **SBC 511
-  Summer 2026 (course id 70438, unpublished)** — but session ended before the audit ran.
-- Noted: 7 stale `mcp-remote` processes accumulated against the hosted server (one per abandoned
-  client session), each exposing the Canvas token in `ps` output; periodic
-  `pkill -f "mcp-remote.*canvas-mcp.disruptionlab"` sweep worth doing.
-- Next: (1) Run the SBC 511 (70438) launch audit — restart session first so the hosted `canvas` MCP
-  picks up the new token, or script direct Canvas API calls with `.venv/bin/python3` + httpx. (2)
-  Watch for PR 2 of the fastmcp 2.x migration (Azure staging/Entra validation) — still not opened.
-  (3) Carry-forward from 6/30: model-fork framing for the LRA correction; onboarding-simplification
-  thread; distribute rebuilt `.mcpb`. (4) Backlog: #142 MCP SDK v2 (~2026-07-27 deadline), #106 mypy
-  cleanup, PR #117 (draft since 6/7 — decide revive/close), backlog triage.
+### 2026-07-04 — `update_discussion_topic` implemented; draft PR #155 open
+- Reviewed #154 (discussion edit gap hit during SBC 511 launch prep), confirmed valid — pages/assignments
+  updatable via MCP but graded discussion prompts are not.
+- Implemented educator-only `update_discussion_topic` on `feature/update-discussion-topic`: partial-update
+  PUT to `/discussion_topics/:id` (title, message, published, pinned, locked, scheduling); covers
+  announcements too. 6 new tests (11 total in test_discussions.py); docs synced (AGENTS.md, tools/README,
+  TOOL_MANIFEST). Confirmed local + hosted share one codebase — single registration, transport-only diff.
+- Committed (`fc8df89`), pushed, opened **draft PR #155**.
+- Next: (1) Review/merge PR #155; close #154 on merge. (2) Manual verify on SBC 511 (70438) — apply the
+  Week 1 discussion wording fix via MCP. (3) Run SBC 511 launch audit (still queued from 7/3). (4) PR #153
+  (dockerfile hosted extra), fastmcp 2.x PR 2, #142 MCP SDK v2 deadline ~7/27, #106 mypy cleanup.

--- a/internal/session-history.md
+++ b/internal/session-history.md
@@ -4,6 +4,24 @@ Archived session log entries from canvas-mcp CLAUDE.md.
 
 ## Session Log
 
+### 2026-07-03 — Canvas token renewed + verified; SBC 511 launch audit queued
+- Canvas API token renewed (user applied via KB form) and verified: `canvas-mcp-server --test` passes
+  (authenticated as Vishal Sachdev). Also swapped the token inside `~/.claude.json` — the hosted-server
+  MCP entry passes it as an `X-Canvas-Token` header to `mcp-remote`, which is **separate from `.env`**
+  and was still carrying the expired token (the running bridge process holds the header from spawn
+  time, so a session restart is needed before the `canvas` MCP server picks it up).
+- Started a launch-readiness audit (canvas-course-audit skill) — target confirmed as **SBC 511
+  Summer 2026 (course id 70438, unpublished)** — but session ended before the audit ran.
+- Noted: 7 stale `mcp-remote` processes accumulated against the hosted server (one per abandoned
+  client session), each exposing the Canvas token in `ps` output; periodic
+  `pkill -f "mcp-remote.*canvas-mcp.disruptionlab"` sweep worth doing.
+- Next: (1) Run the SBC 511 (70438) launch audit — restart session first so the hosted `canvas` MCP
+  picks up the new token, or script direct Canvas API calls with `.venv/bin/python3` + httpx. (2)
+  Watch for PR 2 of the fastmcp 2.x migration (Azure staging/Entra validation) — still not opened.
+  (3) Carry-forward from 6/30: model-fork framing for the LRA correction; onboarding-simplification
+  thread; distribute rebuilt `.mcpb`. (4) Backlog: #142 MCP SDK v2 (~2026-07-27 deadline), #106 mypy
+  cleanup, PR #117 (draft since 6/7 — decide revive/close), backlog triage.
+
 ### 2026-07-02 — Fixed Claude Desktop connector sign-in (Entra manifest), rotated Canvas token
 - Claude Desktop's remote-MCP connector couldn't complete sign-in against the `Canvas MCP API` app
   registration (`e1443fda-5aa7-4136-a884-d97f64258ef0`). Two manifest fixes applied live via `az ad app

--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -813,6 +813,107 @@ def register_educator_discussion_tools(mcp: FastMCP):
                f"Title: {topic_title}\n" + \
                f"Created: {created_at}"
 
+    @mcp.tool()
+    @validate_params
+    async def update_discussion_topic(
+        course_identifier: str | int,
+        topic_id: str | int,
+        title: str | None = None,
+        message: str | None = None,
+        published: bool | None = None,
+        pinned: bool | None = None,
+        locked: bool | None = None,
+        delayed_post_at: str | None = None,
+        lock_at: str | None = None,
+        require_initial_post: bool | None = None,
+    ) -> str:
+        """Update an existing discussion topic or announcement.
+
+        Args:
+            course_identifier: Course code or Canvas ID
+            topic_id: Discussion topic ID
+            title: New title
+            message: New body content (HTML supported)
+            published: Publish or unpublish the topic
+            pinned: Pin or unpin the topic
+            locked: Lock or unlock the topic
+            delayed_post_at: ISO 8601 datetime to schedule posting
+            lock_at: ISO 8601 datetime to auto-lock the discussion
+            require_initial_post: Students must post before seeing others
+        """
+        course_id = await get_course_id(course_identifier)
+
+        data: dict[str, str | bool] = {}
+
+        if title is not None:
+            data["title"] = title
+
+        if message is not None:
+            data["message"] = message
+
+        if published is not None:
+            data["published"] = published
+
+        if pinned is not None:
+            data["pinned"] = pinned
+
+        if locked is not None:
+            data["locked"] = locked
+
+        if require_initial_post is not None:
+            data["require_initial_post"] = require_initial_post
+
+        if delayed_post_at is not None:
+            parsed_delayed = parse_date(delayed_post_at)
+            if not parsed_delayed:
+                return (
+                    f"Invalid date format for delayed_post_at: '{delayed_post_at}'. "
+                    "Use ISO 8601 format (e.g., '2026-01-26T12:00:00Z')."
+                )
+            data["delayed_post_at"] = parsed_delayed.isoformat()
+
+        if lock_at is not None:
+            parsed_lock = parse_date(lock_at)
+            if not parsed_lock:
+                return (
+                    f"Invalid date format for lock_at: '{lock_at}'. "
+                    "Use ISO 8601 format (e.g., '2026-02-01T23:59:00Z')."
+                )
+            data["lock_at"] = parsed_lock.isoformat()
+
+        if not data:
+            return (
+                "No fields provided to update. Specify at least one field to modify "
+                "(e.g., title, message, published, pinned, locked)."
+            )
+
+        response = await make_canvas_request(
+            "put",
+            f"/courses/{course_id}/discussion_topics/{topic_id}",
+            data=data,
+        )
+
+        if "error" in response:
+            return f"Error updating discussion topic: {response['error']}"
+
+        updated_title = response.get("title", "")
+        is_announcement = response.get("is_announcement", False)
+        updated_published = response.get("published", False)
+        topic_type = "Announcement" if is_announcement else "Discussion"
+
+        course_display = await get_course_code(course_id) or course_identifier
+        updated_fields = list(data.keys())
+
+        result = f"✅ {topic_type} updated successfully!\n\n"
+        result += f"**{updated_title}**\n"
+        result += f"  Course: {course_display}\n"
+        result += f"  Topic ID: {topic_id}\n"
+        result += f"  Type: {topic_type}\n"
+        result += f"  Updated fields: {', '.join(updated_fields)}\n"
+        result += f"  Published: {'Yes' if updated_published else 'No'}\n"
+
+        return result
+
     # ===== ANNOUNCEMENT TOOLS =====
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))

--- a/tests/tools/test_discussions.py
+++ b/tests/tools/test_discussions.py
@@ -7,6 +7,181 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 
+@pytest.fixture
+def mock_canvas_api():
+    """Fixture to mock Canvas API calls for discussion tools."""
+    with patch('canvas_mcp.tools.discussions.get_course_id') as mock_get_id, \
+         patch('canvas_mcp.tools.discussions.get_course_code') as mock_get_code, \
+         patch('canvas_mcp.tools.discussions.fetch_all_paginated_results') as mock_fetch, \
+         patch('canvas_mcp.tools.discussions.make_canvas_request') as mock_request:
+
+        mock_get_id.return_value = "60366"
+        mock_get_code.return_value = "badm_350_120251"
+
+        yield {
+            'get_course_id': mock_get_id,
+            'get_course_code': mock_get_code,
+            'fetch_all_paginated_results': mock_fetch,
+            'make_canvas_request': mock_request
+        }
+
+
+def get_tool_function(tool_name: str):
+    """Get a tool function by name from the registered discussion tools."""
+    from fastmcp import FastMCP
+
+    from canvas_mcp.tools.discussions import (
+        register_educator_discussion_tools,
+        register_shared_discussion_tools,
+    )
+
+    mcp = FastMCP("test")
+    captured_functions = {}
+
+    original_tool = mcp.tool
+
+    def capturing_tool(*args, **kwargs):
+        decorator = original_tool(*args, **kwargs)
+
+        def wrapper(fn):
+            captured_functions[fn.__name__] = fn
+            return decorator(fn)
+
+        return wrapper
+
+    mcp.tool = capturing_tool
+    register_shared_discussion_tools(mcp)
+    register_educator_discussion_tools(mcp)
+
+    return captured_functions.get(tool_name)
+
+
+class TestUpdateDiscussionTopic:
+    """Tests for update_discussion_topic tool."""
+
+    @pytest.mark.asyncio
+    async def test_update_discussion_topic_message_only(self, mock_canvas_api):
+        """Test updating only the discussion body."""
+        mock_canvas_api['make_canvas_request'].return_value = {
+            "id": 42,
+            "title": "Week 1 Discussion",
+            "message": "<p>Updated prompt text</p>",
+            "published": True,
+            "is_announcement": False,
+        }
+
+        update_discussion_topic = get_tool_function('update_discussion_topic')
+        assert update_discussion_topic is not None
+
+        result = await update_discussion_topic(
+            "badm_350_120251",
+            42,
+            message="<p>Updated prompt text</p>",
+        )
+
+        mock_canvas_api['get_course_id'].assert_called_once_with("badm_350_120251")
+        mock_canvas_api['make_canvas_request'].assert_called_once()
+
+        call_args = mock_canvas_api['make_canvas_request'].call_args
+        assert call_args[0][0] == "put"
+        assert call_args[0][1] == "/courses/60366/discussion_topics/42"
+        assert call_args[1]['data'] == {"message": "<p>Updated prompt text</p>"}
+
+        assert "successfully" in result
+        assert "Week 1 Discussion" in result
+        assert "Updated fields: message" in result
+
+    @pytest.mark.asyncio
+    async def test_update_discussion_topic_multiple_fields(self, mock_canvas_api):
+        """Test updating title, message, and published together."""
+        mock_canvas_api['make_canvas_request'].return_value = {
+            "id": 42,
+            "title": "Renamed Discussion",
+            "message": "<p>New body</p>",
+            "published": True,
+            "is_announcement": False,
+        }
+
+        update_discussion_topic = get_tool_function('update_discussion_topic')
+        result = await update_discussion_topic(
+            "badm_350_120251",
+            42,
+            title="Renamed Discussion",
+            message="<p>New body</p>",
+            published=True,
+        )
+
+        call_args = mock_canvas_api['make_canvas_request'].call_args
+        assert call_args[1]['data'] == {
+            "title": "Renamed Discussion",
+            "message": "<p>New body</p>",
+            "published": True,
+        }
+
+        assert "successfully" in result
+        assert "title" in result
+        assert "message" in result
+        assert "published" in result
+
+    @pytest.mark.asyncio
+    async def test_update_discussion_topic_no_fields(self, mock_canvas_api):
+        """Test that error is returned when no fields are provided."""
+        update_discussion_topic = get_tool_function('update_discussion_topic')
+        result = await update_discussion_topic("badm_350_120251", 42)
+
+        assert "No fields provided to update" in result
+        mock_canvas_api['make_canvas_request'].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_discussion_topic_api_error(self, mock_canvas_api):
+        """Test error handling when API fails."""
+        mock_canvas_api['make_canvas_request'].return_value = {"error": "Topic not found"}
+
+        update_discussion_topic = get_tool_function('update_discussion_topic')
+        result = await update_discussion_topic(
+            "badm_350_120251",
+            99999,
+            message="New text",
+        )
+
+        assert "Error updating discussion topic" in result
+        assert "Topic not found" in result
+
+    @pytest.mark.asyncio
+    async def test_update_discussion_topic_invalid_date(self, mock_canvas_api):
+        """Test validation of invalid lock_at date."""
+        update_discussion_topic = get_tool_function('update_discussion_topic')
+        result = await update_discussion_topic(
+            "badm_350_120251",
+            42,
+            lock_at="not-a-valid-date",
+        )
+
+        assert "Invalid date format for lock_at" in result
+        mock_canvas_api['make_canvas_request'].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_discussion_topic_announcement(self, mock_canvas_api):
+        """Test that announcement topics are labeled correctly in output."""
+        mock_canvas_api['make_canvas_request'].return_value = {
+            "id": 7,
+            "title": "Exam reminder",
+            "message": "<p>Bring a pencil</p>",
+            "published": True,
+            "is_announcement": True,
+        }
+
+        update_discussion_topic = get_tool_function('update_discussion_topic')
+        result = await update_discussion_topic(
+            "badm_350_120251",
+            7,
+            message="<p>Bring a pencil</p>",
+        )
+
+        assert "Announcement updated successfully" in result
+        assert "Type: Announcement" in result
+
+
 class TestDiscussionTools:
     """Test discussion tool functions."""
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -583,6 +583,28 @@ Start a new discussion forum.
 
 ---
 
+#### `update_discussion_topic`
+Edit an existing discussion topic or announcement (title, body, publish state, etc.).
+
+**Parameters:**
+- `course_identifier`: Course code or ID
+- `topic_id`: Discussion topic ID
+- `title`: New title (optional)
+- `message`: New body content, HTML supported (optional)
+- `published`: Publish or unpublish (optional)
+- `pinned`: Pin or unpin (optional)
+- `locked`: Lock or unlock (optional)
+- `delayed_post_at`: Schedule posting, ISO 8601 (optional)
+- `lock_at`: Auto-lock datetime, ISO 8601 (optional)
+- `require_initial_post`: Require initial post before viewing replies (optional)
+
+**Example:**
+```
+"Update the Week 1 discussion prompt to mention Claude and Gemini"
+```
+
+---
+
 #### `reply_to_discussion_entry`
 Respond to student discussion posts.
 

--- a/tools/TOOL_MANIFEST.json
+++ b/tools/TOOL_MANIFEST.json
@@ -571,6 +571,77 @@
       ]
     },
     {
+      "name": "update_discussion_topic",
+      "category": "educator",
+      "description": "Edit an existing discussion topic or announcement",
+      "parameters": [
+        {
+          "name": "course_identifier",
+          "type": "string | integer",
+          "required": true,
+          "description": "Course code or Canvas ID"
+        },
+        {
+          "name": "topic_id",
+          "type": "string | integer",
+          "required": true,
+          "description": "Discussion topic ID"
+        },
+        {
+          "name": "title",
+          "type": "string",
+          "required": false,
+          "description": "New title"
+        },
+        {
+          "name": "message",
+          "type": "string",
+          "required": false,
+          "description": "New body content (HTML supported)"
+        },
+        {
+          "name": "published",
+          "type": "boolean",
+          "required": false,
+          "description": "Publish or unpublish the topic"
+        },
+        {
+          "name": "pinned",
+          "type": "boolean",
+          "required": false,
+          "description": "Pin or unpin the topic"
+        },
+        {
+          "name": "locked",
+          "type": "boolean",
+          "required": false,
+          "description": "Lock or unlock the topic"
+        },
+        {
+          "name": "delayed_post_at",
+          "type": "string",
+          "required": false,
+          "description": "ISO 8601 datetime to schedule posting"
+        },
+        {
+          "name": "lock_at",
+          "type": "string",
+          "required": false,
+          "description": "ISO 8601 datetime to auto-lock the discussion"
+        },
+        {
+          "name": "require_initial_post",
+          "type": "boolean",
+          "required": false,
+          "description": "Students must post before seeing others"
+        }
+      ],
+      "returns": "Confirmation with updated fields and topic type",
+      "examples": [
+        "Update the Week 1 discussion prompt to mention Claude and Gemini"
+      ]
+    },
+    {
       "name": "search_canvas_tools",
       "category": "developer",
       "description": "Search available Canvas code API operations by keyword",


### PR DESCRIPTION
## Summary
- Adds educator-only `update_discussion_topic` MCP tool backed by `PUT /courses/:id/discussion_topics/:topic_id`
- Supports partial updates (title, message, published, pinned, locked, scheduling fields) — same pattern as `update_assignment`
- Covers both discussions and announcements (same Canvas endpoint)
- Closes the gap reported in #154 where discussion prompts had to be edited manually in Canvas UI during SBC 511 launch prep

## Test plan
- [x] `uv run python -m pytest tests/tools/test_discussions.py -v` — 11 passed
- [x] `uv run python -m pytest tests/test_role_filtering.py -k educator -v` — 5 passed
- [ ] Manual: update Week 1 discussion prompt on SBC 511 (70438) after merge


Made with [Cursor](https://cursor.com)