### PR TITLE
fix(security): recursive identity scrub for the anonymizer (#166)

### DIFF
--- a/src/canvas_mcp/core/anonymization.py
+++ b/src/canvas_mcp/core/anonymization.py
@@ -12,6 +12,108 @@ from typing import Any
 # Global anonymization mapping cache
 _anonymization_cache: dict[str, str] = {}
 
+# --------------------------------------------------------------------------
+# Field policy for the recursive identity scrubber (issue #166)
+# --------------------------------------------------------------------------
+
+#: Person-name fields that are unambiguous: whenever one of these keys is
+#: present it holds a human's name/handle, never a file or object label.
+STRICT_IDENTITY_FIELDS = frozenset({
+    'short_name',
+    'sortable_name',
+    'user_name',
+    'author_name',
+    'assessor_name',
+    'grader_name',
+    'email',
+    'login_id',
+})
+
+#: Name fields that are ambiguous — Canvas uses them for courses, groups,
+#: modules, pages and file attachments as well as for people. These are only
+#: rewritten when the containing dict carries a corroborating user signal
+#: (see ``USER_SIGNAL_FIELDS`` / ``USER_CONTAINER_KEYS`` / user-ish id keys).
+AMBIGUOUS_IDENTITY_FIELDS = frozenset({'name', 'display_name'})
+
+#: All identity fields, for callers that just want the union.
+IDENTITY_FIELDS = STRICT_IDENTITY_FIELDS | AMBIGUOUS_IDENTITY_FIELDS
+
+#: Fields that carry direct identifiers / imagery and are nulled outright.
+#: ``pronouns`` lives here rather than in IDENTITY_FIELDS: replacing it with a
+#: pseudonym would be nonsense, dropping the value is the correct behaviour.
+NULL_FIELDS = frozenset({
+    'sis_user_id',
+    'integration_id',
+    'sis_login_id',
+    'avatar_url',
+    'avatar_image_url',
+    'bio',
+    'pronouns',
+})
+
+#: Keys searched, in order, for the id that a record's identity fields are
+#: keyed to. ``id`` is only used when the record itself looks like a user
+#: (otherwise it is an enrollment/comment/submission id and keying to it would
+#: mis-attribute the pseudonym).
+USER_ID_KEYS = ('user_id', 'author_id', 'assessor_id', 'grader_id')
+
+#: Presence of any of these keys corroborates "this dict describes a person".
+USER_SIGNAL_FIELDS = frozenset({
+    'sortable_name',
+    'short_name',
+    'login_id',
+    'email',
+    'sis_user_id',
+    'sis_login_id',
+    'avatar_url',
+    'avatar_image_url',
+    'enrollments',
+})
+
+#: Keys that positively identify a record as NOT a person. Course objects also
+#: carry an ``enrollments`` list, which would otherwise corroborate them as a
+#: user and get the course title rewritten as a student pseudonym.
+NON_USER_MARKER_FIELDS = frozenset({
+    'course_code',
+    'sis_course_id',
+    'enrollment_term_id',
+})
+
+#: Dict keys whose *value* is by convention a user record.
+USER_CONTAINER_KEYS = frozenset({
+    'user',
+    'author',
+    'assessor',
+    'grader',
+    'editor',
+    'submitter',
+    'participant',
+    'student',
+    'observed_user',
+})
+
+#: Free-text fields that get PII regex scrubbing wherever they are found.
+FREE_TEXT_FIELDS = frozenset({'message', 'comment', 'comments', 'body'})
+
+#: data_type values the router knows about. An explicit value outside this set
+#: (e.g. the legacy "test_endpoint" / "general") falls back to duck-typing;
+#: an explicit value *inside* it suppresses duck-typing entirely.
+KNOWN_DATA_TYPES = frozenset({'users', 'discussions', 'submissions', 'assignments'})
+
+_EMAIL_RE = re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b')
+_PHONE_RE = re.compile(r'\b\d{3}[-.]?\d{3}[-.]?\d{4}\b')
+_SSN_RE = re.compile(r'\b\d{3}-\d{2}-\d{4}\b')
+
+
+def scrub_free_text(value: Any) -> Any:
+    """Redact emails, phone numbers and SSNs from a free-text string."""
+    if not isinstance(value, str) or not value:
+        return value
+    value = _SSN_RE.sub('[SSN_REDACTED]', value)
+    value = _EMAIL_RE.sub('[EMAIL_REDACTED]', value)
+    value = _PHONE_RE.sub('[PHONE_REDACTED]', value)
+    return value
+
 
 def generate_anonymous_id(real_id: str | int, prefix: str = "Student") -> str:
     """Generate a consistent anonymous ID for a given real ID.
@@ -42,250 +144,237 @@ def generate_anonymous_id(real_id: str | int, prefix: str = "Student") -> str:
     return anonymous_id
 
 
-def anonymize_user_data(user_data: Any) -> Any:
-    """Anonymize a single user record.
+def _looks_like_user_record(record: dict[str, Any], user_context: bool) -> bool:
+    """Whether `record` describes a person (vs. a course/group/file/module).
+
+    Corroboration is required before rewriting the ambiguous `name` /
+    `display_name` keys, so that non-user objects keep their labels.
+    """
+    if any(field in record for field in NON_USER_MARKER_FIELDS):
+        return False
+    if user_context:
+        return True
+    if any(field in record for field in USER_SIGNAL_FIELDS):
+        return True
+    return any(record.get(key) not in (None, '') for key in USER_ID_KEYS)
+
+
+def _record_identity_id(record: dict[str, Any], user_context: bool) -> Any:
+    """The id the record's identity fields should be pseudonymised against."""
+    for key in USER_ID_KEYS:
+        value = record.get(key)
+        if value not in (None, ''):
+            return value
+    if _looks_like_user_record(record, user_context):
+        own_id = record.get('id')
+        if own_id not in (None, ''):
+            return own_id
+    return None
+
+
+def scrub_identity(node: Any, inherited_id: Any = None, user_context: bool = False) -> Any:
+    """Recursively remove personal identity from an arbitrary Canvas payload.
+
+    This is the *baseline* protection applied to every response the endpoint
+    gate marks as sensitive. It walks lists and dicts uniformly, so identity
+    fields nested at any depth (``enrollments[].sis_user_id``,
+    ``submission_comments[].author.display_name``,
+    ``full_rubric_assessment.assessor_name``) are scrubbed rather than passed
+    through by a top-level-only typed handler (issue #166).
+
+    Invariants:
+    - It NEVER adds a key that was not already present (no fabricated
+      email/login_id/sortable_name on records that never had them).
+    - Identity fields are keyed to the nearest enclosing user id, so the same
+      student maps to the same pseudonym across a response.
+    - It is idempotent: scrubbed output is a fixed point.
 
     Args:
-        user_data: Dictionary containing user information
+        node: Any JSON-ish value (dict, list or primitive).
+        inherited_id: Id of the nearest enclosing user-ish record, used when a
+            nested dict carries a name but no id of its own.
+        user_context: True when the node was reached through a key that is by
+            convention a user record (``user``, ``author``, ``assessor``, ...).
 
     Returns:
-        Anonymized user data with sensitive fields removed/replaced
+        A scrubbed copy of `node`.
+    """
+    if isinstance(node, list):
+        return [scrub_identity(item, inherited_id, user_context) for item in node]
+
+    if not isinstance(node, dict):
+        return node
+
+    looks_user = _looks_like_user_record(node, user_context)
+    identity_id = _record_identity_id(node, user_context)
+    if identity_id in (None, ''):
+        identity_id = inherited_id
+
+    anonymous_id = generate_anonymous_id(identity_id) if identity_id not in (None, '') else None
+
+    scrubbed: dict[str, Any] = {}
+    for key, value in node.items():
+        key_lower = key.lower() if isinstance(key, str) else key
+
+        if key_lower in NULL_FIELDS:
+            scrubbed[key] = None
+            continue
+
+        if key_lower in STRICT_IDENTITY_FIELDS or (
+            key_lower in AMBIGUOUS_IDENTITY_FIELDS and looks_user
+        ):
+            scrubbed[key] = _pseudonymise_field(key_lower, value, anonymous_id)
+            continue
+
+        # Canvas sometimes returns a bare name string where a user object is
+        # expected (e.g. "author": "Bob Smith") — that is an identity value.
+        if key_lower in USER_CONTAINER_KEYS and isinstance(value, str):
+            scrubbed[key] = _pseudonymise_field('name', value, anonymous_id)
+            continue
+
+        if key_lower in FREE_TEXT_FIELDS and isinstance(value, str):
+            scrubbed[key] = scrub_free_text(value)
+            continue
+
+        scrubbed[key] = scrub_identity(
+            value,
+            inherited_id=identity_id,
+            user_context=(key_lower in USER_CONTAINER_KEYS),
+        )
+
+    return scrubbed
+
+
+def _pseudonymise_field(key_lower: str, value: Any, anonymous_id: str | None) -> Any:
+    """Replace one identity field's value, preserving None/empty as-is."""
+    if value is None or value == '':
+        return value
+    if anonymous_id is None:
+        return "[REDACTED]"
+    if key_lower == 'email':
+        return f"{anonymous_id.lower()}@example.edu"
+    if key_lower == 'login_id':
+        return anonymous_id.lower()
+    return anonymous_id
+
+
+def anonymize_user_data(user_data: Any) -> Any:
+    """Anonymize a single user (or user-wrapping) record.
+
+    Thin wrapper over :func:`scrub_identity` kept for API compatibility. The
+    record is treated as user context, so a bare `name` on it is rewritten.
     """
     if not isinstance(user_data, dict):
         return user_data
-
-    anonymized = user_data.copy()
-    user_id = user_data.get('id')
-
-    # Enrollment-shaped records carry the student in a nested `user` dict.
-    # The wrapper itself is NOT a user record — its `id` is the enrollment's
-    # own id, so running the flat-user branch below would fabricate name/email
-    # fields keyed to the wrong id. Anonymize the nested user, scrub the
-    # identity fields Canvas puts on the wrapper, and return.
-    if isinstance(anonymized.get('user'), dict):
-        anonymized['user'] = anonymize_user_data(anonymized['user'])
-        for identity_field in ('sis_user_id', 'integration_id', 'login_id'):
-            if identity_field in anonymized:
-                anonymized[identity_field] = None
-        return anonymized
-
-    # Only treat the record as a flat user if it actually carries user-identity
-    # fields — a bare dict with a truthy `id` (e.g. a flat enrollment or todo
-    # item) would otherwise get name/email fabricated from an unrelated id.
-    looks_like_user = any(
-        field in user_data
-        for field in ('name', 'display_name', 'short_name', 'sortable_name', 'email', 'login_id')
-    )
-
-    if user_id and looks_like_user:
-        anonymous_id = generate_anonymous_id(user_id)
-
-        # Replace sensitive fields
-        anonymized.update({
-            'name': anonymous_id,
-            'display_name': anonymous_id,
-            'short_name': anonymous_id,
-            'sortable_name': anonymous_id,
-            'email': f"{anonymous_id.lower()}@example.edu",
-            'login_id': anonymous_id.lower(),
-            'sis_user_id': None,
-            'integration_id': None,
-            'avatar_url': None,
-            'bio': None,
-            'time_zone': None,
-            'locale': None
-        })
-
-        # Keep essential fields for functionality
-        essential_fields = ['id', 'enrollments', 'role', 'created_at', 'updated_at']
-        for field in list(anonymized.keys()):
-            if field not in essential_fields and field not in ['name', 'email']:
-                if isinstance(anonymized[field], str) and len(anonymized[field]) > 50:
-                    # Remove potentially identifying long text fields
-                    anonymized[field] = "[REDACTED]"
-
-    return anonymized
+    return scrub_identity(user_data, user_context=True)
 
 
 def anonymize_discussion_entry(entry_data: Any) -> Any:
-    """Anonymize a discussion entry.
+    """Anonymize a discussion entry (or the /view wrapper dict).
 
-    Args:
-        entry_data: Dictionary containing discussion entry data
-
-    Returns:
-        Anonymized discussion entry
+    Thin wrapper over :func:`scrub_identity`; nested replies, ``view``,
+    ``new_entries`` and ``participants`` are handled by the uniform recursion.
     """
     if not isinstance(entry_data, dict):
         return entry_data
+    return scrub_identity(entry_data)
 
-    anonymized = entry_data.copy()
-    user_id = entry_data.get('user_id')
 
-    if user_id:
-        anonymous_id = generate_anonymous_id(user_id)
+def _redact_submission_content(submission: dict[str, Any]) -> dict[str, Any]:
+    """Redact submitted content (body/url/attachments) on a submission record."""
+    user_id = submission.get('user_id')
+    if not user_id:
+        return submission
 
-        # Replace all user-identifying fields
-        anonymized['user_name'] = anonymous_id
-        anonymized['display_name'] = anonymous_id
-
-        # Anonymize author field if present
-        if 'author' in anonymized:
-            if isinstance(anonymized['author'], dict):
-                anonymized['author'] = anonymize_user_data(anonymized['author'])
+    anonymous_id = generate_anonymous_id(user_id)
+    redacted = submission.copy()
+    for field in ('body', 'url', 'attachments'):
+        if field in redacted and redacted[field]:
+            if isinstance(redacted[field], str):
+                redacted[field] = f"[CONTENT_REDACTED_FOR_{anonymous_id}]"
             else:
-                anonymized['author'] = anonymous_id
-
-        # Anonymize editor info if present
-        if 'editor' in anonymized:
-            if isinstance(anonymized['editor'], dict):
-                anonymized['editor'] = anonymize_user_data(anonymized['editor'])
-            else:
-                anonymized['editor'] = anonymous_id
-
-    # Keep message content but remove any potentially identifying information
-    if 'message' in anonymized and anonymized['message']:
-        # Remove email addresses from content
-        anonymized['message'] = re.sub(
-            r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b',
-            '[EMAIL_REDACTED]',
-            anonymized['message']
-        )
-
-        # Remove phone numbers
-        anonymized['message'] = re.sub(
-            r'\b\d{3}[-.]?\d{3}[-.]?\d{4}\b',
-            '[PHONE_REDACTED]',
-            anonymized['message']
-        )
-
-        # Remove social security numbers
-        anonymized['message'] = re.sub(
-            r'\b\d{3}-\d{2}-\d{4}\b',
-            '[SSN_REDACTED]',
-            anonymized['message']
-        )
-
-    # Handle nested replies - anonymize recursively
-    for reply_key in ('recent_replies', 'replies'):
-        if reply_key in anonymized and isinstance(anonymized[reply_key], list):
-            anonymized[reply_key] = [
-                anonymize_discussion_entry(reply) for reply in anonymized[reply_key]
-            ]
-
-    # The /discussion_topics/{id}/view endpoint returns a wrapper dict:
-    # {"view": [entries...], "participants": [users...]} plus "new_entries"
-    # when include_new_entries=1 — recurse into all of them
-    for entry_list_key in ('view', 'new_entries'):
-        if entry_list_key in anonymized and isinstance(anonymized[entry_list_key], list):
-            anonymized[entry_list_key] = [
-                anonymize_discussion_entry(entry) for entry in anonymized[entry_list_key]
-            ]
-    if 'participants' in anonymized and isinstance(anonymized['participants'], list):
-        anonymized['participants'] = [
-            anonymize_user_data(participant) for participant in anonymized['participants']
-        ]
-
-    return anonymized
+                redacted[field] = "[CONTENT_REDACTED]"
+    return redacted
 
 
 def anonymize_submission_data(submission_data: Any) -> Any:
-    """Anonymize submission data.
-
-    Args:
-        submission_data: Dictionary containing submission information
-
-    Returns:
-        Anonymized submission data
-    """
+    """Anonymize submission data (identity scrub + submitted-content redaction)."""
     if not isinstance(submission_data, dict):
         return submission_data
+    return _redact_submission_content(scrub_identity(submission_data))
 
-    anonymized = submission_data.copy()
-    user_id = submission_data.get('user_id')
 
-    if user_id:
-        anonymous_id = generate_anonymous_id(user_id)
-
-        # Replace identifying fields
-        if 'user' in anonymized:
-            anonymized['user'] = anonymize_user_data(anonymized['user'])
-
-        # Remove submission content that might be identifying
-        identifying_fields = ['body', 'url', 'attachments']
-        for field in identifying_fields:
-            if field in anonymized and anonymized[field]:
-                if isinstance(anonymized[field], str):
-                    anonymized[field] = f"[CONTENT_REDACTED_FOR_{anonymous_id}]"
-                else:
-                    anonymized[field] = "[CONTENT_REDACTED]"
-
-    return anonymized
+def _truncate_long_description(assignment: dict[str, Any]) -> dict[str, Any]:
+    """Truncate very long assignment descriptions that may embed student info."""
+    description = assignment.get('description')
+    if isinstance(description, str) and len(description) > 1000:
+        truncated = assignment.copy()
+        truncated['description'] = "[LONG_DESCRIPTION_REDACTED_FOR_PRIVACY]"
+        return truncated
+    return assignment
 
 
 def anonymize_assignment_data(assignment_data: Any) -> Any:
-    """Anonymize assignment data (keep assignment details, remove student-specific info).
-
-    Args:
-        assignment_data: Dictionary containing assignment information
-
-    Returns:
-        Anonymized assignment data
-    """
+    """Anonymize assignment data (keep assignment details, drop student info)."""
     if not isinstance(assignment_data, dict):
         return assignment_data
+    return _truncate_long_description(scrub_identity(assignment_data))
 
-    # For assignments, we typically keep the assignment details
-    # but remove any embedded user-specific information
-    anonymized = assignment_data.copy()
 
-    # Remove potentially identifying description content
-    if 'description' in anonymized and anonymized['description']:
-        # Keep structure but indicate redaction for very long descriptions
-        if len(anonymized['description']) > 1000:
-            anonymized['description'] = "[LONG_DESCRIPTION_REDACTED_FOR_PRIVACY]"
+def _resolve_record_type(record: dict[str, Any], data_type: str) -> str:
+    """Resolve which typed refinement applies to `record`.
 
-    return anonymized
+    An explicit, known `data_type` always wins — duck-typing is only consulted
+    when the caller did not state a type. This stops e.g. an assignment record
+    that happens to carry a `message` key from being treated as a discussion
+    entry, or a course record's `name` from being rewritten as a student's.
+    """
+    if data_type in KNOWN_DATA_TYPES:
+        return data_type
+    if 'submitted_at' in record:
+        return 'submissions'
+    if 'due_at' in record:
+        return 'assignments'
+    if 'message' in record:
+        return 'discussions'
+    return 'general'
+
+
+def _apply_type_refinements(data: Any, data_type: str) -> Any:
+    """Apply the record-level refinements layered on top of the identity scrub."""
+    if isinstance(data, list):
+        return [_apply_type_refinements(item, data_type) for item in data]
+    if not isinstance(data, dict):
+        return data
+
+    resolved = _resolve_record_type(data, data_type)
+    if resolved == 'submissions':
+        return _redact_submission_content(data)
+    if resolved == 'assignments':
+        return _truncate_long_description(data)
+    return data
 
 
 def anonymize_response_data(data: Any, data_type: str = "general") -> Any:
     """Main function to anonymize Canvas API response data.
 
+    Two passes, in order:
+
+    1. :func:`scrub_identity` — the recursive baseline. Runs on every payload
+       regardless of shape or `data_type`, so unknown/nested shapes still get
+       identity protection (fail-closed).
+    2. Typed refinements — submitted-content redaction for submissions and
+       long-description truncation for assignments, applied per record.
+
     Args:
         data: The data to anonymize (can be dict, list, or other types)
-        data_type: Type of data being anonymized for specific handling
+        data_type: Type of data being anonymized for specific handling. Values
+            outside :data:`KNOWN_DATA_TYPES` fall back to duck-typing.
 
     Returns:
         Anonymized data structure
     """
-    if isinstance(data, dict):
-        if data_type == "users" or 'name' in data and 'email' in data:
-            return anonymize_user_data(data)
-        elif data_type == "discussions" or 'message' in data:
-            return anonymize_discussion_entry(data)
-        elif data_type == "submissions" or 'submitted_at' in data:
-            return anonymize_submission_data(data)
-        elif data_type == "assignments" or 'due_at' in data:
-            return anonymize_assignment_data(data)
-        else:
-            # Generic anonymization
-            anonymized = {}
-            for key, value in data.items():
-                if key.lower() in ['name', 'email', 'login_id', 'sis_user_id']:
-                    if 'id' in data:
-                        anonymized[key] = generate_anonymous_id(data['id'])
-                    else:
-                        anonymized[key] = "[REDACTED]"
-                else:
-                    anonymized[key] = anonymize_response_data(value, data_type)
-            return anonymized
-
-    elif isinstance(data, list):
-        return [anonymize_response_data(item, data_type) for item in data]
-
-    else:
-        # For primitive types, return as-is
-        return data
+    return _apply_type_refinements(scrub_identity(data), data_type)
 
 
 def create_anonymization_summary(original_count: int, anonymized_count: int, data_type: str) -> str:

--- a/src/canvas_mcp/core/anonymization.py
+++ b/src/canvas_mcp/core/anonymization.py
@@ -59,6 +59,18 @@ USER_ONLY_NULL_FIELDS = frozenset({
     'locale',
 })
 
+
+def _is_avatar_field(key_lower: str) -> bool:
+    """Whether a key names an avatar image reference in any Canvas variant.
+
+    Canvas scatters avatar URLs under many names (``avatar_url``,
+    ``avatar_image_url``, ``assessor_avatar_url``, ``avatar_path``); suffix
+    matching catches the variants an explicit list would miss.
+    """
+    return 'avatar' in key_lower and (
+        key_lower.endswith('url') or key_lower.endswith('path')
+    )
+
 #: Keys searched, in order, for the id that a record's identity fields are
 #: keyed to. ``id`` is only used when the record itself looks like a user
 #: (otherwise it is an enrollment/comment/submission id and keying to it would
@@ -224,8 +236,10 @@ def scrub_identity(node: Any, inherited_id: Any = None, user_context: bool = Fal
     for key, value in node.items():
         key_lower = key.lower() if isinstance(key, str) else key
 
-        if key_lower in NULL_FIELDS or (
-            key_lower in USER_ONLY_NULL_FIELDS and looks_user
+        if (
+            key_lower in NULL_FIELDS
+            or (isinstance(key_lower, str) and _is_avatar_field(key_lower))
+            or (key_lower in USER_ONLY_NULL_FIELDS and looks_user)
         ):
             scrubbed[key] = None
             continue

--- a/src/canvas_mcp/core/anonymization.py
+++ b/src/canvas_mcp/core/anonymization.py
@@ -51,6 +51,14 @@ NULL_FIELDS = frozenset({
     'pronouns',
 })
 
+#: Profile fields nulled only on records that look like a person. Courses and
+#: terms also carry ``time_zone`` (and could carry ``locale``), where the value
+#: is institutional, not personal — nulling it there would be over-reach.
+USER_ONLY_NULL_FIELDS = frozenset({
+    'time_zone',
+    'locale',
+})
+
 #: Keys searched, in order, for the id that a record's identity fields are
 #: keyed to. ``id`` is only used when the record itself looks like a user
 #: (otherwise it is an enrollment/comment/submission id and keying to it would
@@ -216,7 +224,9 @@ def scrub_identity(node: Any, inherited_id: Any = None, user_context: bool = Fal
     for key, value in node.items():
         key_lower = key.lower() if isinstance(key, str) else key
 
-        if key_lower in NULL_FIELDS:
+        if key_lower in NULL_FIELDS or (
+            key_lower in USER_ONLY_NULL_FIELDS and looks_user
+        ):
             scrubbed[key] = None
             continue
 

--- a/src/canvas_mcp/core/client.py
+++ b/src/canvas_mcp/core/client.py
@@ -69,24 +69,68 @@ def _get_request_semaphore() -> asyncio.Semaphore:
     return _request_semaphore
 
 
-def _determine_data_type(endpoint: str) -> str:
-    """Determine the type of data based on the API endpoint."""
-    endpoint_lower = endpoint.lower()
+def _path_segments(endpoint: str) -> list[str]:
+    """Lower-cased, query-stripped path segments of a Canvas API endpoint."""
+    path = endpoint.lower().split('?', 1)[0]
+    return [seg for seg in path.split('/') if seg]
 
-    if '/users' in endpoint_lower:
+
+def _is_route_segment(segments: list[str], index: int) -> bool:
+    """Whether segments[index] is a route keyword rather than a user slug.
+
+    A segment directly after 'pages' is a user-controlled page slug — e.g. a
+    page named "users" at /courses/{id}/pages/users — and must never be treated
+    as a route keyword.
+    """
+    return not (index > 0 and segments[index - 1] == 'pages')
+
+
+def _has_route_segment(segments: list[str], names: set[str]) -> bool:
+    """Whether any route (non-slug) segment matches one of `names`."""
+    return any(
+        seg in names and _is_route_segment(segments, i)
+        for i, seg in enumerate(segments)
+    )
+
+
+def _self_submission_indices(segments: list[str]) -> set[int]:
+    """Indices of 'submissions' route segments followed by the literal 'self'.
+
+    Anchored on the literal 'self' segment IMMEDIATELY after a 'submissions'
+    route segment. A looser match (e.g. 'self' anywhere in the path) would
+    recreate the #164 bypass class, where a broad short-circuit silently
+    disabled anonymization for unrelated student-data endpoints.
+    """
+    return {
+        i
+        for i, seg in enumerate(segments)
+        if seg == 'submissions'
+        and _is_route_segment(segments, i)
+        and i + 1 < len(segments)
+        and segments[i + 1] == 'self'
+    }
+
+
+def _determine_data_type(endpoint: str) -> str:
+    """Determine the type of data based on the API endpoint.
+
+    Segment-aware (query string stripped, page slugs excluded) so that a
+    substring match on a user-controlled slug cannot mis-route a response into
+    the wrong typed handler.
+    """
+    segments = _path_segments(endpoint)
+
+    if _has_route_segment(segments, {'users'}):
         return 'users'
-    elif '/discussion_topics' in endpoint_lower and '/entries' in endpoint_lower:
+    if _has_route_segment(segments, {'discussion_topics', 'discussion_entries'}):
         return 'discussions'
-    elif '/discussion' in endpoint_lower:
-        return 'discussions'
-    elif '/submissions' in endpoint_lower:
+    if _has_route_segment(segments, {'submissions'}):
         return 'submissions'
-    elif '/assignments' in endpoint_lower:
+    if _has_route_segment(segments, {'assignments'}):
         return 'assignments'
-    elif '/enrollments' in endpoint_lower:
+    if _has_route_segment(segments, {'enrollments'}):
         return 'users'  # Enrollments contain user data
-    else:
-        return 'general'
+    return 'general'
 
 
 def _should_anonymize_endpoint(endpoint: str) -> bool:
@@ -104,27 +148,27 @@ def _should_anonymize_endpoint(endpoint: str) -> bool:
     - /discussion_topics listings (incl. announcements) — typically
       instructor-authored; student content lives under the content endpoints
       matched below.
+    - /submissions/self — the caller's OWN submission. Anonymizing it redacts
+      body/url/attachments, so a student cannot read back what they submitted
+      (issue #166). Only the literal 'self' sub-route is excluded; any other
+      sensitive segment in the same path still forces anonymization.
     """
-    # Match whole path segments (not substrings) so user-controlled slugs —
-    # e.g. a page named "users" at /courses/{id}/pages/users — can't trip the
-    # sensitive match; a segment directly after 'pages' is a slug, not a route.
-    path = endpoint.lower().split('?', 1)[0]
-    segments = [seg for seg in path.split('/') if seg]
+    segments = _path_segments(endpoint)
 
-    def has_sensitive_segment(names: set[str]) -> bool:
-        return any(
-            seg in names and not (i > 0 and segments[i - 1] == 'pages')
-            for i, seg in enumerate(segments)
-        )
+    # Drop only the 'submissions' segment of a /submissions/self route; every
+    # other sensitive segment keeps its effect.
+    self_indices = _self_submission_indices(segments)
+    if self_indices:
+        segments = [seg for i, seg in enumerate(segments) if i not in self_indices]
 
     # Discussion content endpoints carry student posts and names
-    if 'discussion_topics' in segments and has_sensitive_segment(
-        {'entries', 'view', 'entry_list', 'replies'}
+    if 'discussion_topics' in segments and _has_route_segment(
+        segments, {'entries', 'view', 'entry_list', 'replies'}
     ):
         return True
 
     # Endpoints whose responses contain student records
-    return has_sensitive_segment({'users', 'submissions', 'enrollments', 'analytics'})
+    return _has_route_segment(segments, {'users', 'submissions', 'enrollments', 'analytics'})
 
 
 def _get_http_client() -> httpx.AsyncClient:

--- a/tests/security/test_anonymization_shapes.py
+++ b/tests/security/test_anonymization_shapes.py
@@ -402,3 +402,31 @@ class TestSelfSubmissionEndpoint:
         ) is False
         redacted = anonymize_response_data(submission, data_type="submissions")
         assert redacted["body"].startswith("[CONTENT_REDACTED")
+
+
+class TestUserOnlyNullFields:
+    """time_zone/locale are personal on user records, institutional elsewhere
+    (codex review P2: the old anonymize_user_data nulled both on users)."""
+
+    def test_user_time_zone_and_locale_nulled(self):
+        user = {
+            "id": 101,
+            "name": "Jane Doe",
+            "sortable_name": "Doe, Jane",
+            "time_zone": "America/Chicago",
+            "locale": "en",
+        }
+        result = anonymize_response_data(user, data_type="users")
+        assert result["time_zone"] is None
+        assert result["locale"] is None
+
+    def test_course_time_zone_preserved(self):
+        course = {
+            "id": 12,
+            "name": "BADM 350 Fall 2026",
+            "course_code": "BADM350",
+            "time_zone": "America/Chicago",
+        }
+        result = anonymize_response_data(course, data_type="general")
+        assert result["time_zone"] == "America/Chicago"
+        assert result["name"] == "BADM 350 Fall 2026"

--- a/tests/security/test_anonymization_shapes.py
+++ b/tests/security/test_anonymization_shapes.py
@@ -430,3 +430,21 @@ class TestUserOnlyNullFields:
         result = anonymize_response_data(course, data_type="general")
         assert result["time_zone"] == "America/Chicago"
         assert result["name"] == "BADM 350 Fall 2026"
+
+
+class TestAvatarSuffixMatching:
+    """Live replay found avatar URLs surviving under variant key names
+    (assessor_avatar_url, avatar_path) not covered by the explicit list."""
+
+    @pytest.mark.parametrize("key", [
+        "avatar_url", "avatar_image_url", "assessor_avatar_url", "avatar_path",
+    ])
+    def test_avatar_variant_nulled(self, key):
+        record = {"id": 101, "user_id": 101, key: "https://canvas/avatars/101"}
+        result = anonymize_response_data(record, data_type="submissions")
+        assert result[key] is None
+
+    def test_non_avatar_url_preserved(self):
+        record = {"id": 5, "html_url": "https://canvas/courses/1/users/101"}
+        result = anonymize_response_data(record, data_type="general")
+        assert result["html_url"] == "https://canvas/courses/1/users/101"

--- a/tests/security/test_anonymization_shapes.py
+++ b/tests/security/test_anonymization_shapes.py
@@ -1,0 +1,404 @@
+"""
+Anonymizer shape/recursion tests (issue #166).
+
+Follow-up to #164. The endpoint gate was fixed there, but the anonymizer
+itself was a single-shot exclusive router: exactly one typed handler ran per
+payload, each handler only touched top-level fields, and none of them
+recursed. Nested identity fields therefore reached the model verbatim.
+
+These tests pin the three live leaks, the fabrication/mis-route defects, and
+the structural invariants of the recursive scrubber:
+
+- no identity sentinel survives anywhere in the serialized output
+- anonymization never ADDS a key that was not in the input
+- non-user objects keep their names (course/group/module labels)
+- an explicit data_type suppresses duck-typed handlers
+- unknown shapes on sensitive endpoints still get scrubbed (fail-closed)
+- f(f(x)) == f(x)
+- /submissions/self is readable by its owner; /submissions/{id} is not
+"""
+
+import json
+
+import pytest
+
+from canvas_mcp.core.anonymization import (
+    anonymize_response_data,
+    scrub_identity,
+)
+from canvas_mcp.core.client import _determine_data_type, _should_anonymize_endpoint
+
+# Sentinels that must never survive anonymization, in any nesting position.
+SENTINELS = (
+    "jdoe2",
+    "Bob Smith",
+    "Alice Example",
+    "@illinois.edu",
+    "670001234",
+    "Doe, John",
+)
+
+
+def assert_no_pii(payload) -> None:
+    """No identity sentinel may appear anywhere in the serialized output."""
+    blob = json.dumps(payload)
+    for sentinel in SENTINELS:
+        assert sentinel not in blob, f"PII leaked: {sentinel!r} survived in {blob}"
+
+
+def collect_key_sets(node, path="$"):
+    """Flatten a payload into {path: frozenset(keys)} for key-set comparison."""
+    found = {}
+    if isinstance(node, dict):
+        found[path] = frozenset(node.keys())
+        for key, value in node.items():
+            found.update(collect_key_sets(value, f"{path}.{key}"))
+    elif isinstance(node, list):
+        for index, item in enumerate(node):
+            found.update(collect_key_sets(item, f"{path}[{index}]"))
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Fixtures modelled on real Canvas responses
+# ---------------------------------------------------------------------------
+
+def users_with_enrollments():
+    """GET /courses/{id}/users?include[]=enrollments&include[]=email
+
+    admin_tools.list_users requests exactly this. Pre-#166 the top-level
+    sis_user_id was nulled but enrollments[].sis_user_id and the nested
+    enrollments[].user survived verbatim.
+    """
+    return [
+        {
+            "id": 101,
+            "name": "John Doe",
+            "sortable_name": "Doe, John",
+            "short_name": "John",
+            "login_id": "jdoe2",
+            "email": "jdoe2@illinois.edu",
+            "sis_user_id": "670001234",
+            "avatar_url": "https://canvas.example.edu/images/jdoe2.png",
+            "enrollments": [
+                {
+                    "id": 9001,
+                    "user_id": 101,
+                    "course_id": 55,
+                    "type": "StudentEnrollment",
+                    "sis_user_id": "670001234",
+                    "html_url": "https://canvas.example.edu/courses/55/users/101",
+                    "user": {
+                        "id": 101,
+                        "name": "John Doe",
+                        "login_id": "jdoe2",
+                    },
+                }
+            ],
+        }
+    ]
+
+
+def submissions_with_comments():
+    """GET .../submissions?include[]=submission_comments (list_peer_reviews)."""
+    return [
+        {
+            "id": 7001,
+            "user_id": 101,
+            "assignment_id": 42,
+            "submitted_at": "2026-03-01T12:00:00Z",
+            "body": "My essay, by John Doe",
+            "submission_comments": [
+                {
+                    "id": 3001,
+                    "author_id": 202,
+                    "author_name": "Bob Smith",
+                    "comment": "Nice work! Ping me at bob@illinois.edu or 217-555-0134.",
+                    "avatar_path": "/images/thumbnails/bob.png",
+                    "author": {
+                        "id": 202,
+                        "display_name": "Bob Smith",
+                        "avatar_image_url": "https://canvas.example.edu/bob.png",
+                        "html_url": "https://canvas.example.edu/courses/55/users/202",
+                    },
+                }
+            ],
+        }
+    ]
+
+
+def rubric_assessment_submission():
+    """GET .../submissions/{user_id}?include[]=full_rubric_assessment."""
+    return {
+        "id": 7002,
+        "user_id": 101,
+        "submitted_at": "2026-03-01T12:00:00Z",
+        "full_rubric_assessment": {
+            "id": 5001,
+            "assessor_id": 202,
+            "assessor_name": "Bob Smith",
+            "assessment_type": "peer_review",
+            "assessor": {
+                "id": 202,
+                "display_name": "Bob Smith",
+                "avatar_image_url": "https://canvas.example.edu/bob.png",
+            },
+            "data": [
+                {
+                    "criterion_id": "_1234",
+                    "points": 4,
+                    "comments": "Great thesis - reach me at bob@illinois.edu",
+                }
+            ],
+        },
+    }
+
+
+ALL_FIXTURES = {
+    "users_with_enrollments": users_with_enrollments,
+    "submissions_with_comments": submissions_with_comments,
+    "rubric_assessment_submission": rubric_assessment_submission,
+}
+
+
+# ---------------------------------------------------------------------------
+# Live leak regressions
+# ---------------------------------------------------------------------------
+
+class TestNestedLeaks:
+
+    def test_enrollment_nested_identity_scrubbed(self):
+        result = anonymize_response_data(users_with_enrollments(), data_type="users")
+        assert_no_pii(result)
+
+        user = result[0]
+        enrollment = user["enrollments"][0]
+        assert enrollment["sis_user_id"] is None
+        assert enrollment["user"]["name"].startswith("Student_")
+        assert enrollment["user"]["login_id"] == user["login_id"]
+        # IDs are preserved for functionality
+        assert user["id"] == 101
+        assert enrollment["user"]["id"] == 101
+        assert enrollment["type"] == "StudentEnrollment"
+
+    def test_submission_comment_authors_scrubbed(self):
+        result = anonymize_response_data(submissions_with_comments(), data_type="submissions")
+        assert_no_pii(result)
+
+        comment = result[0]["submission_comments"][0]
+        assert comment["author_name"].startswith("Student_")
+        assert comment["author"]["display_name"] == comment["author_name"]
+        assert comment["author"]["avatar_image_url"] is None
+        assert "[EMAIL_REDACTED]" in comment["comment"]
+        assert "[PHONE_REDACTED]" in comment["comment"]
+        # Author id preserved so peer-review analytics still work
+        assert comment["author_id"] == 202
+
+    def test_full_rubric_assessment_scrubbed(self):
+        result = anonymize_response_data(
+            rubric_assessment_submission(), data_type="submissions"
+        )
+        assert_no_pii(result)
+
+        assessment = result["full_rubric_assessment"]
+        assert assessment["assessor_name"].startswith("Student_")
+        assert assessment["assessor"]["display_name"] == assessment["assessor_name"]
+        assert "[EMAIL_REDACTED]" in assessment["data"][0]["comments"]
+        assert assessment["data"][0]["points"] == 4
+
+    def test_submitter_and_reviewer_get_different_pseudonyms(self):
+        result = anonymize_response_data(submissions_with_comments(), data_type="submissions")
+        from canvas_mcp.core.anonymization import generate_anonymous_id
+        assert result[0]["submission_comments"][0]["author_name"] == generate_anonymous_id(202)
+        assert generate_anonymous_id(202) != generate_anonymous_id(101)
+
+
+# ---------------------------------------------------------------------------
+# Structural invariants
+# ---------------------------------------------------------------------------
+
+class TestKeySetInvariant:
+    """Anonymization may remove information, never invent it."""
+
+    @pytest.mark.parametrize("name", sorted(ALL_FIXTURES))
+    def test_no_keys_added(self, name):
+        original = ALL_FIXTURES[name]()
+        result = anonymize_response_data(original, data_type="submissions")
+        before = collect_key_sets(ALL_FIXTURES[name]())
+        after = collect_key_sets(result)
+        assert set(after) == set(before)
+        for path, keys in before.items():
+            assert after[path] == keys, f"key set changed at {path}"
+
+    def test_minimal_user_gains_no_fabricated_fields(self):
+        record = {"id": 101, "name": "John Doe", "login_id": "jdoe2"}
+        result = scrub_identity(record)
+        assert set(result.keys()) == {"id", "name", "login_id"}
+        assert "email" not in result
+        assert "sortable_name" not in result
+
+
+class TestNonUserObjectsPreserved:
+    """The bare-`name` fabrication defect: id + name is not enough."""
+
+    def test_bare_name_without_user_signal_preserved(self):
+        group = {"id": 77, "name": "Project Teams", "members_count": 4}
+        result = scrub_identity(group)
+        assert result["name"] == "Project Teams"
+        assert result["members_count"] == 4
+
+    def test_course_name_not_rewritten(self):
+        course = {"id": 55, "name": "BADM 350 Fall 2026", "course_code": "BADM350"}
+        result = anonymize_response_data(course, data_type="users")
+        assert result["name"] == "BADM 350 Fall 2026"
+
+    def test_course_with_enrollments_not_treated_as_user(self):
+        """Course objects carry an `enrollments` list too — that must not
+        corroborate them as a person and rewrite the course title."""
+        course = {
+            "id": 55,
+            "name": "BADM 350 Fall 2026",
+            "course_code": "BADM350",
+            "enrollments": [{"type": "teacher", "role": "TeacherEnrollment"}],
+        }
+        result = anonymize_response_data(course, data_type="users")
+        assert result["name"] == "BADM 350 Fall 2026"
+
+    def test_attachment_display_name_preserved(self):
+        submission = {
+            "id": 7003,
+            "user_id": 101,
+            "attachments": [{"id": 88, "display_name": "essay.pdf", "size": 1024}],
+        }
+        # scrub_identity alone (no submission content redaction) must leave the
+        # filename intact — it is not a person's name.
+        result = scrub_identity(submission)
+        assert result["attachments"][0]["display_name"] == "essay.pdf"
+
+
+class TestDataTypeRouting:
+
+    def test_explicit_data_type_suppresses_duck_typing(self):
+        """An assignment carrying a `message` key must not be treated as a
+        discussion, and its long description must still be truncated."""
+        assignment = {
+            "id": 42,
+            "name": "Reflection Essay",
+            "due_at": "2026-03-01T23:59:00Z",
+            "message": "See instructions",
+            "description": "x" * 1200,
+        }
+        result = anonymize_response_data(assignment, data_type="assignments")
+        assert result["description"] == "[LONG_DESCRIPTION_REDACTED_FOR_PRIVACY]"
+        assert result["name"] == "Reflection Essay"
+
+    def test_explicit_users_type_does_not_redact_submission_content(self):
+        record = {"id": 1, "user_id": 101, "submitted_at": "2026-03-01T00:00:00Z", "body": "hello"}
+        result = anonymize_response_data(record, data_type="users")
+        assert result["body"] == "hello"
+
+    def test_unknown_data_type_falls_back_to_duck_typing(self):
+        record = {"id": 1, "user_id": 101, "submitted_at": "2026-03-01T00:00:00Z", "body": "hello"}
+        result = anonymize_response_data(record, data_type="general")
+        assert result["body"].startswith("[CONTENT_REDACTED")
+
+    def test_data_type_detection_is_segment_aware(self):
+        assert _determine_data_type("/courses/1/assignments/2/submissions") == "submissions"
+        assert _determine_data_type("/courses/1/assignments/2/submissions?include[]=user") == "submissions"
+        assert _determine_data_type("/courses/1/pages/submissions") == "general"
+        assert _determine_data_type("/courses/1/pages/users") == "general"
+        assert _determine_data_type("/courses/1/assignments") == "assignments"
+
+
+class TestFailClosed:
+    """An unrecognized shape on a sensitive endpoint still gets scrubbed."""
+
+    def test_unknown_shape_still_identity_scrubbed(self):
+        payload = {
+            "meta": {"page": 1},
+            "records": [
+                {
+                    "wrapper_id": 9,
+                    "person": {
+                        "id": 101,
+                        "sortable_name": "Doe, John",
+                        "email": "jdoe2@illinois.edu",
+                        "sis_user_id": "670001234",
+                    },
+                }
+            ],
+        }
+        result = anonymize_response_data(payload, data_type="something_new")
+        assert_no_pii(result)
+        assert result["meta"]["page"] == 1
+
+    def test_deeply_nested_identity_scrubbed(self):
+        payload = {"a": {"b": {"c": [{"user": {"id": 101, "name": "Alice Example",
+                                               "login_id": "jdoe2"}}]}}}
+        result = anonymize_response_data(payload)
+        assert_no_pii(result)
+
+
+class TestIdempotence:
+
+    @pytest.mark.parametrize("name", sorted(ALL_FIXTURES))
+    @pytest.mark.parametrize("data_type", ["users", "submissions", "discussions", "general"])
+    def test_double_application_is_stable(self, name, data_type):
+        once = anonymize_response_data(ALL_FIXTURES[name](), data_type=data_type)
+        twice = anonymize_response_data(once, data_type=data_type)
+        assert twice == once
+
+    def test_tool_layer_double_anonymization_is_stable(self):
+        """Tool modules call anonymize_response_data() on data the client layer
+        already anonymized. That double pass must be a no-op."""
+        client_pass = anonymize_response_data(users_with_enrollments(), data_type="users")
+        tool_pass = anonymize_response_data(client_pass, data_type="users")
+        assert tool_pass == client_pass
+        assert_no_pii(tool_pass)
+
+
+# ---------------------------------------------------------------------------
+# Self-submission carve-out
+# ---------------------------------------------------------------------------
+
+class TestSelfSubmissionEndpoint:
+
+    @pytest.mark.parametrize("endpoint", [
+        "/courses/123/assignments/456/submissions/self",
+        "/courses/123/assignments/456/submissions/self?include[]=submission_comments",
+        "/sections/45/assignments/456/submissions/self",
+    ])
+    def test_self_submission_not_anonymized(self, endpoint):
+        assert _should_anonymize_endpoint(endpoint) is False
+
+    @pytest.mark.parametrize("endpoint", [
+        "/courses/123/assignments/456/submissions/123",
+        "/courses/123/assignments/456/submissions",
+        "/courses/123/assignments/456/submissions/selfie",
+        "/courses/123/assignments/456/submissions/self_review",
+        "/courses/123/students/submissions",
+    ])
+    def test_other_submission_endpoints_still_anonymized(self, endpoint):
+        assert _should_anonymize_endpoint(endpoint) is True
+
+    def test_self_carveout_does_not_disable_other_sensitive_segments(self):
+        # A path that also touches /users must still anonymize.
+        assert _should_anonymize_endpoint(
+            "/courses/123/users/9/assignments/456/submissions/self"
+        ) is True
+
+    def test_self_submission_content_preserved_end_to_end(self):
+        """The gate is the only thing standing between a student and their own
+        submitted text — assert the anonymizer would otherwise redact it."""
+        submission = {
+            "id": 7004,
+            "user_id": 101,
+            "submitted_at": "2026-03-01T12:00:00Z",
+            "body": "My own essay text",
+            "url": "https://example.com/my-work",
+        }
+        assert _should_anonymize_endpoint(
+            "/courses/1/assignments/2/submissions/self"
+        ) is False
+        redacted = anonymize_response_data(submission, data_type="submissions")
+        assert redacted["body"].startswith("[CONTENT_REDACTED")


### PR DESCRIPTION
Rewrites the anonymizer's routing so a recursive identity scrub runs as the baseline on every sensitive payload, with the typed handlers demoted to additive refinements. Fixes the data_type heuristic issues tracked in #166 (fabricated fields, mis-routed dicts) plus related handler coverage gaps found during investigation.

Key properties:
- Anonymization never adds a key that was not present in the input (key-set invariant, tested)
- `name`/`display_name` are only rewritten with a corroborating user signal, so course/group/module labels survive
- Segment-aware, query-stripped endpoint matching for `_determine_data_type` (mirrors the #165 gate fix)
- `/submissions/self` excluded from anonymization (a student can read their own submission again), anchored on the literal `self` segment with regression tests against the #164 bypass class
- `time_zone`/`locale` nulled on person records only; avatar-URL variants nulled via suffix match

Verification:
- Full suite: 658 passed, 21 skipped (+48 new tests in `tests/security/test_anonymization_shapes.py`)
- Existing `test_anonymization_endpoints.py` (41) and `test_ferpa_compliance.py` green, unchanged
- Codex review clean (one P2 raised and fixed in-branch)
- Acceptance replay against live Canvas data from a real course (11 endpoints): PASS — every changed output field classified as an intended scrub, zero over-reach, idempotent, stable pseudonyms

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)