### PR TITLE
fix: anonymization bypass for /courses/-scoped student-data endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **Fixed an anonymization bypass for `/courses/`-scoped student-data endpoints.** `_should_anonymize_endpoint()` checked its safe-endpoint list (which includes the substring `/courses`) before the student-data list, so enrollments, submissions, analytics, and discussion-content responses skipped central anonymization for nearly all real traffic. Sensitive checks now run first, discussion `/view`, `/entry_list`, and `/replies` endpoints are matched as student content, and the anonymizer now recurses into the discussion `/view` wrapper (`view`/`participants`/`replies`) and enrollment records' nested `user` dict — two shapes it previously passed through untouched. Added direct unit tests for the endpoint gate, which was previously untested ([#164](https://github.com/vishalsachdev/canvas-mcp/issues/164)).
+
 ### Fixed
 - **HTTP transport now runs stateless (`stateless_http=True`)**, eliminating the stale-session hang for hosted deployments. Previously the server kept an in-memory session table; a host restart (e.g. Azure App Service recycle) dropped it, the next request's `Mcp-Session-Id` drew a 404, and `mcp-remote` hung indefinitely instead of re-initializing. With stateless HTTP every request is self-contained — credentials already arrive per-request via `X-Canvas-Token`, and no tool uses server-initiated session features, so nothing can go stale ([#159](https://github.com/vishalsachdev/canvas-mcp/issues/159)).
 

--- a/src/canvas_mcp/core/anonymization.py
+++ b/src/canvas_mcp/core/anonymization.py
@@ -57,9 +57,17 @@ def anonymize_user_data(user_data: Any) -> Any:
     anonymized = user_data.copy()
     user_id = user_data.get('id')
 
-    # Enrollment-shaped records carry the student in a nested `user` dict
+    # Enrollment-shaped records carry the student in a nested `user` dict.
+    # The wrapper itself is NOT a user record — its `id` is the enrollment's
+    # own id, so running the flat-user branch below would fabricate name/email
+    # fields keyed to the wrong id. Anonymize the nested user, scrub the
+    # identity fields Canvas puts on the wrapper, and return.
     if isinstance(anonymized.get('user'), dict):
         anonymized['user'] = anonymize_user_data(anonymized['user'])
+        for identity_field in ('sis_user_id', 'integration_id', 'login_id'):
+            if identity_field in anonymized:
+                anonymized[identity_field] = None
+        return anonymized
 
     if user_id:
         anonymous_id = generate_anonymous_id(user_id)
@@ -158,11 +166,13 @@ def anonymize_discussion_entry(entry_data: Any) -> Any:
             ]
 
     # The /discussion_topics/{id}/view endpoint returns a wrapper dict:
-    # {"view": [entries...], "participants": [users...]} — recurse into both
-    if 'view' in anonymized and isinstance(anonymized['view'], list):
-        anonymized['view'] = [
-            anonymize_discussion_entry(entry) for entry in anonymized['view']
-        ]
+    # {"view": [entries...], "participants": [users...]} plus "new_entries"
+    # when include_new_entries=1 — recurse into all of them
+    for entry_list_key in ('view', 'new_entries'):
+        if entry_list_key in anonymized and isinstance(anonymized[entry_list_key], list):
+            anonymized[entry_list_key] = [
+                anonymize_discussion_entry(entry) for entry in anonymized[entry_list_key]
+            ]
     if 'participants' in anonymized and isinstance(anonymized['participants'], list):
         anonymized['participants'] = [
             anonymize_user_data(participant) for participant in anonymized['participants']

--- a/src/canvas_mcp/core/anonymization.py
+++ b/src/canvas_mcp/core/anonymization.py
@@ -57,6 +57,10 @@ def anonymize_user_data(user_data: Any) -> Any:
     anonymized = user_data.copy()
     user_id = user_data.get('id')
 
+    # Enrollment-shaped records carry the student in a nested `user` dict
+    if isinstance(anonymized.get('user'), dict):
+        anonymized['user'] = anonymize_user_data(anonymized['user'])
+
     if user_id:
         anonymous_id = generate_anonymous_id(user_id)
 
@@ -147,9 +151,21 @@ def anonymize_discussion_entry(entry_data: Any) -> Any:
         )
 
     # Handle nested replies - anonymize recursively
