### PR TITLE
docs: update test count from 328 to 550+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ canvas-mcp/
 │   ├── resources/        # MCP resources and prompts
 │   └── server.py         # FastMCP server entry point
 ├── skills/               # Agent skills for skills.sh (8 skills)
-├── tests/                # 328 tests (pytest + pytest-asyncio)
+├── tests/                # 550+ tests (pytest + pytest-asyncio)
 ├── docs/                 # GitHub Pages site + guides
 ├── tools/                # Tool documentation (README.md, TOOL_MANIFEST.json)
 ├── archive/              # Legacy code (git-ignored)

--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ Quick start guides: [Student](examples/student_quickstart.md) | [Educator](examp
 <details>
 <summary>Technical details</summary>
 
-Built on **FastMCP** with async `httpx`, `pydantic` validation, and `python-dotenv` configuration. Modern `src/` layout with `pyproject.toml`. Full type hints, connection pooling, smart pagination, and rate limiting. 328 tests. `ruff` + `black` for code quality.
+Built on **FastMCP** with async `httpx`, `pydantic` validation, and `python-dotenv` configuration. Modern `src/` layout with `pyproject.toml`. Full type hints, connection pooling, smart pagination, and rate limiting. 550+ tests. `ruff` + `black` for code quality.
 
 </details>
 


### PR DESCRIPTION
Fixes #174

README.md (line ~543) and CLAUDE.md (line ~30) hardcoded "328 tests",
which had drifted from the actual suite size. Verified the real count
via `grep -rE "def test_" tests/ | wc -l` → 557 tests.

Used "550+" wording (as suggested in the issue) so this doesn't go
stale again immediately.