### PR TITLE
fix(security): safer defaults — code exec opt-in, image anonymization on

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,11 @@ RUN adduser --disabled-password --gecos '' mcp && \
 # callers supply their own token per request via the X-Canvas-Token header.
 # Code execution (execute_typescript) ships OFF by default for this network-facing
 # image; opt in with -e EXECUTE_TYPESCRIPT_ENABLED=true only behind real auth.
+# Anonymization ships ON — institutional deployments must opt OUT deliberately
+# (set -e ENABLE_DATA_ANONYMIZATION=false) after their own privacy review.
 # Example (stdio/local): docker run -e CANVAS_API_TOKEN=xyz -e CANVAS_API_URL=https://... canvas-mcp
 ENV MCP_SERVER_NAME="canvas-mcp" \
-    ENABLE_DATA_ANONYMIZATION="false" \
+    ENABLE_DATA_ANONYMIZATION="true" \
     ANONYMIZATION_DEBUG="false" \
     EXECUTE_TYPESCRIPT_ENABLED="false"
 

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -147,9 +147,11 @@ class Config:
         self.ts_sandbox_timeout_sec = _int_env("TS_SANDBOX_TIMEOUT_SEC", 120)
         self.ts_sandbox_container_image = os.getenv("TS_SANDBOX_CONTAINER_IMAGE", "node:20-alpine")
 
-        # Code execution kill switch — set EXECUTE_TYPESCRIPT_ENABLED=false to
-        # disable the execute_typescript tool without changing CANVAS_ROLE.
-        self.execute_typescript_enabled = _bool_env("EXECUTE_TYPESCRIPT_ENABLED", True)
+        # Code execution is opt-in — set EXECUTE_TYPESCRIPT_ENABLED=true to
+        # enable the execute_typescript tool (independent of CANVAS_ROLE).
+        # Off by default: arbitrary code execution should be a deliberate
+        # operator choice, not something a default install exposes (#157).
+        self.execute_typescript_enabled = _bool_env("EXECUTE_TYPESCRIPT_ENABLED", False)
 
         # HTTP access-key gate (v1, multi-user). Comma- or whitespace-separated
         # list of accepted keys; an HTTP caller must present a matching

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -156,3 +156,17 @@ def test_config_normalizes_canvas_api_url(monkeypatch):
     monkeypatch.setenv("CANVAS_API_URL", "https://canvas.school.edu")
     config_module.reset_config()
     assert config_module.get_config().canvas_api_url == "https://canvas.school.edu/api/v1"
+
+
+def test_execute_typescript_disabled_by_default(monkeypatch):
+    """Code execution is opt-in (#157): a default install must not expose it."""
+    monkeypatch.delenv("EXECUTE_TYPESCRIPT_ENABLED", raising=False)
+    config_module.reset_config()
+    assert config_module.get_config().execute_typescript_enabled is False
+
+
+def test_anonymization_enabled_by_default(monkeypatch):
+    """FERPA anonymization is opt-out, never opt-in."""
+    monkeypatch.delenv("ENABLE_DATA_ANONYMIZATION", raising=False)
+    config_module.reset_config()
+    assert config_module.get_config().enable_data_anonymization is True


### PR DESCRIPTION
Flips two defaults ahead of sharing the hosted deployment spec with peer institutions:

1. `EXECUTE_TYPESCRIPT_ENABLED` defaults to **false** (was true for stdio). Code execution becomes a deliberate opt-in per #157's hardening direction; existing users who rely on it set one env var.
2. The Docker image ships `ENABLE_DATA_ANONYMIZATION=true` (was false), matching the code default — the FERPA layer should be opt-out, not opt-in, for anyone deploying from the image.

Both defaults now pinned by regression tests in `tests/core/test_config.py`. Full suite green (612 passed).

Note for release notes: the stdio code-exec flip is a behavior change for existing installs that use `execute_typescript` without setting the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)