-    if 'recent_replies' in anonymized and isinstance(anonymized['recent_replies'], list):
-        anonymized['recent_replies'] = [
-            anonymize_discussion_entry(reply) for reply in anonymized['recent_replies']
+    for reply_key in ('recent_replies', 'replies'):
+        if reply_key in anonymized and isinstance(anonymized[reply_key], list):
+            anonymized[reply_key] = [
+                anonymize_discussion_entry(reply) for reply in anonymized[reply_key]
+            ]
+
+    # The /discussion_topics/{id}/view endpoint returns a wrapper dict:
+    # {"view": [entries...], "participants": [users...]} — recurse into both
+    if 'view' in anonymized and isinstance(anonymized['view'], list):
+        anonymized['view'] = [
+            anonymize_discussion_entry(entry) for entry in anonymized['view']
+        ]
+    if 'participants' in anonymized and isinstance(anonymized['participants'], list):
+        anonymized['participants'] = [
+            anonymize_user_data(participant) for participant in anonymized['participants']
         ]
 
     return anonymized

--- a/src/canvas_mcp/core/anonymization.py
+++ b/src/canvas_mcp/core/anonymization.py
@@ -69,7 +69,15 @@ def anonymize_user_data(user_data: Any) -> Any:
                 anonymized[identity_field] = None
         return anonymized
 
-    if user_id:
+    # Only treat the record as a flat user if it actually carries user-identity
+    # fields — a bare dict with a truthy `id` (e.g. a flat enrollment or todo
+    # item) would otherwise get name/email fabricated from an unrelated id.
+    looks_like_user = any(
+        field in user_data
+        for field in ('name', 'display_name', 'short_name', 'sortable_name', 'email', 'login_id')
+    )
+
+    if user_id and looks_like_user:
         anonymous_id = generate_anonymous_id(user_id)
 
         # Replace sensitive fields

--- a/src/canvas_mcp/core/client.py
+++ b/src/canvas_mcp/core/client.py
@@ -90,34 +90,36 @@ def _determine_data_type(endpoint: str) -> str:
 
 
 def _should_anonymize_endpoint(endpoint: str) -> bool:
-    """Determine if an endpoint should have its data anonymized."""
-    # Don't anonymize these endpoints as they don't contain student data
-    safe_endpoints = [
-        '/courses',  # Course info without student data (unless it includes users)
-        '/self',     # User's own profile
-        '/accounts', # Account information
-        '/terms',    # Academic terms
-    ]
+    """Determine if an endpoint should have its data anonymized.
 
+    Sensitive-data checks MUST run before any safe-endpoint reasoning: almost
+    every call here is scoped /courses/{id}/..., so a '/courses' short-circuit
+    checked first silently disables anonymization for the whole codebase
+    (issue #164). Anything not matched as sensitive defaults to False.
+
+    Intentionally NOT matched as sensitive:
+    - /groups listings — carry group names, not student names; generic
+      anonymization would mangle them. Membership goes via /groups/{id}/users,
+      which the '/users' rule covers.
+    - /discussion_topics listings (incl. announcements) — typically
+      instructor-authored; student content lives under the content endpoints
+      matched below.
+    """
     endpoint_lower = endpoint.lower()
 
-    # Always anonymize discussion entries as they contain student posts
-    if '/discussion_topics' in endpoint_lower and '/entries' in endpoint_lower:
+    # Discussion content endpoints carry student posts and names
+    if '/discussion_topics' in endpoint_lower and any(
+        content in endpoint_lower
+        for content in ('/entries', '/view', '/entry_list', '/replies')
+    ):
         return True
 
-    # Check if it's a safe endpoint
-    for safe in safe_endpoints:
-        if safe in endpoint_lower and '/users' not in endpoint_lower:
-            return False
-
-    # Anonymize endpoints that contain student data
+    # Endpoints whose responses contain student records
     student_data_endpoints = [
         '/users',
-        '/discussion',
         '/submissions',
         '/enrollments',
-        '/groups',
-        '/analytics'
+        '/analytics',
     ]
 
     return any(student_endpoint in endpoint_lower for student_endpoint in student_data_endpoints)

--- a/src/canvas_mcp/core/client.py
+++ b/src/canvas_mcp/core/client.py
@@ -105,24 +105,26 @@ def _should_anonymize_endpoint(endpoint: str) -> bool:
       instructor-authored; student content lives under the content endpoints
       matched below.
     """
-    endpoint_lower = endpoint.lower()
+    # Match whole path segments (not substrings) so user-controlled slugs —
+    # e.g. a page named "users" at /courses/{id}/pages/users — can't trip the
+    # sensitive match; a segment directly after 'pages' is a slug, not a route.
+    path = endpoint.lower().split('?', 1)[0]
+    segments = [seg for seg in path.split('/') if seg]
+
+    def has_sensitive_segment(names: set[str]) -> bool:
+        return any(
+            seg in names and not (i > 0 and segments[i - 1] == 'pages')
+            for i, seg in enumerate(segments)
+        )
 
     # Discussion content endpoints carry student posts and names
-    if '/discussion_topics' in endpoint_lower and any(
-        content in endpoint_lower
-        for content in ('/entries', '/view', '/entry_list', '/replies')
+    if 'discussion_topics' in segments and has_sensitive_segment(
+        {'entries', 'view', 'entry_list', 'replies'}
     ):
         return True
 
     # Endpoints whose responses contain student records
-    student_data_endpoints = [
-        '/users',
-        '/submissions',
-        '/enrollments',
-        '/analytics',
-    ]
-
-    return any(student_endpoint in endpoint_lower for student_endpoint in student_data_endpoints)
+    return has_sensitive_segment({'users', 'submissions', 'enrollments', 'analytics'})
 
 
 def _get_http_client() -> httpx.AsyncClient:

--- a/tests/security/test_anonymization_endpoints.py
+++ b/tests/security/test_anonymization_endpoints.py
@@ -165,6 +165,15 @@ class TestEnrollmentAnonymization:
         assert result["sis_user_id"] is None
         assert result["type"] == "StudentEnrollment"  # non-identity fields intact
 
+    def test_flat_non_user_record_not_fabricated(self):
+        # A flat enrollment (no include[]=user) or todo item has an id that
+        # belongs to no user — the flat-user branch must not fabricate
+        # name/email from it.
+        flat_enrollment = {"id": 9003, "course_id": 123, "type": "StudentEnrollment"}
+        result = anonymize_user_data(flat_enrollment)
+        assert "name" not in result
+        assert "email" not in result
+
     def test_enrollment_list_via_response_data(self):
         enrollments = [{
             "id": 9002,

--- a/tests/security/test_anonymization_endpoints.py
+++ b/tests/security/test_anonymization_endpoints.py
@@ -61,12 +61,21 @@ class TestShouldAnonymizeEndpoint:
         # Topic listings (incl. announcements) are typically instructor-authored;
         # student content lives under /entries|/view|/entry_list|/replies.
         "/courses/123/discussion_topics",
+        # Page slugs are user-controlled: a page named "users"/"submissions"
+        # must not trip the sensitive-segment match (PR #165 review).
+        "/courses/123/pages/users",
+        "/courses/123/pages/submissions",
+        "/courses/123/pages/analytics",
     ])
     def test_non_student_endpoints_not_anonymized(self, endpoint):
         assert _should_anonymize_endpoint(endpoint) is False
 
     def test_case_insensitive(self):
         assert _should_anonymize_endpoint("/COURSES/123/ENROLLMENTS") is True
+
+    def test_querystring_stripped_before_matching(self):
+        assert _should_anonymize_endpoint("/courses/123/enrollments?per_page=100") is True
+        assert _should_anonymize_endpoint("/courses/123/pages?search_term=users") is False
 
     def test_enrollments_map_to_users_data_type(self):
         assert _determine_data_type("/courses/123/enrollments") == "users"
@@ -97,6 +106,10 @@ class TestDiscussionViewAnonymization:
                     ],
                 },
             ],
+            # Returned when the caller passes include_new_entries=1
+            "new_entries": [
+                {"id": 3, "user_id": 102, "user_name": "Bob Learner", "message": "A new post"},
+            ],
         }
 
     def test_view_entries_anonymized(self):
@@ -118,6 +131,12 @@ class TestDiscussionViewAnonymization:
         assert "Alice Student" not in names
         assert "Bob Learner" not in names
 
+    def test_new_entries_anonymized(self):
+        result = anonymize_response_data(self._view_response(), data_type="discussions")
+        entry = result["new_entries"][0]
+        assert entry["user_name"] != "Bob Learner"
+        assert entry["user_name"].startswith("Student_")
+
 
 class TestEnrollmentAnonymization:
     """Enrollment records embed the student in a nested `user` dict."""
@@ -127,6 +146,7 @@ class TestEnrollmentAnonymization:
             "id": 9001,  # enrollment id, not a student id
             "course_id": 123,
             "type": "StudentEnrollment",
+            "sis_user_id": "670001234",
             "user": {
                 "id": 101,
                 "name": "Alice Student",
@@ -138,6 +158,12 @@ class TestEnrollmentAnonymization:
         assert result["user"]["name"] != "Alice Student"
         assert result["user"]["name"].startswith("Student_")
         assert result["user"]["id"] == 101  # IDs preserved for functionality
+        # Wrapper-level identity fields are scrubbed, not fabricated:
+        # no fake name/email keyed to the enrollment's own id (PR #165 review)
+        assert "name" not in result
+        assert "email" not in result
+        assert result["sis_user_id"] is None
+        assert result["type"] == "StudentEnrollment"  # non-identity fields intact
 
     def test_enrollment_list_via_response_data(self):
         enrollments = [{

--- a/tests/security/test_anonymization_endpoints.py
+++ b/tests/security/test_anonymization_endpoints.py
@@ -1,0 +1,149 @@
+"""
+Anonymization endpoint-gating tests (issue #164).
+
+Direct unit tests for _should_anonymize_endpoint() — the central gate that
+decides whether a Canvas API response is anonymized before reaching the model.
+Prior to #164 no test exercised this function, which let a safe-endpoint
+short-circuit silently skip anonymization for nearly all /courses/-scoped
+student-data endpoints.
+
+Also covers the two response shapes the anonymizer previously passed through
+untouched: the discussion /view wrapper dict and enrollment records with a
+nested `user` dict.
+"""
+
+import pytest
+
+from canvas_mcp.core.anonymization import (
+    anonymize_response_data,
+    anonymize_user_data,
+)
+from canvas_mcp.core.client import _determine_data_type, _should_anonymize_endpoint
+
+
+class TestShouldAnonymizeEndpoint:
+    """Student-data endpoints must anonymize even when nested under /courses."""
+
+    @pytest.mark.parametrize("endpoint", [
+        "/courses/123/enrollments",
+        "/sections/45/enrollments",
+        "/courses/123/assignments/456/submissions",
+        "/courses/123/assignments/456/submissions/789",
+        "/courses/123/students/submissions",
+        "/courses/123/analytics/student_summaries",
+        "/courses/123/analytics/users/77/activity",
+        "/courses/123/users",
+        "/courses/123/users/456",
+        "/groups/55/users",
+        "/courses/123/discussion_topics/9/entries",
+        "/courses/123/discussion_topics/9/entries/1/replies",
+        "/courses/123/discussion_topics/9/view",
+        "/courses/123/discussion_topics/9/entry_list",
+    ])
+    def test_student_data_endpoints_anonymized(self, endpoint):
+        assert _should_anonymize_endpoint(endpoint) is True
+
+    @pytest.mark.parametrize("endpoint", [
+        "/courses",
+        "/courses/123",
+        "/courses/123/pages",
+        "/courses/123/pages/intro",
+        "/courses/123/modules",
+        "/courses/123/modules/5/items",
+        "/courses/123/assignments",       # assignment definitions, no student data
+        "/courses/123/assignments/456",
+        "/courses/123/front_page",
+        "/courses/123/rubrics/12",
+        "/accounts/1/terms",
+        # Group *listings* carry group names, not student names; membership is
+        # fetched via /groups/{id}/users which the /users rule covers.
+        "/courses/123/groups",
+        # Topic listings (incl. announcements) are typically instructor-authored;
+        # student content lives under /entries|/view|/entry_list|/replies.
+        "/courses/123/discussion_topics",
+    ])
+    def test_non_student_endpoints_not_anonymized(self, endpoint):
+        assert _should_anonymize_endpoint(endpoint) is False
+
+    def test_case_insensitive(self):
+        assert _should_anonymize_endpoint("/COURSES/123/ENROLLMENTS") is True
+
+    def test_enrollments_map_to_users_data_type(self):
+        assert _determine_data_type("/courses/123/enrollments") == "users"
+
+    def test_discussion_view_maps_to_discussions_data_type(self):
+        assert _determine_data_type("/courses/123/discussion_topics/9/view") == "discussions"
+
+
+class TestDiscussionViewAnonymization:
+    """The /view endpoint returns {"view": [...], "participants": [...]} —
+    both lists carry student names and must be anonymized recursively."""
+
+    def _view_response(self):
+        return {
+            "unread_entries": [],
+            "participants": [
+                {"id": 101, "display_name": "Alice Student", "avatar_image_url": "http://x/a.png"},
+                {"id": 102, "display_name": "Bob Learner", "avatar_image_url": "http://x/b.png"},
+            ],
+            "view": [
+                {
+                    "id": 1,
+                    "user_id": 101,
+                    "user_name": "Alice Student",
+                    "message": "My email is alice@example.com",
+                    "replies": [
+                        {"id": 2, "user_id": 102, "user_name": "Bob Learner", "message": "Hi Alice"},
+                    ],
+                },
+            ],
+        }
+
+    def test_view_entries_anonymized(self):
+        result = anonymize_response_data(self._view_response(), data_type="discussions")
+        entry = result["view"][0]
+        assert entry["user_name"] != "Alice Student"
+        assert entry["user_name"].startswith("Student_")
+        assert "alice@example.com" not in entry["message"]
+
+    def test_nested_replies_anonymized(self):
+        result = anonymize_response_data(self._view_response(), data_type="discussions")
+        reply = result["view"][0]["replies"][0]
+        assert reply["user_name"] != "Bob Learner"
+        assert reply["user_name"].startswith("Student_")
+
+    def test_participants_anonymized(self):
+        result = anonymize_response_data(self._view_response(), data_type="discussions")
+        names = [p["display_name"] for p in result["participants"]]
+        assert "Alice Student" not in names
+        assert "Bob Learner" not in names
+
+
+class TestEnrollmentAnonymization:
+    """Enrollment records embed the student in a nested `user` dict."""
+
+    def test_nested_user_anonymized(self):
+        enrollment = {
+            "id": 9001,  # enrollment id, not a student id
+            "course_id": 123,
+            "type": "StudentEnrollment",
+            "user": {
+                "id": 101,
+                "name": "Alice Student",
+                "sortable_name": "Student, Alice",
+                "login_id": "alice1",
+            },
+        }
+        result = anonymize_user_data(enrollment)
+        assert result["user"]["name"] != "Alice Student"
+        assert result["user"]["name"].startswith("Student_")
+        assert result["user"]["id"] == 101  # IDs preserved for functionality
+
+    def test_enrollment_list_via_response_data(self):
+        enrollments = [{
+            "id": 9002,
+            "user_id": 102,
+            "user": {"id": 102, "name": "Bob Learner", "login_id": "bob2"},
+        }]
+        result = anonymize_response_data(enrollments, data_type="users")
+        assert result[0]["user"]["name"] != "Bob Learner"


### PR DESCRIPTION
Closes #164. Refs #162, #163 (weekly maintenance reports that flagged this).

## Problem

`_should_anonymize_endpoint()` checked its `safe_endpoints` list (which includes the substring `/courses`) **before** the `student_data_endpoints` list. Since nearly every Canvas call is scoped `/courses/{id}/...`, central anonymization was silently skipped for enrollments, submissions, analytics, and discussion content — the student-data check was dead code for course-scoped paths. Tool-layer anonymize calls masked this for the highest-traffic paths, but discussion `/view`/`/entry_list` (full threaded content with student names), `assign_peer_review`'s submissions fetch, and the peer-review tool files relied solely on the broken central gate.

## Fix

1. **`core/client.py`** — sensitive checks run first; unmatched endpoints default to not-anonymized. Discussion content endpoints (`/entries`, `/view`, `/entry_list`, `/replies`) are matched explicitly.
2. **`core/anonymization.py`** — two recursion gaps that would have made the central pass a silent no-op even with the gate fixed: the discussion `/view` wrapper (`{"view": [...], "participants": [...]}`) and enrollment records' nested `user` dict are now recursed into.
3. **`tests/security/test_anonymization_endpoints.py`** — 35 direct unit tests for the endpoint gate (previously untested — why this survived two weekly sweeps) plus the two new recursion paths.

## Deliberate scope choices

- `/groups` **listings** stay un-anonymized: they carry group names, not student names, and generic anonymization would mangle them. Membership is fetched via `/groups/{id}/users`, covered by the `/users` rule.
- `/discussion_topics` **listings** (incl. announcements) stay un-anonymized: instructor-authored metadata; student content lives under the content endpoints. Both choices match the previous *effective* behavior and are documented in the function docstring.
- The `ENABLE_DATA_ANONYMIZATION=false` inconsistency (tool-layer calls ignore the flag) is out of scope — noted as follow-up in #164.

## Testing

- 35 new tests; 13 failed against the old code, all pass after the fix.
- Full suite: 604 passed, 21 skipped, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)