### PR TITLE
fix: run HTTP transport stateless to eliminate stale-session hangs (#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **HTTP transport now runs stateless (`stateless_http=True`)**, eliminating the stale-session hang for hosted deployments. Previously the server kept an in-memory session table; a host restart (e.g. Azure App Service recycle) dropped it, the next request's `Mcp-Session-Id` drew a 404, and `mcp-remote` hung indefinitely instead of re-initializing. With stateless HTTP every request is self-contained — credentials already arrive per-request via `X-Canvas-Token`, and no tool uses server-initiated session features, so nothing can go stale ([#159](https://github.com/vishalsachdev/canvas-mcp/issues/159)).
+
 ## [1.5.0] — 2026-07-04
 
 ### Added

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -694,7 +694,13 @@ def _run_http_server(mcp: FastMCP, host: str, port: int) -> None:
     # HTTP is the default transport and the endpoint stays mounted at /mcp.
     # CanvasCredentialMiddleware passes lifespan scopes through, so the
     # inner app's lifespan (required by fastmcp 2) still runs under uvicorn.
-    starlette_app = mcp.http_app()
+    #
+    # stateless_http=True: every request is self-contained (credentials arrive
+    # per-request via X-Canvas-Token; no tool uses server-initiated session
+    # features), so keeping an in-memory session table only creates a failure
+    # mode — an App Service recycle drops it, and mcp-remote hangs forever on
+    # the resulting stale-session 404 instead of re-initializing (issue #159).
+    starlette_app = mcp.http_app(stateless_http=True)
     app = CanvasCredentialMiddleware(starlette_app)
 
     config = uvicorn.Config(

--- a/tests/test_fastmcp2_compat.py
+++ b/tests/test_fastmcp2_compat.py
@@ -70,6 +70,58 @@ def test_http_app_exists_and_mounts_mcp_path():
     assert any(p.startswith("/mcp") for p in paths), f"expected /mcp mount, got {paths}"
 
 
+_STALE_SESSION_REQUEST = {
+    "headers": {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "Mcp-Session-Id": "00000000000000000000000000000000",
+    },
+    "json": {"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+}
+
+
+def test_stateful_http_app_rejects_stale_session_id():
+    """Default (stateful) mode 404s on an unknown Mcp-Session-Id — the
+    response mcp-remote fails to recover from (issue #159)."""
+    from starlette.testclient import TestClient
+
+    mcp = _make_server()
+    with TestClient(mcp.http_app()) as client:
+        response = client.post("/mcp", **_STALE_SESSION_REQUEST)
+    assert response.status_code == 404
+
+
+def test_stateless_http_app_serves_request_with_stale_session_id():
+    """stateless_http=True (what _run_http_server uses) must serve a request
+    carrying a stale session id — no server-side session can go stale, which
+    is the fix for issue #159."""
+    from starlette.testclient import TestClient
+
+    mcp = _make_server()
+    with TestClient(mcp.http_app(stateless_http=True)) as client:
+        response = client.post("/mcp", **_STALE_SESSION_REQUEST)
+    assert response.status_code == 200
+    assert "sample_tool" in response.text
+
+
+def test_run_http_server_builds_stateless_app(monkeypatch):
+    """_run_http_server must pass stateless_http=True — regression guard so a
+    refactor can't silently reintroduce the stateful session table."""
+    from unittest.mock import MagicMock
+
+    from canvas_mcp import server as server_module
+
+    mcp = MagicMock()
+    # Stop before actually binding a port: make uvicorn.Server(...).serve a no-op
+    # by intercepting anyio.run.
+    monkeypatch.setattr(server_module, "CanvasCredentialMiddleware", MagicMock())
+    import anyio
+
+    monkeypatch.setattr(anyio, "run", lambda fn: None)
+    server_module._run_http_server(mcp, host="127.0.0.1", port=0)
+    mcp.http_app.assert_called_once_with(stateless_http=True)
+
+
 @pytest.mark.asyncio
 async def test_summarize_course_prompt_renders(monkeypatch):
     """The real summarize-course prompt must render through fastmcp 2


### PR DESCRIPTION
## Summary
- Fixes #159: canvas tool calls hanging forever in long-lived hosted-server sessions.
- Root cause verified locally: the server kept fastmcp's default in-memory session table; an App Service recycle dropped it, the next request's `Mcp-Session-Id` drew a fast 404 (`Session not found`, ~13 ms), and `mcp-remote` hung on that 404 indefinitely instead of re-initializing per the streamable-HTTP spec.
- Fix: `_run_http_server` now builds the app with `stateless_http=True`. With no server-side session table, nothing can go stale — verified locally that a `tools/list` carrying a bogus `Mcp-Session-Id` with no prior initialize returns 200 with the full tool list.

## Why stateless is safe here
- Credentials already arrive per-request (`X-Canvas-Token` → ContextVars); the server holds no meaningful per-session state.
- No tool uses server-initiated session features (notifications, sampling, elicitation), which is the only capability stateless mode gives up.
- stdio transport is untouched.

## Out of scope (documented in operator runbook)
The other wedge path — Entra token expiry with a stuck `mcp-remote` OAuth refresh — is client-side/upstream; recovery (`/mcp` → reconnect) is documented in `internal/ops-hosted.local.md`.

## Tests
- Characterization pair: stateful app 404s on a stale session id; stateless app serves it (200 + tool list).
- Regression guard: `_run_http_server` must pass `stateless_http=True`.
- Full suite: 569 passed, 21 skipped.

## Deploy notes
Merging to main auto-deploys to the hosted prod slot via `deploy-prod.yml`. After deploy, verify with a real `mcp-remote` client: connect → call a tool → restart the App Service → call again → expect success instead of a hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)