### PR TITLE
feat: Tier 1 student write tools with per-course faculty gate (#170)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,36 @@ Personal academic tracking using Canvas "self" endpoints. Students only see thei
 | `get_my_submission_status` | What's submitted vs missing |
 | `get_my_course_grades` | Current grades across courses |
 | `get_my_peer_reviews_todo` | Pending peer reviews to complete |
+| `get_my_submission` | Your submission for one assignment, with attempts used |
+
+### Student Write Tools (off by default)
+Let an agent act on Canvas for the student rather than only read. **None of these
+are available unless the server operator enables them**, and an individual
+instructor can still block them in their own course.
+
+| Tool | Purpose |
+|------|---------|
+| `submit_assignment` | Submit your own assignment (text, URL, or any file type) |
+| `comment_on_my_submission` | Comment on your own submission |
+| `mark_module_item_done` | Mark a module item done for yourself |
+
+Three things to know before using them:
+
+1. **They may not exist.** Operators enable them individually via
+   `STUDENT_WRITE_TOOLS`, which defaults to empty. A disabled tool is absent
+   from the tool list entirely, so treat its absence as normal.
+2. **An instructor can turn them off per course.** If a write comes back blocked,
+   that is the course's stated policy. Relay the reason to the student and do not
+   look for a way around it.
+3. **`submit_assignment` is two calls.** The first returns a preview and a
+   confirmation token, and submits nothing. **Show the preview to the student and
+   get their answer** before calling again with the token. The token is
+   single-use and dies if the content or attempt count changed, so do not cache
+   or reuse one. Submitting spends an attempt the student may not be able to
+   recover.
+
+Quiz-taking is deliberately not offered. Group assignments are refused, because
+submitting would bind classmates who never agreed to it.
 
 ### Educator Tools
 Course management, grading, and analytics. Requires instructor/TA role.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,7 +152,12 @@ See: [Issue #56](https://github.com/vishalsachdev/canvas-mcp/issues/56) for comp
 - [x] Issue #159: mcp-remote proxy hangs on stale hosted session — **fixed 2026-07-09** (PR #160: `stateless_http=True`; deployed + live-verified)
 - [x] Issue #164 / PR #165: FERPA anonymization bypass (safe-endpoint short-circuit) — **fixed, merged, deployed 2026-07-21**; follow-up #166 filed
 - [x] Issue #166: anonymizer recursive identity scrub — **fixed, merged (PR #177), deployed to hosted 2026-07-29**; follow-up #179 (layer consolidation)
-- [ ] **#170 Tier 1 student write tools** (UMich decision factor, publicly committed ~1-1.5wk → v1.6.0) + #171 identity tools (`get_my_enrollments`/`get_my_profile`) as companion
+- [x] **#170 Tier 1 student write tools** — **built + review-hardened 2026-07-30** on
+  `feature/student-write-tools` (13 commits, 750 tests green, 10 codex rounds to clean).
+  **Not pushed, no PR, #170 comment drafted but not posted** — all three are public actions on a
+  repo UMich is watching, so they need a decision. Policy carrier is the course syllabus
+  (page carrier deliberately removed — see session log). Draft: `internal/issue-170-followup-draft.md`
+- [ ] #171 identity tools (`get_my_enrollments`/`get_my_profile`) as companion to #170
 - [ ] Issue #142: MCP SDK v2 migration — **blocked upstream**: fastmcp 3.4.4 pins `mcp<2.0`, so relaxing our pin can't resolve. Re-scoped via issue comment 7/21 (verify our v2-readiness, track fastmcp upstream). **Assigned to Ash (`ashcastelinocs124`), orig. deadline ~2026-07-27 — confirm plan with Ash**
 - [x] Issue #145 / PR #167: fastmcp 3.4.4 migration — **DONE 2026-07-21** (CVEs PYSEC-2026-2475/2476 resolved; dep-scan green; staging-validated then prod-deployed + live-verified; #145 closed)
 - [ ] Issue #157: `execute_typescript` sandbox hardening backlog (container-level egress, non-root user, prebuilt tsx image) — **self-hosted-only now**: tool is DISABLED on both hosted slots (`EXECUTE_TYPESCRIPT_ENABLED=false`, verified 2026-07-10); gate on re-enabling hosted code-exec
@@ -199,36 +204,36 @@ these local-only files publicly; `docs/.assetsignore` is now a backstop).
 ## Session Log
 > Full history: [internal/session-history.md](./internal/session-history.md)
 
-### 2026-07-29 — UMich evaluation response: triage blitz, #166 PII fix shipped, hosted spec drafted
-- **UMich context (drives everything)**: Zhen Qian (UMich ITS) email — deploying MCP stores this Fall,
-  evaluating canvas-mcp vs DMontgomery40/mcp-canvas-lms; issues #170-172 are from U-M accounts and
-  **#170 (student update tools) is their stated decision factor**. In-thread reply drafted in Thunderbird
-  (Zoom yes, Aug 4+ availability) — **verify it was sent**.
-- **Parallel-agent triage (opus/sonnet fleet)**: #170 answered publicly (Tier 1 student-write tools,
-  `STUDENT_WRITE_TOOLS` empty-default allowlist, structural self-scoping, quiz-taking deliberately gated;
-  ~1-1.5wk → next minor release — public commitment); #171 diagnosed (self-identity capability gap →
-  `get_my_enrollments`/`get_my_profile` planned, fix spec in agent report); #172 scoped (Classic-vs-New
-  Quizzes question posted); spam PR #169 declined (author owns mcptoplist.com, 50+ bulk PRs); digests
-  #162/#163 closed, #168 = live tracker; spun out #173 (TOOL_MANIFEST 24/93) + #175 (ruff in CI);
-  #174 (stale test count) fixed same-day by external PR #176 (merged); Ash nudged on overdue #142.
-- **#166 anonymizer fix — merged (PR #177) + deployed to hosted**: investigation found the leak half was
-  worse than filed — 3 live nested PII leaks (enrollments[].sis_user_id in list_users, submission_comments
-  author names/emails, assessor_name). Fix = recursive `scrub_identity` baseline, never-add-keys invariant,
-  corroborated-name guard, `/submissions/self` carve-out. Verified 3 ways: 658 tests (+48 new in
-  test_anonymization_shapes.py), codex review (its one P2 fixed), **live acceptance replay vs a real course:
-  PASS** (576 changes all classified, 0 over-reach, 0 PII survivors). Follow-up #179 filed (tool-layer call
-  consolidation). **UNFILED on purpose** (undisclosed leak): `/pages` endpoint ungated → `last_edited_by`
-  names/avatars pass through — fix quietly in next PR (details in `internal/hosted-spec-draft/REVIEW.md`).
-- **PR #178 merged + deployed — safer defaults**: `EXECUTE_TYPESCRIPT_ENABLED` now defaults **false**
-  everywhere (**behavior change** for stdio code-exec users — release-notes line needed); Docker image now
-  ships `ENABLE_DATA_ANONYMIZATION=true`.
-- **Hosted deployment spec for UMich/UCI**: drafted + sanitization-audited (zero literal leaks from
-  ops-hosted.local.md, grep-verified); B1-B3 approved as written, B4/B7 resolved via #178. Preserved in
-  gitignored `internal/hosted-spec-draft/`. Plan: share standalone with Zhen/UCI post-Zoom → land as
-  `deploy/azure/` (NOT docs/ — Cloudflare publish root).
-- Canvas token confirmed rotated + live (200 on /users/self); hosted client header already synced.
-- Next: (1) **Send the Zhen reply** (Thunderbird compose window) + schedule Zoom (Aug 4+). (2) **#170 Tier 1
-  implementation** (~1-1.5wk, publicly committed) + #171 identity tools as companion PR. (3) Quiet `/pages`
-  gating fix. (4) Watch #170/#171/#172 for zqian/khagyard replies (Classic-vs-New Quizzes answer gates #172).
-  (5) Release v1.6.0 when Tier 1 lands (include #177/#178 in notes; behavior-change line for code-exec).
-  (6) #142/Ash — escalate if no reply to the 7/29 nudge. (7) #179, #173, #175 backlog; #106 status comment.
+### 2026-07-30 — Tier 1 student write tools built and review-hardened (#170)
+- **Zhen (UMich) replied** (7/29 18:42; our reply did send at 18:13). Tier 1 scope and the
+  `STUDENT_WRITE_TOOLS` model both endorsed; **assignment submission is the only pilot blocker**;
+  **Zoom moved to mid-September**, so design discussion happens in the issue threads. Two new
+  requirements: genuinely binary file upload (a competing project OCR'd their JPEG), and
+  **per-course faculty agency** — an instructor must be able to allow agent reads but block writes
+  in their own course. Their deployment is a **central multi-replica HTTP service** on an unnamed
+  commercial platform, so per-course policy has to live in this library, not their infra.
+- **Tier 1 implemented on `feature/student-write-tools`** (13 commits, ~3.6K lines, NOT pushed):
+  `get_my_submission`, `submit_assignment` (text/URL/binary upload), `comment_on_my_submission`,
+  `mark_module_item_done`. Three layered gates: `STUDENT_WRITE_TOOLS` operator ceiling (**default
+  empty**, unlisted tools never register), a per-course instructor policy, and an HMAC-signed
+  single-use confirmation token bound to caller + payload + attempt state.
+- **Policy carrier = the course SYLLABUS, and that is load-bearing.** A course-page carrier was
+  built and then **deleted**: `editing_roles` says who may edit a page *now*, not who wrote it, so a
+  student who can create pages could author `agent_writes: allow` and lock it teacher-only in the
+  same breath. Authorship cannot be established from a student's own token. A test asserts the
+  config attributes are gone so the option cannot return.
+- **10 rounds of `codex review --base main`** before clean. It caught things worth remembering:
+  the submit endpoint is **not** `/self`-scoped (Canvas honours `submission[user_id]`), `file_paths`
+  is **arbitrary server file disclosure** over HTTP transport, `tools or None` turned an empty
+  `allow_tools` into "allow everything", a double-submit race I introduced while fixing an earlier
+  finding, and a shared token secret (added in round 3) that round 5 showed enables concurrent
+  double-redemption — so tokens are per-process and hosted deployments need **session affinity**.
+- **750 tests pass** (21 skipped); 90 are feature-specific, including a real JPEG byte-equality
+  fixture and races simulated from inside the upload call.
+- `internal/issue-170-followup-draft.md` written and revised to match the shipped design.
+  **NOT posted.** It openly corrects two things already told to UMich (the `/self` claim and the
+  page-carrier proposal) and asks them two questions: default posture when a course states no
+  policy, and whether a student-visible syllabus policy is acceptable.
+- Next: (1) **review + post the #170 comment**; decide whether to push the branch / open the PR
+  (both are public actions on a repo UMich is watching). (2) #171 identity tools as companion.
+  (3) Quiet `/pages` gating fix. (4) v1.6.0 when Tier 1 lands. (5) #142/Ash escalation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,9 +154,11 @@ See: [Issue #56](https://github.com/vishalsachdev/canvas-mcp/issues/56) for comp
 - [x] Issue #166: anonymizer recursive identity scrub — **fixed, merged (PR #177), deployed to hosted 2026-07-29**; follow-up #179 (layer consolidation)
 - [x] **#170 Tier 1 student write tools** — **built + review-hardened 2026-07-30** on
   `feature/student-write-tools` (13 commits, 750 tests green, 10 codex rounds to clean).
-  **Not pushed, no PR, #170 comment drafted but not posted** — all three are public actions on a
-  repo UMich is watching, so they need a decision. Policy carrier is the course syllabus
-  (page carrier deliberately removed — see session log). Draft: `internal/issue-170-followup-draft.md`
+  **#170 design comment POSTED 2026-07-30** ([comment 5125231050](https://github.com/vishalsachdev/canvas-mcp/issues/170#issuecomment-5125231050));
+  it corrects two earlier public claims (the `/self`-scoping claim, the page-carrier proposal),
+  explains 5 tools → 4, and asks UMich two questions (default posture; syllabus visible to students).
+  **Branch still NOT pushed, no PR** — awaiting decision. Policy carrier is the course syllabus
+  (page carrier deliberately removed — see session log). Record: `internal/issue-170-followup-draft.md`
 - [ ] #171 identity tools (`get_my_enrollments`/`get_my_profile`) as companion to #170
 - [ ] Issue #142: MCP SDK v2 migration — **blocked upstream**: fastmcp 3.4.4 pins `mcp<2.0`, so relaxing our pin can't resolve. Re-scoped via issue comment 7/21 (verify our v2-readiness, track fastmcp upstream). **Assigned to Ash (`ashcastelinocs124`), orig. deadline ~2026-07-27 — confirm plan with Ash**
 - [x] Issue #145 / PR #167: fastmcp 3.4.4 migration — **DONE 2026-07-21** (CVEs PYSEC-2026-2475/2476 resolved; dep-scan green; staging-validated then prod-deployed + live-verified; #145 closed)
@@ -230,10 +232,12 @@ these local-only files publicly; `docs/.assetsignore` is now a backstop).
   double-redemption — so tokens are per-process and hosted deployments need **session affinity**.
 - **750 tests pass** (21 skipped); 90 are feature-specific, including a real JPEG byte-equality
   fixture and races simulated from inside the upload call.
-- `internal/issue-170-followup-draft.md` written and revised to match the shipped design.
-  **NOT posted.** It openly corrects two things already told to UMich (the `/self` claim and the
-  page-carrier proposal) and asks them two questions: default posture when a course states no
-  policy, and whether a student-visible syllabus policy is acceptable.
-- Next: (1) **review + post the #170 comment**; decide whether to push the branch / open the PR
+- **Design comment POSTED to #170** ([5125231050](https://github.com/vishalsachdev/canvas-mcp/issues/170#issuecomment-5125231050);
+  record kept in `internal/issue-170-followup-draft.md`). It openly corrects two things already
+  told to UMich (the `/self`-scoping claim and the page-carrier proposal), explains why the promised
+  five Tier 1 tools became four (`upload_submission_file` folded into `submit_assignment`, so an
+  agent cannot upload outside the confirmed operation), and asks them two questions: default posture
+  when a course states no policy, and whether a student-visible syllabus policy is acceptable.
+- Next: (1) **#170 comment POSTED** — watch for zqian reply; decide whether to push the branch / open the PR
   (both are public actions on a repo UMich is watching). (2) #171 identity tools as companion.
   (3) Quiet `/pages` gating fix. (4) v1.6.0 when Tier 1 lands. (5) #142/Ash escalation.

--- a/env.template
+++ b/env.template
@@ -45,6 +45,14 @@ TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
 # Quiz-taking is deliberately NOT available here; it is a separate decision.
 # STUDENT_WRITE_TOOLS=
 
+# Signing key for submit_assignment confirmation tokens (Optional).
+# Tokens are self-contained and verified by signature, so any worker can check
+# one. REQUIRED if you run more than one process or replica: without a shared
+# key each process signs differently, and a token issued by one worker is
+# rejected by another. Unset is correct for stdio and single-worker servers.
+# Use a long random value, e.g. `openssl rand -hex 32`.
+# STUDENT_WRITE_TOKEN_SECRET=
+
 # Per-course instructor policy (Optional; applies only to the tools above)
 # Lets an individual instructor allow or block agent writes in THEIR course.
 # It can only further restrict STUDENT_WRITE_TOOLS, never widen it.

--- a/env.template
+++ b/env.template
@@ -63,14 +63,12 @@ TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
 # It can only further restrict STUDENT_WRITE_TOOLS, never widen it.
 # COURSE_AGENT_POLICY_ENABLED=true
 #
-# Which Canvas artifact carries the policy.
-#   syllabus (default) — read from the course syllabus. Students cannot edit it,
-#                        so instructor authorship is structural.
-#   page              — read from a course page named by COURSE_AGENT_POLICY_PAGE.
-#                        Weaker: Canvas pages can be student-editable, so a page
-#                        whose editing_roles is not teacher-only is NOT trusted.
-# COURSE_AGENT_POLICY_SOURCE=syllabus
-# COURSE_AGENT_POLICY_PAGE=agent-policy
+# The policy is read from the course SYLLABUS. That is not configurable, on
+# purpose: students can read the syllabus but cannot edit it, so instructor
+# authorship is structural. (A course-page carrier was implemented and removed:
+# a page's editing_roles says who may edit it now, not who wrote it, so a
+# student who can create pages could author the policy and lock it teacher-only
+# afterwards.)
 #
 # Posture when a course states no policy. Institutional choice.
 #   deny (default) — instructors must opt in before any agent write works

--- a/env.template
+++ b/env.template
@@ -45,13 +45,18 @@ TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
 # Quiz-taking is deliberately NOT available here; it is a separate decision.
 # STUDENT_WRITE_TOOLS=
 
-# Signing key for submit_assignment confirmation tokens (Optional).
-# Tokens are self-contained and verified by signature, so any worker can check
-# one. REQUIRED if you run more than one process or replica: without a shared
-# key each process signs differently, and a token issued by one worker is
-# rejected by another. Unset is correct for stdio and single-worker servers.
-# Use a long random value, e.g. `openssl rand -hex 32`.
-# STUDENT_WRITE_TOKEN_SECRET=
+# NOTE for multi-worker HTTP deployments, if you enable submit_assignment:
+# a submission confirmation is redeemable ONLY on the process that issued it.
+# This is deliberate. A confirmation is single-use, and that claim is held in
+# process memory; if a token were redeemable on any worker, two workers could
+# accept it at once and both submit, spending two of the student's attempts.
+# Enforcing single-use across replicas would require shared state (Redis or a
+# database), which this server does not require.
+#
+# So configure session affinity ("sticky sessions") on your load balancer so a
+# student's preview and confirmation reach the same worker. Without affinity
+# nothing unsafe happens: the confirmation is simply rejected and the student
+# previews again. There is no configuration knob to relax this.
 
 # Per-course instructor policy (Optional; applies only to the tools above)
 # Lets an individual instructor allow or block agent writes in THEIR course.

--- a/env.template
+++ b/env.template
@@ -38,6 +38,44 @@ TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
 # Controls which tools are registered: student (~31), educator (~86), all (default)
 # CANVAS_ROLE=all
 
+# Student write tools (Optional; OFF by default)
+# Campus-wide ceiling. Empty (the default) means NO student write tool is
+# registered at all — an unlisted tool never appears in the MCP tool list.
+# Valid names: submit_assignment, comment_on_my_submission, mark_module_item_done
+# Quiz-taking is deliberately NOT available here; it is a separate decision.
+# STUDENT_WRITE_TOOLS=
+
+# Per-course instructor policy (Optional; applies only to the tools above)
+# Lets an individual instructor allow or block agent writes in THEIR course.
+# It can only further restrict STUDENT_WRITE_TOOLS, never widen it.
+# COURSE_AGENT_POLICY_ENABLED=true
+#
+# Which Canvas artifact carries the policy.
+#   syllabus (default) — read from the course syllabus. Students cannot edit it,
+#                        so instructor authorship is structural.
+#   page              — read from a course page named by COURSE_AGENT_POLICY_PAGE.
+#                        Weaker: Canvas pages can be student-editable, so a page
+#                        whose editing_roles is not teacher-only is NOT trusted.
+# COURSE_AGENT_POLICY_SOURCE=syllabus
+# COURSE_AGENT_POLICY_PAGE=agent-policy
+#
+# Posture when a course states no policy. Institutional choice.
+#   deny (default) — instructors must opt in before any agent write works
+#   allow          — writes work unless an instructor opts out
+# COURSE_AGENT_POLICY_DEFAULT=deny
+#
+# Cache lifetimes in seconds. Grants are cached briefly on purpose: a stale
+# grant is a revocation window on an action that spends a student's attempts.
+# COURSE_AGENT_POLICY_ALLOW_TTL=30
+# COURSE_AGENT_POLICY_DENY_TTL=300
+#
+# Instructors write the policy into that artifact as plain lines, e.g.:
+#   agent_writes: deny
+# or:
+#   agent_writes: allow
+#   allow_tools: submit_assignment
+#   note: Allowed for weekly labs. Ask me before using it on the final project.
+
 # HTTP transport — multi-user access-key gate (Optional; HTTP mode only)
 # Comma/space-separated list of accepted keys. An HTTP caller must send a
 # matching X-MCP-Access-Key header. Leave empty to disable (rely on external

--- a/internal/session-history.md
+++ b/internal/session-history.md
@@ -4,6 +4,41 @@ Archived session log entries from canvas-mcp CLAUDE.md.
 
 ## Session Log
 
+### 2026-07-29 — UMich evaluation response: triage blitz, #166 PII fix shipped, hosted spec drafted
+- **UMich context (drives everything)**: Zhen Qian (UMich ITS) email — deploying MCP stores this Fall,
+  evaluating canvas-mcp vs DMontgomery40/mcp-canvas-lms; issues #170-172 are from U-M accounts and
+  **#170 (student update tools) is their stated decision factor**. In-thread reply drafted in Thunderbird
+  (Zoom yes, Aug 4+ availability) — **verify it was sent**.
+- **Parallel-agent triage (opus/sonnet fleet)**: #170 answered publicly (Tier 1 student-write tools,
+  `STUDENT_WRITE_TOOLS` empty-default allowlist, structural self-scoping, quiz-taking deliberately gated;
+  ~1-1.5wk → next minor release — public commitment); #171 diagnosed (self-identity capability gap →
+  `get_my_enrollments`/`get_my_profile` planned, fix spec in agent report); #172 scoped (Classic-vs-New
+  Quizzes question posted); spam PR #169 declined (author owns mcptoplist.com, 50+ bulk PRs); digests
+  #162/#163 closed, #168 = live tracker; spun out #173 (TOOL_MANIFEST 24/93) + #175 (ruff in CI);
+  #174 (stale test count) fixed same-day by external PR #176 (merged); Ash nudged on overdue #142.
+- **#166 anonymizer fix — merged (PR #177) + deployed to hosted**: investigation found the leak half was
+  worse than filed — 3 live nested PII leaks (enrollments[].sis_user_id in list_users, submission_comments
+  author names/emails, assessor_name). Fix = recursive `scrub_identity` baseline, never-add-keys invariant,
+  corroborated-name guard, `/submissions/self` carve-out. Verified 3 ways: 658 tests (+48 new in
+  test_anonymization_shapes.py), codex review (its one P2 fixed), **live acceptance replay vs a real course:
+  PASS** (576 changes all classified, 0 over-reach, 0 PII survivors). Follow-up #179 filed (tool-layer call
+  consolidation). **UNFILED on purpose** (undisclosed leak): `/pages` endpoint ungated → `last_edited_by`
+  names/avatars pass through — fix quietly in next PR (details in `internal/hosted-spec-draft/REVIEW.md`).
+- **PR #178 merged + deployed — safer defaults**: `EXECUTE_TYPESCRIPT_ENABLED` now defaults **false**
+  everywhere (**behavior change** for stdio code-exec users — release-notes line needed); Docker image now
+  ships `ENABLE_DATA_ANONYMIZATION=true`.
+- **Hosted deployment spec for UMich/UCI**: drafted + sanitization-audited (zero literal leaks from
+  ops-hosted.local.md, grep-verified); B1-B3 approved as written, B4/B7 resolved via #178. Preserved in
+  gitignored `internal/hosted-spec-draft/`. Plan: share standalone with Zhen/UCI post-Zoom → land as
+  `deploy/azure/` (NOT docs/ — Cloudflare publish root).
+- Canvas token confirmed rotated + live (200 on /users/self); hosted client header already synced.
+- Next: (1) **Send the Zhen reply** (Thunderbird compose window) + schedule Zoom (Aug 4+). (2) **#170 Tier 1
+  implementation** (~1-1.5wk, publicly committed) + #171 identity tools as companion PR. (3) Quiet `/pages`
+  gating fix. (4) Watch #170/#171/#172 for zqian/khagyard replies (Classic-vs-New Quizzes answer gates #172).
+  (5) Release v1.6.0 when Tier 1 lands (include #177/#178 in notes; behavior-change line for code-exec).
+  (6) #142/Ash — escalate if no reply to the 7/29 nudge. (7) #179, #173, #175 backlog; #106 status comment.
+
+
 ### 2026-07-20/21 — FERPA anonymization bypass fixed (#164/PR #165), merged + deployed; fastmcp CVE flagged
 - **Fixed the high-severity anonymization bypass** carried across weekly reports #162→#163:
   `_should_anonymize_endpoint()` checked its `/courses`-containing safe-list *before* the student-data

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -229,18 +229,6 @@ class Config:
         # Per-course instructor policy. Can further restrict (never expand) the
         # operator ceiling above.
         self.course_agent_policy_enabled = _bool_env("COURSE_AGENT_POLICY_ENABLED", True)
-        # Which Canvas artifact carries the policy. "syllabus" is the default and
-        # the only structurally sound option: students cannot edit syllabus_body
-        # under any standard role. "page" is offered for operators who prefer to
-        # keep the syllabus clean, but a Canvas Page can be student-editable
-        # (editing_roles), so the page reader refuses to trust anything not
-        # restricted to teachers.
-        self.course_agent_policy_source = os.getenv(
-            "COURSE_AGENT_POLICY_SOURCE", "syllabus"
-        ).strip().lower()
-        self.course_agent_policy_page = os.getenv(
-            "COURSE_AGENT_POLICY_PAGE", "agent-policy"
-        ).strip()
         # Posture when a course has no policy artifact. Institutional decision, so
         # it is operator-configurable; "deny" is the safe default.
         self.course_agent_policy_default = os.getenv(
@@ -372,15 +360,6 @@ def validate_config() -> bool:
             f"defaulting to 'deny' (got '{config.course_agent_policy_default}')"
         )
         config.course_agent_policy_default = "deny"
-
-    valid_policy_sources = ("syllabus", "page")
-    if config.course_agent_policy_source not in valid_policy_sources:
-        log_warning(
-            "COURSE_AGENT_POLICY_SOURCE should be one of "
-            f"{', '.join(valid_policy_sources)}; defaulting to 'syllabus' "
-            f"(got '{config.course_agent_policy_source}')"
-        )
-        config.course_agent_policy_source = "syllabus"
 
     unknown_write_tools = config.student_write_tools - STUDENT_WRITE_TOOL_NAMES
     if unknown_write_tools:

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -16,6 +16,17 @@ _INVALID_FLOAT_ENV_VARS: dict[str, str] = {}
 
 VALID_SANDBOX_MODES = frozenset({"auto", "local", "container"})
 
+# Canonical names of the student write tools an operator may enable via
+# STUDENT_WRITE_TOOLS. Declared here rather than in the tools package so config
+# stays free of imports from it. Quiz-taking is deliberately absent: it is an
+# academic-integrity decision gated behind its own separate flag, not something
+# an operator can switch on by naming it in this allowlist.
+STUDENT_WRITE_TOOL_NAMES = frozenset({
+    "submit_assignment",
+    "comment_on_my_submission",
+    "mark_module_item_done",
+})
+
 
 def _parse_keys(raw: str) -> frozenset[str]:
     """Parse a comma/whitespace-separated list of access keys into a set."""
@@ -206,6 +217,40 @@ class Config:
         # Role-based tool filtering
         self.canvas_role = os.getenv("CANVAS_ROLE", "all").lower()
 
+        # --- Student write tools (#170) ---
+        # Campus-wide operator ceiling. Empty (the default) means NO student write
+        # tool is registered, so an unlisted tool never enters the MCP tool list at
+        # all. Accepts comma- and/or space-separated tool names.
+        self.student_write_tools = frozenset(
+            name.strip()
+            for name in os.getenv("STUDENT_WRITE_TOOLS", "").replace(",", " ").split()
+            if name.strip()
+        )
+        # Per-course instructor policy. Can further restrict (never expand) the
+        # operator ceiling above.
+        self.course_agent_policy_enabled = _bool_env("COURSE_AGENT_POLICY_ENABLED", True)
+        # Which Canvas artifact carries the policy. "syllabus" is the default and
+        # the only structurally sound option: students cannot edit syllabus_body
+        # under any standard role. "page" is offered for operators who prefer to
+        # keep the syllabus clean, but a Canvas Page can be student-editable
+        # (editing_roles), so the page reader refuses to trust anything not
+        # restricted to teachers.
+        self.course_agent_policy_source = os.getenv(
+            "COURSE_AGENT_POLICY_SOURCE", "syllabus"
+        ).strip().lower()
+        self.course_agent_policy_page = os.getenv(
+            "COURSE_AGENT_POLICY_PAGE", "agent-policy"
+        ).strip()
+        # Posture when a course has no policy artifact. Institutional decision, so
+        # it is operator-configurable; "deny" is the safe default.
+        self.course_agent_policy_default = os.getenv(
+            "COURSE_AGENT_POLICY_DEFAULT", "deny"
+        ).strip().lower()
+        # Denials cache longer than grants. A stale grant is a revocation window on
+        # an attempt-consuming action, so it is deliberately short.
+        self.course_agent_policy_allow_ttl = _int_env("COURSE_AGENT_POLICY_ALLOW_TTL", 30)
+        self.course_agent_policy_deny_ttl = _int_env("COURSE_AGENT_POLICY_DENY_TTL", 300)
+
 
 # Global configuration instance
 _config: Config | None = None
@@ -317,6 +362,32 @@ def validate_config() -> bool:
             f"defaulting to 'all' (got '{config.canvas_role}')"
         )
         config.canvas_role = "all"
+
+    # Student write policy: an unrecognized posture must fail closed, not fall
+    # through to something permissive.
+    valid_postures = ("allow", "deny")
+    if config.course_agent_policy_default not in valid_postures:
+        log_warning(
+            f"COURSE_AGENT_POLICY_DEFAULT should be one of {', '.join(valid_postures)}; "
+            f"defaulting to 'deny' (got '{config.course_agent_policy_default}')"
+        )
+        config.course_agent_policy_default = "deny"
+
+    valid_policy_sources = ("syllabus", "page")
+    if config.course_agent_policy_source not in valid_policy_sources:
+        log_warning(
+            "COURSE_AGENT_POLICY_SOURCE should be one of "
+            f"{', '.join(valid_policy_sources)}; defaulting to 'syllabus' "
+            f"(got '{config.course_agent_policy_source}')"
+        )
+        config.course_agent_policy_source = "syllabus"
+
+    unknown_write_tools = config.student_write_tools - STUDENT_WRITE_TOOL_NAMES
+    if unknown_write_tools:
+        log_warning(
+            "STUDENT_WRITE_TOOLS names unknown tools; they will be ignored: "
+            f"{', '.join(sorted(unknown_write_tools))}"
+        )
 
     for env_name, env_value in _INVALID_INT_ENV_VARS.items():
         log_warning(

--- a/src/canvas_mcp/core/course_policy.py
+++ b/src/canvas_mcp/core/course_policy.py
@@ -183,6 +183,21 @@ def parse_policy_body(body: str) -> CoursePolicy:
         tools = frozenset(
             name.strip() for name in raw_tools.replace(",", " ").split() if name.strip()
         )
+        # An OMITTED allow_tools means "no extra narrowing". A PRESENT but empty
+        # one means the instructor either named nothing or left the line
+        # unfinished. Collapsing the two with `tools or None` would turn the most
+        # restrictive possible directive into the least restrictive one, so an
+        # empty list denies instead.
+        if _KEY_ALLOW_TOOLS in values and not tools:
+            return CoursePolicy(
+                allow_writes=False,
+                allow_tools=None,
+                note=note or (
+                    "The course's agent policy allows agent writes but lists no "
+                    "permitted tools. Ask your instructor to complete it."
+                ),
+                source="course_artifact_empty_allowlist",
+            )
         return CoursePolicy(True, tools or None, note, "course_artifact")
 
     if raw_writes == "deny":

--- a/src/canvas_mcp/core/course_policy.py
+++ b/src/canvas_mcp/core/course_policy.py
@@ -82,6 +82,13 @@ def reset_policy_cache() -> None:
     _policy_cache.clear()
 
 
+def _evict_expired_policies() -> None:
+    """Drop timed-out cache entries so the map cannot grow without bound."""
+    now = time.monotonic()
+    for key in [k for k, (expiry, _) in _policy_cache.items() if expiry < now]:
+        _policy_cache.pop(key, None)
+
+
 def _is_not_found(error_message: str) -> bool:
     """Distinguish "no policy artifact" from "the read failed".
 
@@ -284,6 +291,10 @@ async def get_course_policy(course_id: str | int) -> CoursePolicy:
         if policy.allow_writes
         else config.course_agent_policy_deny_ttl
     )
+    # Evict on write. Callers choose the course id, so on a long-running hosted
+    # server a stream of made-up ids would otherwise grow this map forever, even
+    # though every one of those lookups was denied.
+    _evict_expired_policies()
     _policy_cache[key] = (time.monotonic() + ttl, policy)
     return policy
 

--- a/src/canvas_mcp/core/course_policy.py
+++ b/src/canvas_mcp/core/course_policy.py
@@ -47,10 +47,11 @@ _KEY_NOTE = "note"
 _TAG_RE = re.compile(r"<[^>]+>")
 _KV_RE = re.compile(r"^\s*([a-z_]+)\s*:\s*(.*?)\s*$", re.IGNORECASE)
 
-# Editing roles that keep a Page out of student hands. Canvas returns a
-# comma-separated string; anything mentioning students/members/public means the
-# artifact is not trustworthy as an instructor statement.
-_UNTRUSTED_EDIT_ROLES = ("student", "member", "public")
+# The only editing_roles value that makes a Page trustworthy as an instructor
+# statement. Canvas returns a comma-separated string; this is matched as an
+# exact set so that a missing, empty, or unfamiliar value fails closed rather
+# than slipping past a denylist.
+_TRUSTED_EDIT_ROLES = frozenset({"teachers"})
 
 
 class CoursePolicy(NamedTuple):
@@ -177,12 +178,21 @@ async def _read_policy_text(course_id: str) -> tuple[str | None, str]:
 
         # Provenance guard. A page a student could edit is not an instructor
         # statement, regardless of what it says.
-        editing_roles = str(response.get("editing_roles") or "").lower()
-        if any(role in editing_roles for role in _UNTRUSTED_EDIT_ROLES):
+        #
+        # This is an allowlist, not a denylist, and deliberately so. Screening
+        # only for known-bad role names would trust a page whose editing_roles
+        # is missing, empty, or some value Canvas adds later — exactly the
+        # ambiguous cases a fail-closed check exists to catch.
+        roles = {
+            role.strip()
+            for role in str(response.get("editing_roles") or "").lower().split(",")
+            if role.strip()
+        }
+        if roles != _TRUSTED_EDIT_ROLES:
             log_warning(
-                "Ignoring course agent policy page: it is not teacher-only",
+                "Ignoring course agent policy page: not explicitly teacher-only",
                 course_id=course_id,
-                editing_roles=editing_roles,
+                editing_roles=sorted(roles) or ["<missing>"],
             )
             return None, "untrusted"
 

--- a/src/canvas_mcp/core/course_policy.py
+++ b/src/canvas_mcp/core/course_policy.py
@@ -45,6 +45,7 @@ _KEY_ALLOW_TOOLS = "allow_tools"
 _KEY_NOTE = "note"
 
 _TAG_RE = re.compile(r"<[^>]+>")
+_HTTP_STATUS_RE = re.compile(r"^HTTP error:\s*(\d{3})\b")
 _KV_RE = re.compile(r"^\s*([a-z_]+)\s*:\s*(.*?)\s*$", re.IGNORECASE)
 
 # The only editing_roles value that makes a Page trustworthy as an instructor
@@ -90,8 +91,14 @@ def _is_not_found(error_message: str) -> bool:
     posture applies, while any other failure means the policy is *unknown* and
     must deny. Collapsing the two would let a Canvas outage grant writes
     everywhere the default is permissive.
+
+    The status is therefore parsed from the front of the message rather than
+    searched for anywhere in it. A substring test would read
+    ``"HTTP error: 500, Details: {'message': 'upstream 404...'}"`` as an absent
+    artifact and, under a permissive default, turn a server error into a grant.
     """
-    return "404" in error_message
+    match = _HTTP_STATUS_RE.match(error_message.strip())
+    return bool(match) and match.group(1) == "404"
 
 
 def _strip_html(body: str) -> str:

--- a/src/canvas_mcp/core/course_policy.py
+++ b/src/canvas_mcp/core/course_policy.py
@@ -1,0 +1,337 @@
+"""Per-course instructor policy for student write tools (#170).
+
+Faculty need agency over whether AI agents may write in *their* course, separate
+from whatever the campus operator has enabled server-wide. Canvas has no native
+concept of "agent access", so the policy is expressed as a Canvas-native
+artifact that the instructor controls.
+
+Choosing the carrier is the whole security question here, because the policy is
+read using the *student's own token*. The artifact must therefore be one the
+student cannot author or alter:
+
+* **Syllabus (default).** ``syllabus_body`` is editable only by instructors and
+  admins under every standard Canvas role, and readable by enrolled students.
+  That makes instructor authorship structural rather than assumed.
+* **Page (opt-in).** A course Page is friendlier, but Canvas Pages carry an
+  ``editing_roles`` setting that can be ``students``, ``members`` or ``public``,
+  and in many courses a student may create a page before any instructor does.
+  Reading such a page through the student's own token proves nothing about who
+  wrote it. So when this mode is selected the reader **refuses to trust** any
+  page whose ``editing_roles`` is not restricted to teachers.
+
+Layering holds strictly: ``STUDENT_WRITE_TOOLS`` is the campus-wide operator
+ceiling. A course policy may only further restrict within it, never expand it,
+because a course-level artifact is the wrong trust level for widening a
+campus-wide permission.
+
+Failure posture: only a definitively read, well-formed artifact can yield
+"allow". Malformed content, permission failures, transient errors and
+untrusted-provenance artifacts all deny.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+import time
+from typing import Any, NamedTuple
+
+from .client import make_canvas_request
+from .config import get_config
+from .logging import log_warning
+
+_KEY_AGENT_WRITES = "agent_writes"
+_KEY_ALLOW_TOOLS = "allow_tools"
+_KEY_NOTE = "note"
+
+_TAG_RE = re.compile(r"<[^>]+>")
+_KV_RE = re.compile(r"^\s*([a-z_]+)\s*:\s*(.*?)\s*$", re.IGNORECASE)
+
+# Editing roles that keep a Page out of student hands. Canvas returns a
+# comma-separated string; anything mentioning students/members/public means the
+# artifact is not trustworthy as an instructor statement.
+_UNTRUSTED_EDIT_ROLES = ("student", "member", "public")
+
+
+class CoursePolicy(NamedTuple):
+    """Resolved write policy for a single course.
+
+    Attributes:
+        allow_writes: Whether agent writes are permitted in this course.
+        allow_tools: Optional further narrowing to named tools. ``None`` means
+            "every tool the operator has enabled".
+        note: Instructor-authored message surfaced on refusal, so a block is
+            informative rather than opaque.
+        source: Where the decision came from, for diagnostics and tests.
+    """
+
+    allow_writes: bool
+    allow_tools: frozenset[str] | None
+    note: str
+    source: str
+
+
+# course_id -> (expires_at_monotonic, policy)
+_policy_cache: dict[str, tuple[float, CoursePolicy]] = {}
+
+
+def reset_policy_cache() -> None:
+    """Discard cached course policies (tests, and immediate policy re-read)."""
+    _policy_cache.clear()
+
+
+def _is_not_found(error_message: str) -> bool:
+    """Distinguish "no policy artifact" from "the read failed".
+
+    ``make_canvas_request`` flattens HTTP failures into ``{"error": "HTTP error:
+    404"}``, so status is only available as text. The distinction is
+    load-bearing: a 404 means the artifact is absent and the configured default
+    posture applies, while any other failure means the policy is *unknown* and
+    must deny. Collapsing the two would let a Canvas outage grant writes
+    everywhere the default is permissive.
+    """
+    return "404" in error_message
+
+
+def _strip_html(body: str) -> str:
+    """Reduce Canvas rich text to plain lines.
+
+    Instructors type policy into Canvas's WYSIWYG editor, which wraps content in
+    markup, so the parser sees through tags rather than demanding clean source.
+    """
+    text = re.sub(r"<\s*br\s*/?\s*>", "\n", body, flags=re.IGNORECASE)
+    text = re.sub(r"</\s*(p|div|li|h[1-6])\s*>", "\n", text, flags=re.IGNORECASE)
+    text = _TAG_RE.sub("", text)
+    return html.unescape(text)
+
+
+def parse_policy_body(body: str) -> CoursePolicy:
+    """Parse policy text into a :class:`CoursePolicy`.
+
+    Format is ``key: value`` lines, so an instructor can express "no agents
+    writing in my course" in one line without knowing YAML or JSON::
+
+        agent_writes: deny
+
+    Text that does not yield a valid ``agent_writes`` value denies. Failing
+    closed on malformed policy is the only defensible posture: the alternative
+    is a typo silently granting write access.
+
+    Note the marker must be *present* to be meaningful. A syllabus with no
+    ``agent_writes`` line is treated as "no policy stated" by the caller, not as
+    a malformed policy.
+    """
+    values: dict[str, str] = {}
+    for line in _strip_html(body).splitlines():
+        match = _KV_RE.match(line)
+        if match:
+            key = match.group(1).lower()
+            if key in (_KEY_AGENT_WRITES, _KEY_ALLOW_TOOLS, _KEY_NOTE):
+                values.setdefault(key, match.group(2).strip())
+
+    note = values.get(_KEY_NOTE, "")
+    raw_writes = values.get(_KEY_AGENT_WRITES, "").lower()
+
+    if raw_writes == "allow":
+        raw_tools = values.get(_KEY_ALLOW_TOOLS, "")
+        tools = frozenset(
+            name.strip() for name in raw_tools.replace(",", " ").split() if name.strip()
+        )
+        return CoursePolicy(True, tools or None, note, "course_artifact")
+
+    if raw_writes == "deny":
+        return CoursePolicy(False, None, note, "course_artifact")
+
+    return CoursePolicy(
+        allow_writes=False,
+        allow_tools=None,
+        note=note or (
+            "The course's agent policy could not be interpreted. Ask your "
+            "instructor to check it."
+        ),
+        source="course_artifact_malformed",
+    )
+
+
+def _has_policy_marker(text: str) -> bool:
+    """Whether text actually states a policy, vs. merely being a syllabus."""
+    return bool(re.search(rf"\b{_KEY_AGENT_WRITES}\s*:", _strip_html(text), re.IGNORECASE))
+
+
+async def _read_policy_text(course_id: str) -> tuple[str | None, str]:
+    """Fetch the raw policy text for a course.
+
+    Returns ``(text, status)`` where status is one of ``ok`` (text found),
+    ``absent`` (no artifact, apply default), ``error`` (undetermined, deny) or
+    ``untrusted`` (artifact exists but its provenance cannot be trusted, deny).
+    """
+    config = get_config()
+
+    if config.course_agent_policy_source == "page":
+        response = await make_canvas_request(
+            "get", f"/courses/{course_id}/pages/{config.course_agent_policy_page}"
+        )
+        if isinstance(response, dict) and "error" in response:
+            message = str(response["error"])
+            return None, "absent" if _is_not_found(message) else "error"
+
+        # Provenance guard. A page a student could edit is not an instructor
+        # statement, regardless of what it says.
+        editing_roles = str(response.get("editing_roles") or "").lower()
+        if any(role in editing_roles for role in _UNTRUSTED_EDIT_ROLES):
+            log_warning(
+                "Ignoring course agent policy page: it is not teacher-only",
+                course_id=course_id,
+                editing_roles=editing_roles,
+            )
+            return None, "untrusted"
+
+        return str(response.get("body") or ""), "ok"
+
+    # Default: the syllabus, which students cannot edit.
+    response = await make_canvas_request(
+        "get", f"/courses/{course_id}", params={"include[]": ["syllabus_body"]}
+    )
+    if isinstance(response, dict) and "error" in response:
+        message = str(response["error"])
+        return None, "absent" if _is_not_found(message) else "error"
+
+    body = str(response.get("syllabus_body") or "")
+    if not _has_policy_marker(body):
+        return None, "absent"
+    return body, "ok"
+
+
+def _default_policy() -> CoursePolicy:
+    """Posture for a course that states no policy at all."""
+    allows = get_config().course_agent_policy_default == "allow"
+    return CoursePolicy(
+        allow_writes=allows,
+        allow_tools=None,
+        note="" if allows else (
+            "This course has not opted in to agent-assisted writes. Ask your "
+            "instructor if you think it should."
+        ),
+        source="default",
+    )
+
+
+async def get_course_policy(course_id: str | int) -> CoursePolicy:
+    """Resolve the effective write policy for one course, with a TTL cache.
+
+    Grants are cached far more briefly than denials. A stale grant is a
+    revocation window on an action that consumes a student's limited attempts,
+    so it is deliberately short; a stale denial is merely inconvenient.
+    """
+    config = get_config()
+    key = str(course_id)
+
+    cached = _policy_cache.get(key)
+    if cached and cached[0] > time.monotonic():
+        return cached[1]
+
+    text, status = await _read_policy_text(key)
+
+    if status == "ok" and text is not None:
+        policy = parse_policy_body(text)
+    elif status == "absent":
+        policy = _default_policy()
+    elif status == "untrusted":
+        policy = CoursePolicy(
+            allow_writes=False,
+            allow_tools=None,
+            note=(
+                "This course's agent policy is stored somewhere students can "
+                "edit, so it is not being trusted. Ask your instructor to move "
+                "it somewhere only teachers can change."
+            ),
+            source="untrusted_artifact",
+        )
+    else:
+        log_warning(
+            "Could not read course agent policy; denying student write",
+            course_id=key,
+        )
+        policy = CoursePolicy(
+            allow_writes=False,
+            allow_tools=None,
+            note=(
+                "The course's agent policy could not be checked right now, so "
+                "nothing was submitted. Try again shortly."
+            ),
+            source="read_error",
+        )
+
+    ttl = (
+        config.course_agent_policy_allow_ttl
+        if policy.allow_writes
+        else config.course_agent_policy_deny_ttl
+    )
+    _policy_cache[key] = (time.monotonic() + ttl, policy)
+    return policy
+
+
+async def check_student_write_allowed(
+    course_id: str | int, tool_name: str
+) -> tuple[bool, str]:
+    """Authorize one student write in one course.
+
+    Returns ``(allowed, reason)``; ``reason`` is empty when allowed.
+
+    The operator ceiling is checked first, so a course artifact can never widen
+    it. Callers must re-invoke this immediately before the write itself, not
+    only during a preview, so a policy change between the two takes effect.
+    """
+    config = get_config()
+
+    if tool_name not in config.student_write_tools:
+        return False, (
+            f"'{tool_name}' is not enabled on this server. Student write tools "
+            "are off unless an administrator adds them to STUDENT_WRITE_TOOLS."
+        )
+
+    if not config.course_agent_policy_enabled:
+        return True, ""
+
+    policy = await get_course_policy(course_id)
+
+    if not policy.allow_writes:
+        reason = "Agent writes are not permitted in this course."
+        return False, f"{reason} {policy.note}".strip()
+
+    if policy.allow_tools is not None and tool_name not in policy.allow_tools:
+        reason = f"This course permits agent writes but not '{tool_name}'."
+        return False, f"{reason} {policy.note}".strip()
+
+    return True, ""
+
+
+def assert_no_identity_override(data: dict[str, Any]) -> None:
+    """Guard the outbound field set of a student write.
+
+    The submit endpoint (``POST /courses/:id/assignments/:id/submissions``) is
+    the one student write path that is *not* structurally self-scoped: Canvas
+    accepts ``submission[user_id]`` there to submit on another user's behalf
+    when the token carries grading permission. Since a real person can hold
+    mixed student and TA enrollments, the tool profile alone does not guarantee
+    the token lacks that permission.
+
+    So the guarantee is enforced on the wire instead: no student write may ever
+    carry an identity override. Raising here is deliberate. This is a
+    programming error, not a user error, and it must never be swallowed into a
+    partial success.
+    """
+    forbidden = {
+        "as_user_id",
+        "submission[user_id]",
+        "user_id",
+        "submission[group_id]",
+        "group_id",
+        "student_id",
+    }
+    present = forbidden.intersection(data)
+    if present:
+        raise ValueError(
+            "Student write attempted with identity-override field(s): "
+            f"{', '.join(sorted(present))}"
+        )

--- a/src/canvas_mcp/core/course_policy.py
+++ b/src/canvas_mcp/core/course_policy.py
@@ -6,18 +6,22 @@ concept of "agent access", so the policy is expressed as a Canvas-native
 artifact that the instructor controls.
 
 Choosing the carrier is the whole security question here, because the policy is
-read using the *student's own token*. The artifact must therefore be one the
-student cannot author or alter:
+read using the *student's own token*. The artifact must be one the student
+cannot author or alter, and there is exactly one such option:
 
-* **Syllabus (default).** ``syllabus_body`` is editable only by instructors and
-  admins under every standard Canvas role, and readable by enrolled students.
-  That makes instructor authorship structural rather than assumed.
-* **Page (opt-in).** A course Page is friendlier, but Canvas Pages carry an
-  ``editing_roles`` setting that can be ``students``, ``members`` or ``public``,
-  and in many courses a student may create a page before any instructor does.
-  Reading such a page through the student's own token proves nothing about who
-  wrote it. So when this mode is selected the reader **refuses to trust** any
-  page whose ``editing_roles`` is not restricted to teachers.
+**The syllabus.** ``syllabus_body`` is editable only by instructors and admins
+under every standard Canvas role, and readable by enrolled students. That makes
+instructor authorship structural rather than assumed.
+
+A course Page was considered and deliberately **rejected**, which is worth
+recording so it is not reintroduced. Pages carry an ``editing_roles`` setting,
+and the obvious guard is to trust only teacher-only pages. That guard does not
+work: ``editing_roles`` describes who may edit a page *now*, not who wrote it.
+In a course where students may create pages, a student can create the policy
+page containing ``agent_writes: allow`` and set it teacher-only in the same
+breath, locking themselves out *after* authoring the content that governs them.
+Authorship cannot be established from a student's own token, so a Page can
+never be a trustworthy authorization source here, however it is screened.
 
 Layering holds strictly: ``STUDENT_WRITE_TOOLS`` is the campus-wide operator
 ceiling. A course policy may only further restrict within it, never expand it,
@@ -48,11 +52,6 @@ _TAG_RE = re.compile(r"<[^>]+>")
 _HTTP_STATUS_RE = re.compile(r"^HTTP error:\s*(\d{3})\b")
 _KV_RE = re.compile(r"^\s*([a-z_]+)\s*:\s*(.*?)\s*$", re.IGNORECASE)
 
-# The only editing_roles value that makes a Page trustworthy as an instructor
-# statement. Canvas returns a comma-separated string; this is matched as an
-# exact set so that a missing, empty, or unfamiliar value fails closed rather
-# than slipping past a denylist.
-_TRUSTED_EDIT_ROLES = frozenset({"teachers"})
 
 
 class CoursePolicy(NamedTuple):
@@ -136,19 +135,51 @@ def parse_policy_body(body: str) -> CoursePolicy:
     ``agent_writes`` line is treated as "no policy stated" by the caller, not as
     a malformed policy.
     """
-    values: dict[str, str] = {}
+    # Collect EVERY occurrence of each key rather than the first. Keeping only
+    # the first would let an instructor who appends "agent_writes: deny" below an
+    # earlier "agent_writes: allow" have their revocation silently discarded,
+    # which is the worst possible direction for this to fail.
+    values: dict[str, list[str]] = {}
     for line in _strip_html(body).splitlines():
         match = _KV_RE.match(line)
         if match:
             key = match.group(1).lower()
             if key in (_KEY_AGENT_WRITES, _KEY_ALLOW_TOOLS, _KEY_NOTE):
-                values.setdefault(key, match.group(2).strip())
+                values.setdefault(key, []).append(match.group(2).strip())
 
-    note = values.get(_KEY_NOTE, "")
-    raw_writes = values.get(_KEY_AGENT_WRITES, "").lower()
+    note = (values.get(_KEY_NOTE) or [""])[0]
+    write_directives = {v.lower() for v in values.get(_KEY_AGENT_WRITES, [])}
+
+    # Contradictory directives are ambiguous, and ambiguity denies. An explicit
+    # denial anywhere in the policy must never be overridden by an allow.
+    if len(write_directives) > 1:
+        return CoursePolicy(
+            allow_writes=False,
+            allow_tools=None,
+            note=note or (
+                "The course's agent policy states more than one conflicting "
+                "value. Ask your instructor to correct it."
+            ),
+            source="course_artifact_conflict",
+        )
+
+    raw_writes = next(iter(write_directives), "")
 
     if raw_writes == "allow":
-        raw_tools = values.get(_KEY_ALLOW_TOOLS, "")
+        tool_directives = set(values.get(_KEY_ALLOW_TOOLS, []))
+        # Same rule as above: contradictory narrowing is ambiguous, so deny
+        # rather than guess which line the instructor meant.
+        if len(tool_directives) > 1:
+            return CoursePolicy(
+                allow_writes=False,
+                allow_tools=None,
+                note=note or (
+                    "The course's agent policy lists allow_tools more than once "
+                    "with different values. Ask your instructor to correct it."
+                ),
+                source="course_artifact_conflict",
+            )
+        raw_tools = next(iter(tool_directives), "")
         tools = frozenset(
             name.strip() for name in raw_tools.replace(",", " ").split() if name.strip()
         )
@@ -180,54 +211,9 @@ async def _read_policy_text(course_id: str) -> tuple[str | None, str]:
 
     * ``ok`` — text found
     * ``absent`` — the course was read and states no policy; apply the default
-    * ``absent_ambiguous`` — looked absent, but might instead mean this caller
-      cannot see it; apply the default WITHOUT caching (see below)
-    * ``error`` — undetermined; deny
-    * ``untrusted`` — an artifact exists but its provenance cannot be trusted; deny
-
-    The ``absent`` / ``absent_ambiguous`` split exists because Canvas answers 404
-    both for "this thing does not exist" and for "you cannot see this". Caching
-    the second under the course id alone would let one caller who lacks access
-    install a global verdict for everyone — and where the default is permissive,
-    that verdict would override an instructor's explicit denial.
+    * ``error`` — undetermined, or this caller cannot see the course; deny
     """
-    config = get_config()
-
-    if config.course_agent_policy_source == "page":
-        response = await make_canvas_request(
-            "get", f"/courses/{course_id}/pages/{config.course_agent_policy_page}"
-        )
-        if isinstance(response, dict) and "error" in response:
-            message = str(response["error"])
-            if not _is_not_found(message):
-                return None, "error"
-            # Could be "no such page" or "no access to this course". Honour the
-            # default posture, but never cache a guess.
-            return None, "absent_ambiguous"
-
-        # Provenance guard. A page a student could edit is not an instructor
-        # statement, regardless of what it says.
-        #
-        # This is an allowlist, not a denylist, and deliberately so. Screening
-        # only for known-bad role names would trust a page whose editing_roles
-        # is missing, empty, or some value Canvas adds later — exactly the
-        # ambiguous cases a fail-closed check exists to catch.
-        roles = {
-            role.strip()
-            for role in str(response.get("editing_roles") or "").lower().split(",")
-            if role.strip()
-        }
-        if roles != _TRUSTED_EDIT_ROLES:
-            log_warning(
-                "Ignoring course agent policy page: not explicitly teacher-only",
-                course_id=course_id,
-                editing_roles=sorted(roles) or ["<missing>"],
-            )
-            return None, "untrusted"
-
-        return str(response.get("body") or ""), "ok"
-
-    # Default: the syllabus, which students cannot edit.
+    # The syllabus, which students cannot edit.
     response = await make_canvas_request(
         "get", f"/courses/{course_id}", params={"include[]": ["syllabus_body"]}
     )
@@ -281,10 +267,6 @@ async def get_course_policy(course_id: str | int) -> CoursePolicy:
         policy = parse_policy_body(text)
     elif status == "absent":
         policy = _default_policy()
-    elif status == "absent_ambiguous":
-        # Apply the default, but return before the cache write below: this
-        # verdict may reflect only what THIS caller can see.
-        return _default_policy()._replace(source="default_uncached")
     elif status == "untrusted":
         policy = CoursePolicy(
             allow_writes=False,

--- a/src/canvas_mcp/core/course_policy.py
+++ b/src/canvas_mcp/core/course_policy.py
@@ -286,6 +286,15 @@ async def get_course_policy(course_id: str | int) -> CoursePolicy:
             source="read_error",
         )
 
+    # A read failure is a property of THIS caller's request, not of the course:
+    # it can mean an expired token, a caller not enrolled, or a transient error.
+    # Caching it under the course id alone would let one bad caller deny writes
+    # for every legitimate student in that course for a full deny TTL. So it is
+    # never cached; the retry cost is small and falls only on the caller who
+    # actually hit the error.
+    if policy.source == "read_error":
+        return policy
+
     ttl = (
         config.course_agent_policy_allow_ttl
         if policy.allow_writes

--- a/src/canvas_mcp/core/course_policy.py
+++ b/src/canvas_mcp/core/course_policy.py
@@ -176,9 +176,20 @@ def _has_policy_marker(text: str) -> bool:
 async def _read_policy_text(course_id: str) -> tuple[str | None, str]:
     """Fetch the raw policy text for a course.
 
-    Returns ``(text, status)`` where status is one of ``ok`` (text found),
-    ``absent`` (no artifact, apply default), ``error`` (undetermined, deny) or
-    ``untrusted`` (artifact exists but its provenance cannot be trusted, deny).
+    Returns ``(text, status)``:
+
+    * ``ok`` — text found
+    * ``absent`` — the course was read and states no policy; apply the default
+    * ``absent_ambiguous`` — looked absent, but might instead mean this caller
+      cannot see it; apply the default WITHOUT caching (see below)
+    * ``error`` — undetermined; deny
+    * ``untrusted`` — an artifact exists but its provenance cannot be trusted; deny
+
+    The ``absent`` / ``absent_ambiguous`` split exists because Canvas answers 404
+    both for "this thing does not exist" and for "you cannot see this". Caching
+    the second under the course id alone would let one caller who lacks access
+    install a global verdict for everyone — and where the default is permissive,
+    that verdict would override an instructor's explicit denial.
     """
     config = get_config()
 
@@ -188,7 +199,11 @@ async def _read_policy_text(course_id: str) -> tuple[str | None, str]:
         )
         if isinstance(response, dict) and "error" in response:
             message = str(response["error"])
-            return None, "absent" if _is_not_found(message) else "error"
+            if not _is_not_found(message):
+                return None, "error"
+            # Could be "no such page" or "no access to this course". Honour the
+            # default posture, but never cache a guess.
+            return None, "absent_ambiguous"
 
         # Provenance guard. A page a student could edit is not an instructor
         # statement, regardless of what it says.
@@ -217,9 +232,15 @@ async def _read_policy_text(course_id: str) -> tuple[str | None, str]:
         "get", f"/courses/{course_id}", params={"include[]": ["syllabus_body"]}
     )
     if isinstance(response, dict) and "error" in response:
-        message = str(response["error"])
-        return None, "absent" if _is_not_found(message) else "error"
+        # A 404 on the COURSE itself means this caller cannot see the course at
+        # all, which is a fact about the caller and not about policy. Deny, and
+        # do not let it become a cached verdict for everyone else. (The write
+        # would fail against Canvas anyway.)
+        return None, "error"
 
+    # The course read succeeded, so an unmarked syllabus is genuinely "this
+    # course states no policy" rather than something this caller cannot see.
+    # That conclusion is caller-independent, so it is safe to cache.
     body = str(response.get("syllabus_body") or "")
     if not _has_policy_marker(body):
         return None, "absent"
@@ -260,6 +281,10 @@ async def get_course_policy(course_id: str | int) -> CoursePolicy:
         policy = parse_policy_body(text)
     elif status == "absent":
         policy = _default_policy()
+    elif status == "absent_ambiguous":
+        # Apply the default, but return before the cache write below: this
+        # verdict may reflect only what THIS caller can see.
+        return _default_policy()._replace(source="default_uncached")
     elif status == "untrusted":
         policy = CoursePolicy(
             allow_writes=False,

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -58,6 +58,7 @@ from .tools import (
     register_shared_messaging_tools,
     register_shared_module_tools,
     register_student_tools,
+    register_student_write_tools,
 )
 
 
@@ -340,6 +341,9 @@ def register_all_tools(mcp: FastMCP, role: str = "all") -> None:
     # Student-specific tools
     if role in ("student", "all"):
         register_student_tools(mcp)
+        # Tier 1 writes register only for tools the operator named in
+        # STUDENT_WRITE_TOOLS (default: none). See tools/student_write.py.
+        register_student_write_tools(mcp)
 
     # Educator-specific tools
     if role in ("educator", "all"):

--- a/src/canvas_mcp/tools/__init__.py
+++ b/src/canvas_mcp/tools/__init__.py
@@ -25,6 +25,7 @@ from .peer_review_comments import register_peer_review_comment_tools
 from .peer_reviews import register_peer_review_tools
 from .rubrics import register_rubric_tools
 from .student_tools import register_student_tools
+from .student_write import register_student_write_tools
 
 __all__ = [
     'register_accessibility_tools',
@@ -50,4 +51,5 @@ __all__ = [
     'register_shared_messaging_tools',
     'register_shared_module_tools',
     'register_student_tools',
+    'register_student_write_tools',
 ]

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -64,6 +64,21 @@ from ..core.validation import validate_params
 # flag, and discussion participation already has dedicated tools.
 _SUPPORTED_TYPES = ("online_text_entry", "online_url", "online_upload")
 
+# Whole-request upload bounds. These exist on top of the per-file limit in
+# core/file_validation, which on its own would allow an unlimited number of
+# maximum-size files in a single call. Both are checked before any file content
+# is decoded or read.
+_MAX_UPLOAD_FILES = 20
+_MAX_TOTAL_UPLOAD_BYTES = DEFAULT_MAX_FILE_SIZE_BYTES
+
+
+def _too_large_message() -> str:
+    limit_mb = _MAX_TOTAL_UPLOAD_BYTES // (1024 * 1024)
+    return (
+        f"❌ Those files total more than the {limit_mb} MB allowed for one "
+        "submission. Submit fewer or smaller files, or upload them in Canvas."
+    )
+
 # How long a confirmation token stays valid. Long enough for a human to read a
 # preview and answer, short enough that course state cannot drift far.
 _CONFIRM_TTL_SECONDS = 300
@@ -314,10 +329,26 @@ def _prepare_files(
             "the file with 'file_contents' as base64 instead."
         )
 
+    # Bound the whole request, not just each file. A per-file cap alone lets a
+    # caller send an unlimited NUMBER of maximum-size files, and the preview
+    # decodes and holds them all before any confirmation is required, so one
+    # authenticated request could exhaust a shared server's memory.
+    total_files = len(file_paths or []) + len(file_contents or [])
+    if total_files > _MAX_UPLOAD_FILES:
+        return [], (
+            f"❌ Too many files ({total_files}). At most {_MAX_UPLOAD_FILES} may "
+            "be submitted at once."
+        )
+
+    running_bytes = 0
+
     for path in file_paths or []:
         result = validate_file_for_upload(path)
         if not result.valid:
             return [], f"❌ Cannot submit '{path}': {result.error}"
+        running_bytes += result.file_size
+        if running_bytes > _MAX_TOTAL_UPLOAD_BYTES:
+            return [], _too_large_message()
         try:
             with open(path, "rb") as handle:
                 content = handle.read()
@@ -331,10 +362,15 @@ def _prepare_files(
         if not name or not encoded:
             return [], "Error: each file_contents entry needs 'name' and 'content_base64'"
 
-        # Bound the decoded size before decoding. base64 inflates by 4/3, so the
-        # encoded length is a safe proxy and avoids materializing a huge buffer.
-        if len(encoded) // 4 * 3 > DEFAULT_MAX_FILE_SIZE_BYTES:
+        # Bound sizes BEFORE decoding. base64 inflates by 4/3, so the encoded
+        # length is a safe proxy, and checking it first means an oversized
+        # request is rejected without ever allocating the buffer it describes.
+        approx_size = len(encoded) // 4 * 3
+        if approx_size > DEFAULT_MAX_FILE_SIZE_BYTES:
             return [], f"❌ '{name}' exceeds the maximum upload size."
+        running_bytes += approx_size
+        if running_bytes > _MAX_TOTAL_UPLOAD_BYTES:
+            return [], _too_large_message()
 
         try:
             content = base64.b64decode(encoded, validate=True)

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -1,0 +1,604 @@
+"""Tier 1 student write tools (#170).
+
+These are the first tools that let an agent act *on* Canvas on a student's
+behalf rather than only read. Four properties are load-bearing:
+
+1. **No identity override on the wire.** The submit endpoint
+   (``POST /courses/:id/assignments/:id/submissions``) is not structurally
+   self-scoped: Canvas accepts ``submission[user_id]`` there when the token
+   carries grading permission, and a real person can hold mixed student and TA
+   enrollments. So rather than trusting the tool profile, every outbound write
+   body is checked against an identity-override denylist immediately before it
+   is sent (``assert_no_identity_override``).
+2. **Operator ceiling.** A tool absent from ``STUDENT_WRITE_TOOLS`` is never
+   registered, so it never enters the MCP tool list. The default is empty.
+3. **Instructor agency.** Within that ceiling, a per-course policy can further
+   restrict writes, and it is re-checked immediately before the write itself,
+   not merely during the preview. See ``core/course_policy.py``.
+4. **Confirmation bound to content.** ``submit_assignment`` will not submit on
+   a bare boolean. The preview issues a short-lived, single-use token bound to
+   the target, the payload hash and the observed attempt number, so an agent
+   cannot submit without first surfacing a preview, and cannot submit something
+   other than what was previewed.
+
+Group assignments are refused in Tier 1: a submission to a group assignment
+becomes the whole group's submission, affecting students who never consented,
+and those shared-attempt semantics deserve their own decision.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import os
+import secrets
+import tempfile
+import time
+from typing import Any
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from ..core.cache import get_course_id
+from ..core.client import make_canvas_request, upload_file_to_storage
+from ..core.config import get_config
+from ..core.course_policy import (
+    assert_no_identity_override,
+    check_student_write_allowed,
+)
+from ..core.credentials import is_http_request_active
+from ..core.dates import format_date
+from ..core.file_validation import (
+    DEFAULT_MAX_FILE_SIZE_BYTES,
+    validate_file_for_upload,
+)
+from ..core.validation import validate_params
+
+# Submission types this tool supports. Quiz and discussion types are absent by
+# design: quiz-taking is a separate academic-integrity decision behind its own
+# flag, and discussion participation already has dedicated tools.
+_SUPPORTED_TYPES = ("online_text_entry", "online_url", "online_upload")
+
+# How long a confirmation token stays valid. Long enough for a human to read a
+# preview and answer, short enough that course state cannot drift far.
+_CONFIRM_TTL_SECONDS = 300
+
+# token -> (expires_at_monotonic, payload_fingerprint)
+_pending_confirmations: dict[str, tuple[float, str]] = {}
+
+
+def reset_pending_confirmations() -> None:
+    """Discard outstanding confirmation tokens (used by tests)."""
+    _pending_confirmations.clear()
+
+
+class _PreparedFile:
+    """A file staged for upload, with its bytes already resolved.
+
+    Holds bytes rather than a path because the two ingress modes differ: a
+    stdio caller names a local file, while an HTTP caller must inline the
+    content. Normalizing early keeps the upload path identical for both.
+    """
+
+    def __init__(self, name: str, content: bytes, mime_type: str) -> None:
+        self.name = name
+        self.content = content
+        self.mime_type = mime_type
+
+    @property
+    def size(self) -> int:
+        return len(self.content)
+
+
+def _fingerprint(
+    course_id: str,
+    assignment_id: str,
+    submission_type: str,
+    payload_digest: str,
+    attempt: int,
+) -> str:
+    """Bind a confirmation to exactly what was previewed.
+
+    Including the observed attempt number means a submission that lands between
+    preview and confirm invalidates the token rather than silently consuming a
+    second attempt.
+    """
+    raw = f"{course_id}|{assignment_id}|{submission_type}|{payload_digest}|{attempt}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def _digest_payload(
+    body: str | None, url: str | None, files: list[_PreparedFile]
+) -> str:
+    """Hash the exact content that would be submitted."""
+    hasher = hashlib.sha256()
+    hasher.update((body or "").encode())
+    hasher.update(b"\x00")
+    hasher.update((url or "").encode())
+    for prepared in files:
+        hasher.update(b"\x00")
+        hasher.update(prepared.name.encode())
+        hasher.update(prepared.content)
+    return hasher.hexdigest()
+
+
+def _describe_attempts(assignment: dict, submission: dict) -> str:
+    """Render attempt usage for the preview.
+
+    Canvas encodes "unlimited" as ``allowed_attempts = -1`` (and often omits the
+    field), which is the detail worth stating plainly: the student needs to know
+    whether proceeding spends a scarce resource.
+    """
+    allowed = assignment.get("allowed_attempts")
+    used = submission.get("attempt") or 0
+
+    if allowed in (None, -1):
+        return f"Attempts: {used} used, unlimited allowed"
+
+    remaining = allowed - used
+    warning = "  ⚠️  This is your LAST attempt." if remaining <= 1 else ""
+    return f"Attempts: {used} of {allowed} used, {remaining} remaining.{warning}"
+
+
+def _prepare_files(
+    file_paths: list[str] | None,
+    file_contents: list[dict[str, str]] | None,
+) -> tuple[list[_PreparedFile], str | None]:
+    """Resolve either ingress mode into raw bytes.
+
+    Returns ``(files, error)``.
+
+    ``file_paths`` reads the *server's* filesystem, which is correct for a
+    local stdio server and a serious disclosure hole for a shared HTTP one: a
+    remote caller could name any file the server process can read and upload it
+    into their own Canvas submission. It is therefore refused outright over HTTP
+    transport, where callers must inline content instead.
+    """
+    prepared: list[_PreparedFile] = []
+
+    if file_paths and is_http_request_active():
+        return [], (
+            "Error: 'file_paths' reads files from the server and is only "
+            "available on a local (stdio) server. On this hosted server, pass "
+            "the file with 'file_contents' as base64 instead."
+        )
+
+    for path in file_paths or []:
+        result = validate_file_for_upload(path)
+        if not result.valid:
+            return [], f"❌ Cannot submit '{path}': {result.error}"
+        try:
+            with open(path, "rb") as handle:
+                content = handle.read()
+        except OSError as exc:
+            return [], f"❌ Could not read '{path}': {exc}"
+        prepared.append(_PreparedFile(result.sanitized_name, content, result.mime_type))
+
+    for entry in file_contents or []:
+        name = str(entry.get("name") or "").strip()
+        encoded = entry.get("content_base64")
+        if not name or not encoded:
+            return [], "Error: each file_contents entry needs 'name' and 'content_base64'"
+
+        # Bound the decoded size before decoding. base64 inflates by 4/3, so the
+        # encoded length is a safe proxy and avoids materializing a huge buffer.
+        if len(encoded) // 4 * 3 > DEFAULT_MAX_FILE_SIZE_BYTES:
+            return [], f"❌ '{name}' exceeds the maximum upload size."
+
+        try:
+            content = base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError):
+            return [], f"❌ '{name}' is not valid base64."
+
+        # Validate the *name* (extension allowlist, sanitization) by writing to a
+        # temp file, so inline uploads get exactly the same checks as local ones.
+        handle_fd, temp_path = tempfile.mkstemp(suffix=os.path.splitext(name)[1])
+        try:
+            with os.fdopen(handle_fd, "wb") as handle:
+                handle.write(content)
+            result = validate_file_for_upload(temp_path)
+            if not result.valid:
+                return [], f"❌ Cannot submit '{name}': {result.error}"
+            prepared.append(_PreparedFile(name, content, result.mime_type))
+        finally:
+            os.unlink(temp_path)
+
+    return prepared, None
+
+
+async def _upload_one(
+    course_id: str, assignment_id: str, prepared: _PreparedFile
+) -> tuple[str | None, str | None]:
+    """Run Canvas's 3-step upload for one file. Returns ``(file_id, error)``.
+
+    Step 1 targets ``/submissions/self/files``, which *is* structurally
+    self-scoped: the slot Canvas hands back belongs to the calling user's own
+    submission and cannot be redirected at another student.
+    """
+    slot = await make_canvas_request(
+        "post",
+        f"/courses/{course_id}/assignments/{assignment_id}/submissions/self/files",
+        data={
+            "name": prepared.name,
+            "size": prepared.size,
+            "content_type": prepared.mime_type,
+        },
+        use_form_data=True,
+    )
+    if isinstance(slot, dict) and "error" in slot:
+        return None, f"❌ Failed to request an upload slot for '{prepared.name}': {slot['error']}"
+
+    upload_url = slot.get("upload_url")
+    if not upload_url:
+        return None, f"❌ Canvas returned no upload URL for '{prepared.name}'."
+
+    # Step 2 writes the bytes through a temp file, because the storage helper
+    # takes a path. The bytes are passed through verbatim: no decoding, no
+    # transcoding, no content inspection, no OCR. Whether they are a JPEG, a
+    # PDF or a zip is not this server's business.
+    handle_fd, temp_path = tempfile.mkstemp()
+    try:
+        with os.fdopen(handle_fd, "wb") as handle:
+            handle.write(prepared.content)
+        stored = await upload_file_to_storage(
+            upload_url=upload_url,
+            upload_params=slot.get("upload_params", {}),
+            file_path=temp_path,
+            filename=prepared.name,
+            content_type=prepared.mime_type,
+        )
+    finally:
+        os.unlink(temp_path)
+
+    if isinstance(stored, dict) and "error" in stored:
+        return None, f"❌ Upload failed for '{prepared.name}': {stored['error']}"
+
+    file_id = stored.get("id")
+    if not file_id:
+        return None, f"❌ Canvas did not return a file ID for '{prepared.name}'."
+    return str(file_id), None
+
+
+def register_student_write_tools(mcp: FastMCP) -> None:
+    """Register Tier 1 student tools.
+
+    ``get_my_submission`` is read-only and always registered. The write tools
+    register only when the operator has named them in ``STUDENT_WRITE_TOOLS``,
+    so an unlisted tool never becomes visible to an agent at all.
+    """
+    enabled = get_config().student_write_tools
+
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @validate_params
+    async def get_my_submission(
+        course_identifier: str | int,
+        assignment_id: str | int,
+    ) -> str:
+        """Get your own submission for an assignment, including attempts used.
+
+        Args:
+            course_identifier: Course code or Canvas ID
+            assignment_id: Canvas assignment ID
+        """
+        course_id = await get_course_id(course_identifier)
+        if not course_id:
+            return f"Error: Could not find course {course_identifier}"
+
+        submission = await make_canvas_request(
+            "get",
+            f"/courses/{course_id}/assignments/{assignment_id}/submissions/self",
+            params={"include[]": ["submission_comments", "assignment"]},
+        )
+        if isinstance(submission, dict) and "error" in submission:
+            return f"Error fetching submission: {submission['error']}"
+
+        assignment = submission.get("assignment") or {}
+        lines = [
+            f"Submission for: {assignment.get('name', f'Assignment {assignment_id}')}",
+            f"Status: {submission.get('workflow_state', 'unsubmitted')}",
+        ]
+
+        if submission.get("submitted_at"):
+            lines.append(f"Submitted: {format_date(submission['submitted_at'])}")
+        else:
+            lines.append("Submitted: not yet")
+
+        if assignment.get("due_at"):
+            lines.append(f"Due: {format_date(assignment['due_at'])}")
+        if assignment.get("lock_at"):
+            lines.append(f"Locks: {format_date(assignment['lock_at'])}")
+
+        lines.append(_describe_attempts(assignment, submission))
+
+        if submission.get("grade") is not None:
+            lines.append(f"Grade: {submission['grade']}")
+
+        comments = submission.get("submission_comments") or []
+        if comments:
+            lines.append(f"\nComments ({len(comments)}):")
+            for comment in comments:
+                lines.append(f"• {comment.get('comment', '')}")
+
+        return "\n".join(lines)
+
+    if "submit_assignment" in enabled:
+
+        @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+        @validate_params
+        async def submit_assignment(
+            course_identifier: str | int,
+            assignment_id: str | int,
+            submission_type: str,
+            body: str | None = None,
+            url: str | None = None,
+            file_paths: list[str] | None = None,
+            file_contents: list[dict[str, str]] | None = None,
+            comment: str | None = None,
+            confirmation_token: str | None = None,
+        ) -> str:
+            """Submit one of YOUR OWN assignments. Consumes an attempt.
+
+            Two-step by design. Call it without a confirmation_token to get a
+            preview of exactly what would be sent plus a token; show that preview
+            to the student, then call again passing the token to actually submit.
+            The token expires, is single-use, and is void if the content or the
+            attempt count changed since the preview.
+
+            Args:
+                course_identifier: Course code or Canvas ID
+                assignment_id: Canvas assignment ID
+                submission_type: online_text_entry, online_url, or online_upload
+                body: HTML/text content for online_text_entry
+                url: URL for online_url
+                file_paths: Local file paths (local stdio servers only, any file type)
+                file_contents: Inline files as [{"name": ..., "content_base64": ...}]
+                comment: Optional comment to include with the submission
+                confirmation_token: Token from the preview call; omit to preview
+            """
+            if submission_type not in _SUPPORTED_TYPES:
+                return (
+                    f"Error: submission_type must be one of "
+                    f"{', '.join(_SUPPORTED_TYPES)} (got '{submission_type}')"
+                )
+
+            course_id = await get_course_id(course_identifier)
+            if not course_id:
+                return f"Error: Could not find course {course_identifier}"
+
+            allowed, reason = await check_student_write_allowed(
+                course_id, "submit_assignment"
+            )
+            if not allowed:
+                return f"❌ Submission blocked. {reason}"
+
+            if submission_type == "online_text_entry" and not body:
+                return "Error: online_text_entry requires 'body'"
+            if submission_type == "online_url" and not url:
+                return "Error: online_url requires 'url'"
+            if submission_type == "online_upload" and not (file_paths or file_contents):
+                return "Error: online_upload requires 'file_paths' or 'file_contents'"
+
+            assignment = await make_canvas_request(
+                "get", f"/courses/{course_id}/assignments/{assignment_id}"
+            )
+            if isinstance(assignment, dict) and "error" in assignment:
+                return f"Error fetching assignment: {assignment['error']}"
+
+            # A group submission becomes the whole group's submission and
+            # consumes a shared attempt, affecting students who never consented.
+            # That needs its own decision, so Tier 1 declines rather than guess.
+            if assignment.get("group_category_id"):
+                return (
+                    "❌ This is a group assignment. Agent-assisted submission is "
+                    "not supported for group assignments, because it would submit "
+                    "on behalf of your whole group. Please submit it in Canvas."
+                )
+
+            if submission_type not in (assignment.get("submission_types") or []):
+                return (
+                    f"❌ This assignment does not accept '{submission_type}'. "
+                    f"It accepts: {', '.join(assignment.get('submission_types') or []) or 'nothing'}"
+                )
+
+            submission = await make_canvas_request(
+                "get",
+                f"/courses/{course_id}/assignments/{assignment_id}/submissions/self",
+            )
+            if not isinstance(submission, dict) or "error" in submission:
+                submission = {}
+            attempt = submission.get("attempt") or 0
+
+            prepared, prep_error = _prepare_files(file_paths, file_contents)
+            if prep_error:
+                return prep_error
+
+            digest = _digest_payload(body, url, prepared)
+            fingerprint = _fingerprint(
+                course_id, str(assignment_id), submission_type, digest, attempt
+            )
+
+            if not confirmation_token:
+                token = secrets.token_urlsafe(16)
+                _pending_confirmations[token] = (
+                    time.monotonic() + _CONFIRM_TTL_SECONDS,
+                    fingerprint,
+                )
+
+                preview = [
+                    "📋 Submission preview — NOTHING has been submitted yet.",
+                    "",
+                    f"Assignment: {assignment.get('name', assignment_id)}",
+                    f"Type: {submission_type}",
+                ]
+                if assignment.get("due_at"):
+                    preview.append(f"Due: {format_date(assignment['due_at'])}")
+                if assignment.get("lock_at"):
+                    preview.append(f"Locks: {format_date(assignment['lock_at'])}")
+                preview.append(_describe_attempts(assignment, submission))
+                preview.append("")
+
+                if submission_type == "online_text_entry":
+                    text = body or ""
+                    excerpt = text[:500] + ("..." if len(text) > 500 else "")
+                    preview.append(f"Content ({len(text)} chars):\n{excerpt}")
+                elif submission_type == "online_url":
+                    preview.append(f"URL: {url}")
+                else:
+                    preview.append("Files:")
+                    for item in prepared:
+                        preview.append(f"• {item.name} ({item.mime_type}, {item.size} bytes)")
+                if comment:
+                    preview.append(f"\nComment: {comment}")
+
+                preview.append(
+                    "\n➡️  Show this to the student. To submit, call again with "
+                    f"confirmation_token='{token}' and identical content.\n"
+                    "This consumes an attempt and cannot be undone."
+                )
+                return "\n".join(preview)
+
+            record = _pending_confirmations.pop(confirmation_token, None)
+            if record is None:
+                return (
+                    "❌ Unknown or already-used confirmation token. Run the "
+                    "preview again and confirm the fresh token."
+                )
+            expires_at, expected = record
+            if expires_at < time.monotonic():
+                return "❌ That confirmation expired. Run the preview again."
+            if expected != fingerprint:
+                return (
+                    "❌ The submission changed since the preview (content or "
+                    "attempt count differs). Nothing was submitted. Preview again."
+                )
+
+            # Re-check policy at the moment of the write, so an instructor's
+            # change between preview and confirm takes effect.
+            allowed, reason = await check_student_write_allowed(
+                course_id, "submit_assignment"
+            )
+            if not allowed:
+                return f"❌ Submission blocked. {reason}"
+
+            data: dict[str, Any] = {"submission[submission_type]": submission_type}
+            if submission_type == "online_text_entry":
+                data["submission[body]"] = body
+            elif submission_type == "online_url":
+                data["submission[url]"] = url
+            else:
+                file_ids = []
+                for item in prepared:
+                    file_id, upload_error = await _upload_one(
+                        course_id, str(assignment_id), item
+                    )
+                    if upload_error:
+                        return upload_error
+                    file_ids.append(file_id)
+                data["submission[file_ids][]"] = file_ids
+
+            if comment:
+                data["comment[text_comment]"] = comment
+
+            assert_no_identity_override(data)
+
+            response = await make_canvas_request(
+                "post",
+                f"/courses/{course_id}/assignments/{assignment_id}/submissions",
+                data=data,
+                use_form_data=True,
+            )
+            if isinstance(response, dict) and "error" in response:
+                return (
+                    f"❌ Submission failed: {response['error']}\n"
+                    "Check get_my_submission before retrying — if Canvas accepted "
+                    "it and only the reply was lost, retrying would spend another "
+                    "attempt."
+                )
+
+            lines = ["✅ Submitted.", f"Assignment: {assignment.get('name', assignment_id)}"]
+            if response.get("submitted_at"):
+                lines.append(f"Submitted at: {format_date(response['submitted_at'])}")
+            if response.get("attempt"):
+                lines.append(f"Attempt: {response['attempt']}")
+            if response.get("late"):
+                lines.append("⚠️  Canvas marked this submission LATE.")
+            return "\n".join(lines)
+
+    if "comment_on_my_submission" in enabled:
+
+        @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+        @validate_params
+        async def comment_on_my_submission(
+            course_identifier: str | int,
+            assignment_id: str | int,
+            comment: str,
+        ) -> str:
+            """Add a comment to YOUR OWN submission.
+
+            Args:
+                course_identifier: Course code or Canvas ID
+                assignment_id: Canvas assignment ID
+                comment: The comment text
+            """
+            if not comment.strip():
+                return "Error: comment cannot be empty"
+
+            course_id = await get_course_id(course_identifier)
+            if not course_id:
+                return f"Error: Could not find course {course_identifier}"
+
+            allowed, reason = await check_student_write_allowed(
+                course_id, "comment_on_my_submission"
+            )
+            if not allowed:
+                return f"❌ Comment blocked. {reason}"
+
+            data = {"comment[text_comment]": comment}
+            assert_no_identity_override(data)
+
+            response = await make_canvas_request(
+                "put",
+                f"/courses/{course_id}/assignments/{assignment_id}/submissions/self",
+                data=data,
+                use_form_data=True,
+            )
+            if isinstance(response, dict) and "error" in response:
+                return f"❌ Comment failed: {response['error']}"
+
+            return "✅ Comment added to your submission."
+
+    if "mark_module_item_done" in enabled:
+
+        @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+        @validate_params
+        async def mark_module_item_done(
+            course_identifier: str | int,
+            module_id: str | int,
+            item_id: str | int,
+        ) -> str:
+            """Mark a module item done for YOURSELF.
+
+            Args:
+                course_identifier: Course code or Canvas ID
+                module_id: Canvas module ID
+                item_id: Canvas module item ID
+            """
+            course_id = await get_course_id(course_identifier)
+            if not course_id:
+                return f"Error: Could not find course {course_identifier}"
+
+            allowed, reason = await check_student_write_allowed(
+                course_id, "mark_module_item_done"
+            )
+            if not allowed:
+                return f"❌ Update blocked. {reason}"
+
+            response = await make_canvas_request(
+                "put",
+                f"/courses/{course_id}/modules/{module_id}/items/{item_id}/done",
+            )
+            if isinstance(response, dict) and "error" in response:
+                return f"❌ Could not mark item done: {response['error']}"
+
+            return "✅ Module item marked done."

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -311,6 +311,18 @@ def _describe_attempts(assignment: dict, submission: dict) -> str:
     return f"Attempts: {used} of {allowed} used, {remaining} remaining.{warning}"
 
 
+def _decoded_size(encoded: str) -> int:
+    """How many bytes a base64 string will decode to, computed without decoding.
+
+    Used to reject an oversized upload before allocating it. The naive
+    ``len(encoded) // 4 * 3`` overshoots by the number of padding characters, so
+    a file whose decoded size is exactly the documented limit would be refused;
+    subtracting the trailing '=' makes this exact for well-formed input.
+    """
+    padding = len(encoded) - len(encoded.rstrip("="))
+    return max(0, len(encoded) // 4 * 3 - padding)
+
+
 def _normalize_extensions(raw: list[str] | None) -> frozenset[str] | None:
     """Normalize an assignment's ``allowed_extensions`` into ``{'.pdf', ...}``.
 
@@ -424,10 +436,10 @@ def _prepare_files(
         if not name or not encoded:
             return [], "Error: each file_contents entry needs 'name' and 'content_base64'"
 
-        # Bound sizes BEFORE decoding. base64 inflates by 4/3, so the encoded
-        # length is a safe proxy, and checking it first means an oversized
-        # request is rejected without ever allocating the buffer it describes.
-        approx_size = len(encoded) // 4 * 3
+        # Bound sizes BEFORE decoding, so an oversized request is rejected
+        # without ever allocating the buffer it describes.
+        encoded = encoded.strip()
+        approx_size = _decoded_size(encoded)
         if approx_size > DEFAULT_MAX_FILE_SIZE_BYTES:
             return [], f"❌ '{name}' exceeds the maximum upload size."
         running_bytes += approx_size
@@ -456,21 +468,34 @@ def _prepare_files(
     return prepared, None
 
 
-async def _attempt_state_changed(
+async def _final_preflight(
     course_id: str,
     assignment_id: str,
     submission_type: str,
     payload_digest: str,
     confirmed_fingerprint: str,
 ) -> str | None:
-    """Confirm attempt state still matches what the confirmation committed to.
+    """Re-verify EVERY precondition immediately before the submit call.
 
-    Returns an error message if it drifted, or None if the write may proceed.
-    Re-reading both the assignment and the submission is two extra requests on a
-    rare, irreversible, attempt-consuming operation, which is a trade worth
-    making. If the state cannot be re-read, that is treated as drift: proceeding
-    would mean submitting without the guarantee the student was promised.
+    Returns an error message if anything has changed, or None if the write may
+    proceed.
+
+    This exists because arbitrary time passes between the earlier checks and the
+    POST: the policy read, and for uploads a multi-step round trip per file. Any
+    precondition checked earlier can have changed in that window, so all of them
+    are re-checked here rather than only the attempt count. Three extra requests
+    on a rare, irreversible, attempt-consuming operation is a trade worth making.
+
+    If the state cannot be re-read, that counts as changed. Proceeding would mean
+    submitting without the guarantee the student was promised.
     """
+    # The instructor may have revoked agent writes while uploads were running,
+    # and the earlier grant may have been served from a cache that has since
+    # expired. The authoritative check is the last one before the write.
+    allowed, reason = await check_student_write_allowed(course_id, "submit_assignment")
+    if not allowed:
+        return f"❌ Submission blocked. {reason}"
+
     assignment = await make_canvas_request(
         "get", f"/courses/{course_id}/assignments/{assignment_id}"
     )
@@ -486,6 +511,16 @@ async def _attempt_state_changed(
         return (
             "❌ Could not re-check your attempt count just before submitting, so "
             "nothing was submitted. Try again shortly."
+        )
+
+    # The assignment may have become a group assignment in the meantime, which
+    # the tool refuses outright: submitting would bind classmates who never
+    # agreed to it and spend a shared attempt.
+    if assignment.get("group_category_id"):
+        return (
+            "❌ This became a group assignment while the submission was being "
+            "prepared, so nothing was submitted. Agent-assisted submission is "
+            "not supported for group assignments. Please submit it in Canvas."
         )
 
     current = _fingerprint(
@@ -840,18 +875,16 @@ def register_student_write_tools(mcp: FastMCP) -> None:
 
             assert_no_identity_override(data)
 
-            # Re-verify attempt state immediately before the write. Everything
-            # above involves awaited work — the policy read, and for uploads a
-            # multi-step round trip per file — during which another submission
-            # can land or an instructor can change allowed_attempts. Confirming
-            # against state read before all that would spend an attempt the
-            # student never agreed to.
-            drift_error = await _attempt_state_changed(
+            # Re-verify every precondition immediately before the write. See
+            # _final_preflight: arbitrary time has passed since the earlier
+            # checks, so policy, group status and attempt state are all rechecked
+            # rather than trusted.
+            preflight_error = await _final_preflight(
                 course_id, str(assignment_id), submission_type, digest, fingerprint
             )
-            if drift_error:
+            if preflight_error:
                 _release_confirmation(fingerprint)
-                return drift_error
+                return preflight_error
 
             # The claim taken above stands from here on. Even if this call
             # errors, the token is not released: Canvas may have accepted the

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -285,8 +285,22 @@ async def _upload_one(
     if isinstance(stored, dict) and "error" in stored:
         return None, f"❌ Upload failed for '{prepared.name}': {stored['error']}"
 
-    file_id = stored.get("id")
+    # Canvas storage answers in more than one shape. A 200/201 whose body is
+    # empty or non-JSON yields {"success": true} with no id, and a redirect
+    # confirmation can nest the file under "attachment". Check each documented
+    # shape before concluding the upload produced nothing usable.
+    file_id = (
+        stored.get("id")
+        or (stored.get("attachment") or {}).get("id")
+        or (stored.get("file") or {}).get("id")
+    )
     if not file_id:
+        if stored.get("success"):
+            return None, (
+                f"❌ '{prepared.name}' uploaded, but Canvas returned no file ID "
+                "to attach it with, so the submission was not sent. Check "
+                "whether the file appears in Canvas before retrying."
+            )
         return None, f"❌ Canvas did not return a file ID for '{prepared.name}'."
     return str(file_id), None
 
@@ -484,9 +498,12 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                 preview.append("")
 
                 if submission_type == "online_text_entry":
+                    # Shown in full, deliberately. The token authorizes the whole
+                    # body, so truncating here would ask the student to confirm
+                    # text they were never shown — which is exactly the thing
+                    # this preview exists to prevent.
                     text = body or ""
-                    excerpt = text[:500] + ("..." if len(text) > 500 else "")
-                    preview.append(f"Content ({len(text)} chars):\n{excerpt}")
+                    preview.append(f"Content ({len(text)} chars):\n{text}")
                 elif submission_type == "online_url":
                     preview.append(f"URL: {url}")
                 else:
@@ -503,7 +520,12 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                 )
                 return "\n".join(preview)
 
-            record = _pending_confirmations.pop(confirmation_token, None)
+            # Validate the token WITHOUT consuming it yet. Uploads happen before
+            # the submit call, and burning the token on an upload failure would
+            # force the student through a fresh preview for a problem that had
+            # nothing to do with their content. It is consumed just before the
+            # POST instead, which keeps it genuinely single-use.
+            record = _pending_confirmations.get(confirmation_token)
             if record is None:
                 return (
                     "❌ Unknown or already-used confirmation token. Run the "
@@ -511,6 +533,7 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                 )
             expires_at, expected = record
             if expires_at < time.monotonic():
+                _pending_confirmations.pop(confirmation_token, None)
                 return "❌ That confirmation expired. Run the preview again."
             if expected != fingerprint:
                 return (
@@ -538,7 +561,9 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                         course_id, str(assignment_id), item
                     )
                     if upload_error:
-                        return upload_error
+                        # Token deliberately left intact: nothing was submitted,
+                        # so the student can retry without re-previewing.
+                        return f"{upload_error}\nNothing was submitted."
                     file_ids.append(file_id)
                 data["submission[file_ids][]"] = file_ids
 
@@ -546,6 +571,14 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                 data["comment[text_comment]"] = comment
 
             assert_no_identity_override(data)
+
+            # Consume the token now, immediately before the only call that can
+            # actually spend an attempt.
+            if _pending_confirmations.pop(confirmation_token, None) is None:
+                return (
+                    "❌ That confirmation was already used. Nothing was "
+                    "submitted. Run the preview again."
+                )
 
             response = await make_canvas_request(
                 "post",

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -68,17 +68,21 @@ _SUPPORTED_TYPES = ("online_text_entry", "online_url", "online_upload")
 # preview and answer, short enough that course state cannot drift far.
 _CONFIRM_TTL_SECONDS = 300
 
-# Signing key for confirmation tokens. Tokens are self-contained and verified by
-# signature rather than looked up in a table, because a hosted deployment runs
-# several workers: a table-based token issued by one worker would be rejected as
-# unknown by another, and would not survive a restart inside the confirm window.
+# Signing key for confirmation tokens, generated per process and deliberately
+# NOT shareable between workers.
 #
-# An operator running multiple replicas must set STUDENT_WRITE_TOKEN_SECRET so
-# every replica signs alike. Left unset, each process generates its own key,
-# which is correct for stdio and for a single worker.
-_TOKEN_SECRET = (
-    os.getenv("STUDENT_WRITE_TOKEN_SECRET", "").encode() or secrets.token_bytes(32)
-)
+# A shared key would let the same token verify on every replica, and since the
+# claim that makes a confirmation single-use is process-local, two workers could
+# then accept the same token concurrently and both submit, spending two of the
+# student's attempts. Enforcing single-use across replicas would require shared
+# atomic state (Redis or a database), which this library should not require.
+#
+# So a token is redeemable only on the process that issued it. A hosted
+# deployment should use session affinity to keep a student's preview and confirm
+# on one worker; without affinity, a confirmation may be rejected and the
+# student simply previews again. That is an inconvenience. Silently spending a
+# second attempt is not.
+_TOKEN_SECRET = secrets.token_bytes(32)
 
 # Replay guard: fingerprint -> the time its claim can be forgotten. Entries only
 # need to outlive the token that created them, so they expire rather than
@@ -155,12 +159,20 @@ def _check_token(token: str, fingerprint: str) -> str | None:
     ).hexdigest()[:32]
     if not hmac.compare_digest(mac, expected):
         return (
-            "❌ The submission changed since the preview (content or attempt "
-            "count differs), or the token is not yours. Nothing was submitted. "
-            "Preview again."
+            "❌ This confirmation does not match. Either the submission changed "
+            "since the preview (content or attempt count differs), or the "
+            "preview was handled by a different server process. Nothing was "
+            "submitted. Preview again and confirm the new token."
         )
     if expiry < time.time():
         return "❌ That confirmation expired. Run the preview again."
+
+    # Purge before the membership test, not only inside the reservation. An
+    # uncertain submission error deliberately keeps its claim, and a later
+    # preview of unchanged content at an unchanged attempt count produces the
+    # same fingerprint — so without purging here, a quiet process would keep
+    # rejecting that retry long after the claim should have lapsed.
+    _purge_redeemed()
     if fingerprint in _redeemed:
         return (
             "❌ That confirmation was already used. Nothing was submitted. "

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -204,7 +204,15 @@ def _caller_identity() -> str:
     credentials = get_request_credentials()
     if credentials is None:
         return "stdio"
-    return hashlib.sha256(credentials.api_token.encode()).hexdigest()
+    # Keyed with the per-process token secret rather than bare SHA-256. Canvas
+    # tokens are high-entropy (this is not password hashing, whatever a scanner
+    # pattern-matches it as), but keying costs nothing and means a leaked
+    # fingerprint is not even a digest-of-the-token oracle. Stability within
+    # the process is all the confirmation flow needs, and _TOKEN_SECRET is
+    # per-process by design.
+    return hmac.new(
+        _TOKEN_SECRET, credentials.api_token.encode(), hashlib.sha256
+    ).hexdigest()
 
 
 class _PreparedFile:

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import base64
 import binascii
 import hashlib
+import hmac
 import os
 import secrets
 import tempfile
@@ -47,10 +48,13 @@ from ..core.course_policy import (
     assert_no_identity_override,
     check_student_write_allowed,
 )
-from ..core.credentials import is_http_request_active
+from ..core.credentials import get_request_credentials, is_http_request_active
 from ..core.dates import format_date
 from ..core.file_validation import (
+    ALLOWED_EXTENSIONS,
     DEFAULT_MAX_FILE_SIZE_BYTES,
+    detect_mime_type,
+    sanitize_filename,
     validate_file_for_upload,
 )
 from ..core.validation import validate_params
@@ -64,13 +68,88 @@ _SUPPORTED_TYPES = ("online_text_entry", "online_url", "online_upload")
 # preview and answer, short enough that course state cannot drift far.
 _CONFIRM_TTL_SECONDS = 300
 
-# token -> (expires_at_monotonic, payload_fingerprint)
-_pending_confirmations: dict[str, tuple[float, str]] = {}
+# Signing key for confirmation tokens. Tokens are self-contained and verified by
+# signature rather than looked up in a table, because a hosted deployment runs
+# several workers: a table-based token issued by one worker would be rejected as
+# unknown by another, and would not survive a restart inside the confirm window.
+#
+# An operator running multiple replicas must set STUDENT_WRITE_TOKEN_SECRET so
+# every replica signs alike. Left unset, each process generates its own key,
+# which is correct for stdio and for a single worker.
+_TOKEN_SECRET = (
+    os.getenv("STUDENT_WRITE_TOKEN_SECRET", "").encode() or secrets.token_bytes(32)
+)
+
+# Best-effort replay guard: fingerprints already redeemed by THIS process.
+# Single-use cannot be enforced across replicas without shared state, but replay
+# is separately defeated by the attempt number inside the fingerprint — once a
+# submission succeeds the attempt increments and the old token matches nothing.
+_redeemed: set[str] = set()
 
 
 def reset_pending_confirmations() -> None:
-    """Discard outstanding confirmation tokens (used by tests)."""
-    _pending_confirmations.clear()
+    """Discard redeemed-token state (used by tests)."""
+    _redeemed.clear()
+
+
+def _issue_token(fingerprint: str, now: float | None = None) -> str:
+    """Mint a confirmation token committing to ``fingerprint`` until it expires."""
+    expiry = int((now if now is not None else time.time()) + _CONFIRM_TTL_SECONDS)
+    mac = hmac.new(
+        _TOKEN_SECRET, f"{expiry}|{fingerprint}".encode(), hashlib.sha256
+    ).hexdigest()[:32]
+    return f"{expiry}.{mac}"
+
+
+def _check_token(token: str, fingerprint: str) -> str | None:
+    """Verify a token against the current request. Returns an error, or None.
+
+    The signature covers the fingerprint, which in turn covers the caller's own
+    credential, the target, the exact payload and the observed attempt count. So
+    a token cannot be moved to another student, another assignment, or different
+    content: any of those changes the fingerprint and the signature stops
+    matching.
+    """
+    expiry_text, _, mac = token.partition(".")
+    if not mac:
+        return (
+            "❌ That confirmation token is malformed. Run the preview again."
+        )
+    try:
+        expiry = int(expiry_text)
+    except ValueError:
+        return "❌ That confirmation token is malformed. Run the preview again."
+
+    expected = hmac.new(
+        _TOKEN_SECRET, f"{expiry}|{fingerprint}".encode(), hashlib.sha256
+    ).hexdigest()[:32]
+    if not hmac.compare_digest(mac, expected):
+        return (
+            "❌ The submission changed since the preview (content or attempt "
+            "count differs), or the token is not yours. Nothing was submitted. "
+            "Preview again."
+        )
+    if expiry < time.time():
+        return "❌ That confirmation expired. Run the preview again."
+    if fingerprint in _redeemed:
+        return (
+            "❌ That confirmation was already used. Nothing was submitted. "
+            "Run the preview again."
+        )
+    return None
+
+
+def _caller_identity() -> str:
+    """A stable, non-reversible handle for whoever is calling.
+
+    Hosted deployments pass a per-user Canvas token on every request, so this
+    distinguishes students without ever storing or logging the credential. In
+    stdio mode there is a single user and the constant is fine.
+    """
+    credentials = get_request_credentials()
+    if credentials is None:
+        return "stdio"
+    return hashlib.sha256(credentials.api_token.encode()).hexdigest()
 
 
 class _PreparedFile:
@@ -98,13 +177,21 @@ def _fingerprint(
     payload_digest: str,
     attempt: int,
 ) -> str:
-    """Bind a confirmation to exactly what was previewed.
+    """Bind a confirmation to exactly what was previewed, and to who previewed it.
 
     Including the observed attempt number means a submission that lands between
     preview and confirm invalidates the token rather than silently consuming a
     second attempt.
+
+    Including the caller identity matters on a hosted server, where each request
+    carries its own Canvas token: without it, a token issued to one student could
+    be redeemed by another whose attempt number happened to match, so the
+    confirmation would no longer authorize the account that saw the preview.
     """
-    raw = f"{course_id}|{assignment_id}|{submission_type}|{payload_digest}|{attempt}"
+    raw = (
+        f"{_caller_identity()}|{course_id}|{assignment_id}|"
+        f"{submission_type}|{payload_digest}|{attempt}"
+    )
     return hashlib.sha256(raw.encode()).hexdigest()
 
 
@@ -142,16 +229,6 @@ def _digest_payload(
     return hasher.hexdigest()
 
 
-def _purge_expired_confirmations() -> None:
-    """Drop timed-out confirmation records.
-
-    Without this, an abandoned preview lingers for the life of the process, so
-    a caller could grow the map without bound simply by previewing repeatedly
-    and never confirming.
-    """
-    now = time.monotonic()
-    for token in [t for t, (expiry, _) in _pending_confirmations.items() if expiry < now]:
-        _pending_confirmations.pop(token, None)
 
 
 def _describe_attempts(assignment: dict, submission: dict) -> str:
@@ -222,18 +299,24 @@ def _prepare_files(
         except (binascii.Error, ValueError):
             return [], f"❌ '{name}' is not valid base64."
 
-        # Validate the *name* (extension allowlist, sanitization) by writing to a
-        # temp file, so inline uploads get exactly the same checks as local ones.
-        handle_fd, temp_path = tempfile.mkstemp(suffix=os.path.splitext(name)[1])
-        try:
-            with os.fdopen(handle_fd, "wb") as handle:
-                handle.write(content)
-            result = validate_file_for_upload(temp_path)
-            if not result.valid:
-                return [], f"❌ Cannot submit '{name}': {result.error}"
-            prepared.append(_PreparedFile(name, content, result.mime_type))
-        finally:
-            os.unlink(temp_path)
+        # Validate the name the CLIENT actually supplied. An earlier version
+        # checked a temp file's random basename instead, which meant the
+        # sanitized result was discarded and a name like "../essay.pdf" reached
+        # Canvas untouched (and an odd extension could make mkstemp raise
+        # instead of returning a clean validation error).
+        safe_name = sanitize_filename(name)
+        extension = os.path.splitext(safe_name)[1].lower()
+        if extension not in ALLOWED_EXTENSIONS:
+            return [], (
+                f"❌ Cannot submit '{name}': '{extension or 'no extension'}' is "
+                "not an allowed file type."
+            )
+        if len(content) > DEFAULT_MAX_FILE_SIZE_BYTES:
+            return [], f"❌ '{name}' exceeds the maximum upload size."
+
+        prepared.append(
+            _PreparedFile(safe_name, content, detect_mime_type(safe_name))
+        )
 
     return prepared, None
 
@@ -477,12 +560,7 @@ def register_student_write_tools(mcp: FastMCP) -> None:
             )
 
             if not confirmation_token:
-                _purge_expired_confirmations()
-                token = secrets.token_urlsafe(16)
-                _pending_confirmations[token] = (
-                    time.monotonic() + _CONFIRM_TTL_SECONDS,
-                    fingerprint,
-                )
+                token = _issue_token(fingerprint)
 
                 preview = [
                     "📋 Submission preview — NOTHING has been submitted yet.",
@@ -520,26 +598,14 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                 )
                 return "\n".join(preview)
 
-            # Validate the token WITHOUT consuming it yet. Uploads happen before
-            # the submit call, and burning the token on an upload failure would
-            # force the student through a fresh preview for a problem that had
-            # nothing to do with their content. It is consumed just before the
-            # POST instead, which keeps it genuinely single-use.
-            record = _pending_confirmations.get(confirmation_token)
-            if record is None:
-                return (
-                    "❌ Unknown or already-used confirmation token. Run the "
-                    "preview again and confirm the fresh token."
-                )
-            expires_at, expected = record
-            if expires_at < time.monotonic():
-                _pending_confirmations.pop(confirmation_token, None)
-                return "❌ That confirmation expired. Run the preview again."
-            if expected != fingerprint:
-                return (
-                    "❌ The submission changed since the preview (content or "
-                    "attempt count differs). Nothing was submitted. Preview again."
-                )
+            # Verify WITHOUT marking it redeemed yet. Uploads happen before the
+            # submit call, and retiring the token on an upload failure would
+            # force the student through a fresh preview over a problem that had
+            # nothing to do with their content. It is retired just before the
+            # POST instead.
+            token_error = _check_token(confirmation_token, fingerprint)
+            if token_error:
+                return token_error
 
             # Re-check policy at the moment of the write, so an instructor's
             # change between preview and confirm takes effect.
@@ -572,13 +638,9 @@ def register_student_write_tools(mcp: FastMCP) -> None:
 
             assert_no_identity_override(data)
 
-            # Consume the token now, immediately before the only call that can
+            # Retire the token now, immediately before the only call that can
             # actually spend an attempt.
-            if _pending_confirmations.pop(confirmation_token, None) is None:
-                return (
-                    "❌ That confirmation was already used. Nothing was "
-                    "submitted. Run the preview again."
-                )
+            _redeemed.add(fingerprint)
 
             response = await make_canvas_request(
                 "post",

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -80,16 +80,46 @@ _TOKEN_SECRET = (
     os.getenv("STUDENT_WRITE_TOKEN_SECRET", "").encode() or secrets.token_bytes(32)
 )
 
-# Best-effort replay guard: fingerprints already redeemed by THIS process.
-# Single-use cannot be enforced across replicas without shared state, but replay
-# is separately defeated by the attempt number inside the fingerprint — once a
-# submission succeeds the attempt increments and the old token matches nothing.
-_redeemed: set[str] = set()
+# Replay guard: fingerprint -> the time its claim can be forgotten. Entries only
+# need to outlive the token that created them, so they expire rather than
+# accumulating for the lifetime of the process.
+#
+# This is per-process. Single-use cannot be enforced across replicas without
+# shared state, but replay is separately defeated by the attempt number inside
+# the fingerprint: once a submission succeeds the attempt increments and the old
+# token matches nothing.
+_redeemed: dict[str, float] = {}
 
 
 def reset_pending_confirmations() -> None:
     """Discard redeemed-token state (used by tests)."""
     _redeemed.clear()
+
+
+def _purge_redeemed() -> None:
+    """Forget claims whose tokens have expired anyway."""
+    now = time.time()
+    for fingerprint in [f for f, expiry in _redeemed.items() if expiry < now]:
+        _redeemed.pop(fingerprint, None)
+
+
+def _reserve_confirmation(fingerprint: str) -> bool:
+    """Atomically claim a confirmation. False if it was already claimed.
+
+    There is deliberately no ``await`` between the membership test and the
+    write, which is what makes this atomic on the event loop. Without that,
+    two overlapping confirmations could both pass and both submit.
+    """
+    _purge_redeemed()
+    if fingerprint in _redeemed:
+        return False
+    _redeemed[fingerprint] = time.time() + _CONFIRM_TTL_SECONDS
+    return True
+
+
+def _release_confirmation(fingerprint: str) -> None:
+    """Give a claim back after a path that ended without submitting."""
+    _redeemed.pop(fingerprint, None)
 
 
 def _issue_token(fingerprint: str, now: float | None = None) -> str:
@@ -598,14 +628,21 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                 )
                 return "\n".join(preview)
 
-            # Verify WITHOUT marking it redeemed yet. Uploads happen before the
-            # submit call, and retiring the token on an upload failure would
-            # force the student through a fresh preview over a problem that had
-            # nothing to do with their content. It is retired just before the
-            # POST instead.
             token_error = _check_token(confirmation_token, fingerprint)
             if token_error:
                 return token_error
+
+            # Claim the confirmation BEFORE any awaited work. File uploads sit
+            # between here and the submit call, so two overlapping confirmations
+            # could otherwise both pass validation during those uploads and both
+            # submit, spending two attempts. Reserving first makes that
+            # impossible; every path that ends without submitting releases it
+            # again, so a failed upload still does not cost a fresh preview.
+            if not _reserve_confirmation(fingerprint):
+                return (
+                    "❌ That confirmation was already used. Nothing was "
+                    "submitted. Run the preview again."
+                )
 
             # Re-check policy at the moment of the write, so an instructor's
             # change between preview and confirm takes effect.
@@ -613,6 +650,7 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                 course_id, "submit_assignment"
             )
             if not allowed:
+                _release_confirmation(fingerprint)
                 return f"❌ Submission blocked. {reason}"
 
             data: dict[str, Any] = {"submission[submission_type]": submission_type}
@@ -627,8 +665,9 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                         course_id, str(assignment_id), item
                     )
                     if upload_error:
-                        # Token deliberately left intact: nothing was submitted,
-                        # so the student can retry without re-previewing.
+                        # Release the claim: nothing was submitted, so the
+                        # student can retry without re-previewing.
+                        _release_confirmation(fingerprint)
                         return f"{upload_error}\nNothing was submitted."
                     file_ids.append(file_id)
                 data["submission[file_ids][]"] = file_ids
@@ -638,10 +677,10 @@ def register_student_write_tools(mcp: FastMCP) -> None:
 
             assert_no_identity_override(data)
 
-            # Retire the token now, immediately before the only call that can
-            # actually spend an attempt.
-            _redeemed.add(fingerprint)
-
+            # The claim taken above stands from here on. Even if this call
+            # errors, the token is not released: Canvas may have accepted the
+            # submission and only lost the reply, and a blind retry would spend
+            # a second attempt.
             response = await make_canvas_request(
                 "post",
                 f"/courses/{course_id}/assignments/{assignment_id}/submissions",

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -456,6 +456,55 @@ def _prepare_files(
     return prepared, None
 
 
+async def _attempt_state_changed(
+    course_id: str,
+    assignment_id: str,
+    submission_type: str,
+    payload_digest: str,
+    confirmed_fingerprint: str,
+) -> str | None:
+    """Confirm attempt state still matches what the confirmation committed to.
+
+    Returns an error message if it drifted, or None if the write may proceed.
+    Re-reading both the assignment and the submission is two extra requests on a
+    rare, irreversible, attempt-consuming operation, which is a trade worth
+    making. If the state cannot be re-read, that is treated as drift: proceeding
+    would mean submitting without the guarantee the student was promised.
+    """
+    assignment = await make_canvas_request(
+        "get", f"/courses/{course_id}/assignments/{assignment_id}"
+    )
+    submission = await make_canvas_request(
+        "get", f"/courses/{course_id}/assignments/{assignment_id}/submissions/self"
+    )
+    if (
+        not isinstance(assignment, dict)
+        or "error" in assignment
+        or not isinstance(submission, dict)
+        or "error" in submission
+    ):
+        return (
+            "❌ Could not re-check your attempt count just before submitting, so "
+            "nothing was submitted. Try again shortly."
+        )
+
+    current = _fingerprint(
+        course_id,
+        assignment_id,
+        submission_type,
+        payload_digest,
+        submission.get("attempt") or 0,
+        assignment.get("allowed_attempts"),
+    )
+    if current != confirmed_fingerprint:
+        return (
+            "❌ Your submission state changed while this was being prepared "
+            "(another submission landed, or the attempt limit changed). Nothing "
+            "was submitted. Check get_my_submission, then preview again."
+        )
+    return None
+
+
 async def _upload_one(
     course_id: str, assignment_id: str, prepared: _PreparedFile
 ) -> tuple[str | None, str | None]:
@@ -790,6 +839,19 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                 data["comment[text_comment]"] = comment
 
             assert_no_identity_override(data)
+
+            # Re-verify attempt state immediately before the write. Everything
+            # above involves awaited work — the policy read, and for uploads a
+            # multi-step round trip per file — during which another submission
+            # can land or an instructor can change allowed_attempts. Confirming
+            # against state read before all that would spend an attempt the
+            # student never agreed to.
+            drift_error = await _attempt_state_changed(
+                course_id, str(assignment_id), submission_type, digest, fingerprint
+            )
+            if drift_error:
+                _release_confirmation(fingerprint)
+                return drift_error
 
             # The claim taken above stands from here on. Even if this call
             # errors, the token is not released: Canvas may have accepted the

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -51,11 +51,9 @@ from ..core.course_policy import (
 from ..core.credentials import get_request_credentials, is_http_request_active
 from ..core.dates import format_date
 from ..core.file_validation import (
-    ALLOWED_EXTENSIONS,
     DEFAULT_MAX_FILE_SIZE_BYTES,
     detect_mime_type,
     sanitize_filename,
-    validate_file_for_upload,
 )
 from ..core.validation import validate_params
 
@@ -233,6 +231,7 @@ def _fingerprint(
     submission_type: str,
     payload_digest: str,
     attempt: int,
+    allowed_attempts: int | None = None,
 ) -> str:
     """Bind a confirmation to exactly what was previewed, and to who previewed it.
 
@@ -244,10 +243,16 @@ def _fingerprint(
     carries its own Canvas token: without it, a token issued to one student could
     be redeemed by another whose attempt number happened to match, so the
     confirmation would no longer authorize the account that saw the preview.
+
+    Including the attempt *limit* as well as the count matters because an
+    instructor can change ``allowed_attempts`` in between. A preview that said
+    "unlimited" could otherwise be confirmed against a freshly capped assignment
+    and spend what is now the final attempt, with the student having agreed to
+    something different.
     """
     raw = (
         f"{_caller_identity()}|{course_id}|{assignment_id}|"
-        f"{submission_type}|{payload_digest}|{attempt}"
+        f"{submission_type}|{payload_digest}|{attempt}|{allowed_attempts}"
     )
     return hashlib.sha256(raw.encode()).hexdigest()
 
@@ -306,9 +311,53 @@ def _describe_attempts(assignment: dict, submission: dict) -> str:
     return f"Attempts: {used} of {allowed} used, {remaining} remaining.{warning}"
 
 
+def _normalize_extensions(raw: list[str] | None) -> frozenset[str] | None:
+    """Normalize an assignment's ``allowed_extensions`` into ``{'.pdf', ...}``.
+
+    Canvas stores these without leading dots and with inconsistent case. An
+    empty or absent list means the assignment does not restrict types.
+    """
+    if not raw:
+        return None
+    return frozenset(
+        f".{str(ext).strip().lstrip('.').lower()}" for ext in raw if str(ext).strip()
+    )
+
+
+def _check_submission_name(
+    name: str, allowed_extensions: frozenset[str] | None
+) -> tuple[str, str | None]:
+    """Sanitize a filename and check it against the ASSIGNMENT's own rules.
+
+    Returns ``(safe_name, error)``.
+
+    Deliberately no global extension allowlist. The instructor's
+    ``allowed_extensions`` on the assignment is the legitimate statement of what
+    that assignment accepts; a separate hard-coded list can only disagree with
+    it, and the one previously used here rejected ordinary student work such as
+    ``.heic`` photos and ``.tex`` sources. Sanitization is still applied, since
+    a malicious *path* is a real attack whereas an unusual extension is not.
+    """
+    safe_name = sanitize_filename(name)
+    if not safe_name or safe_name in (".", ".."):
+        return "", f"❌ '{name}' is not a usable filename."
+
+    if allowed_extensions is not None:
+        extension = os.path.splitext(safe_name)[1].lower()
+        if extension not in allowed_extensions:
+            accepted = ", ".join(sorted(allowed_extensions))
+            return "", (
+                f"❌ This assignment does not accept "
+                f"'{extension or 'files without an extension'}'. "
+                f"It accepts: {accepted}"
+            )
+    return safe_name, None
+
+
 def _prepare_files(
     file_paths: list[str] | None,
     file_contents: list[dict[str, str]] | None,
+    allowed_extensions: frozenset[str] | None = None,
 ) -> tuple[list[_PreparedFile], str | None]:
     """Resolve either ingress mode into raw bytes.
 
@@ -343,18 +392,31 @@ def _prepare_files(
     running_bytes = 0
 
     for path in file_paths or []:
-        result = validate_file_for_upload(path)
-        if not result.valid:
-            return [], f"❌ Cannot submit '{path}': {result.error}"
-        running_bytes += result.file_size
+        if not os.path.isfile(path):
+            return [], f"❌ Cannot submit '{path}': no such file."
+        try:
+            file_size = os.path.getsize(path)
+        except OSError as exc:
+            return [], f"❌ Could not read '{path}': {exc}"
+        if file_size > DEFAULT_MAX_FILE_SIZE_BYTES:
+            return [], f"❌ '{path}' exceeds the maximum upload size."
+        running_bytes += file_size
         if running_bytes > _MAX_TOTAL_UPLOAD_BYTES:
             return [], _too_large_message()
+
+        safe_name, name_error = _check_submission_name(
+            os.path.basename(path), allowed_extensions
+        )
+        if name_error:
+            return [], name_error
         try:
             with open(path, "rb") as handle:
                 content = handle.read()
         except OSError as exc:
             return [], f"❌ Could not read '{path}': {exc}"
-        prepared.append(_PreparedFile(result.sanitized_name, content, result.mime_type))
+        prepared.append(
+            _PreparedFile(safe_name, content, detect_mime_type(safe_name))
+        )
 
     for entry in file_contents or []:
         name = str(entry.get("name") or "").strip()
@@ -380,15 +442,10 @@ def _prepare_files(
         # Validate the name the CLIENT actually supplied. An earlier version
         # checked a temp file's random basename instead, which meant the
         # sanitized result was discarded and a name like "../essay.pdf" reached
-        # Canvas untouched (and an odd extension could make mkstemp raise
-        # instead of returning a clean validation error).
-        safe_name = sanitize_filename(name)
-        extension = os.path.splitext(safe_name)[1].lower()
-        if extension not in ALLOWED_EXTENSIONS:
-            return [], (
-                f"❌ Cannot submit '{name}': '{extension or 'no extension'}' is "
-                "not an allowed file type."
-            )
+        # Canvas untouched.
+        safe_name, name_error = _check_submission_name(name, allowed_extensions)
+        if name_error:
+            return [], name_error
         if len(content) > DEFAULT_MAX_FILE_SIZE_BYTES:
             return [], f"❌ '{name}' exceeds the maximum upload size."
 
@@ -628,13 +685,22 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                 )
             attempt = submission.get("attempt") or 0
 
-            prepared, prep_error = _prepare_files(file_paths, file_contents)
+            prepared, prep_error = _prepare_files(
+                file_paths,
+                file_contents,
+                _normalize_extensions(assignment.get("allowed_extensions")),
+            )
             if prep_error:
                 return prep_error
 
             digest = _digest_payload(body, url, comment, prepared)
             fingerprint = _fingerprint(
-                course_id, str(assignment_id), submission_type, digest, attempt
+                course_id,
+                str(assignment_id),
+                submission_type,
+                digest,
+                attempt,
+                assignment.get("allowed_attempts"),
             )
 
             if not confirmation_token:

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -109,18 +109,49 @@ def _fingerprint(
 
 
 def _digest_payload(
-    body: str | None, url: str | None, files: list[_PreparedFile]
+    body: str | None,
+    url: str | None,
+    comment: str | None,
+    files: list[_PreparedFile],
 ) -> str:
-    """Hash the exact content that would be submitted."""
+    """Hash the exact content that would be submitted.
+
+    Every field is length-prefixed rather than concatenated, because plain
+    concatenation is ambiguous: a file named ``a.txt`` holding ``XPAYLOAD``
+    would hash identically to one named ``a.txtX`` holding ``PAYLOAD``. That
+    would let a token approve content other than what was previewed, which is
+    precisely the guarantee this digest exists to provide.
+
+    ``comment`` is covered too. The preview displays it, so a confirmation that
+    did not commit to it could swap in text the student never saw before it
+    reached their instructor.
+    """
     hasher = hashlib.sha256()
-    hasher.update((body or "").encode())
-    hasher.update(b"\x00")
-    hasher.update((url or "").encode())
+
+    def absorb(chunk: bytes) -> None:
+        hasher.update(len(chunk).to_bytes(8, "big"))
+        hasher.update(chunk)
+
+    absorb((body or "").encode())
+    absorb((url or "").encode())
+    absorb((comment or "").encode())
+    absorb(len(files).to_bytes(8, "big"))
     for prepared in files:
-        hasher.update(b"\x00")
-        hasher.update(prepared.name.encode())
-        hasher.update(prepared.content)
+        absorb(prepared.name.encode())
+        absorb(prepared.content)
     return hasher.hexdigest()
+
+
+def _purge_expired_confirmations() -> None:
+    """Drop timed-out confirmation records.
+
+    Without this, an abandoned preview lingers for the life of the process, so
+    a caller could grow the map without bound simply by previewing repeatedly
+    and never confirming.
+    """
+    now = time.monotonic()
+    for token in [t for t, (expiry, _) in _pending_confirmations.items() if expiry < now]:
+        _pending_confirmations.pop(token, None)
 
 
 def _describe_attempts(assignment: dict, submission: dict) -> str:
@@ -405,20 +436,34 @@ def register_student_write_tools(mcp: FastMCP) -> None:
                 "get",
                 f"/courses/{course_id}/assignments/{assignment_id}/submissions/self",
             )
+            # Attempt state is not optional context here: it is what the preview
+            # reports and what the confirmation commits to. Substituting zero on
+            # a failed read would show the student a false attempt count and
+            # make the drift check vacuous, so stop instead.
             if not isinstance(submission, dict) or "error" in submission:
-                submission = {}
+                detail = (
+                    submission.get("error")
+                    if isinstance(submission, dict)
+                    else "unexpected response from Canvas"
+                )
+                return (
+                    "❌ Could not read your current submission state, so the "
+                    f"attempt count is unknown: {detail}\n"
+                    "Nothing was submitted. Try again shortly."
+                )
             attempt = submission.get("attempt") or 0
 
             prepared, prep_error = _prepare_files(file_paths, file_contents)
             if prep_error:
                 return prep_error
 
-            digest = _digest_payload(body, url, prepared)
+            digest = _digest_payload(body, url, comment, prepared)
             fingerprint = _fingerprint(
                 course_id, str(assignment_id), submission_type, digest, attempt
             )
 
             if not confirmation_token:
+                _purge_expired_confirmations()
                 token = secrets.token_urlsafe(16)
                 _pending_confirmations[token] = (
                     time.monotonic() + _CONFIRM_TTL_SECONDS,

--- a/tests/security/test_student_write_invariants.py
+++ b/tests/security/test_student_write_invariants.py
@@ -1,0 +1,364 @@
+"""Security invariants for Tier 1 student write tools (#170).
+
+These tests exist to make specific public promises falsifiable. Each one
+corresponds to a claim made to institutions evaluating this server, and each
+should fail loudly if a future change quietly breaks it.
+"""
+
+import inspect
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from canvas_mcp.core.config import get_config, reset_config
+from canvas_mcp.core.course_policy import (
+    assert_no_identity_override,
+    check_student_write_allowed,
+    get_course_policy,
+    parse_policy_body,
+    reset_policy_cache,
+)
+from canvas_mcp.tools.student_write import (
+    register_student_write_tools,
+    reset_pending_confirmations,
+)
+
+ALL_WRITE_TOOLS = "submit_assignment,comment_on_my_submission,mark_module_item_done"
+
+# Any parameter that could let a caller name someone other than themselves.
+IDENTITY_PARAMS = {
+    "user_id", "as_user_id", "student_id", "assessor_id",
+    "user", "student", "on_behalf_of", "group_id",
+}
+
+
+def get_tools(**env):
+    captured = {}
+    mcp = FastMCP("test")
+    original_tool = mcp.tool
+
+    def capturing_tool(*args, **kwargs):
+        decorator = original_tool(*args, **kwargs)
+
+        def wrapper(fn):
+            captured[fn.__name__] = fn
+            return decorator(fn)
+
+        return wrapper
+
+    mcp.tool = capturing_tool
+    with patch.dict("os.environ", env, clear=False):
+        reset_config()
+        register_student_write_tools(mcp)
+    return captured
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    reset_config()
+    reset_policy_cache()
+    reset_pending_confirmations()
+    yield
+    reset_config()
+    reset_policy_cache()
+    reset_pending_confirmations()
+
+
+class TestNoIdentityOverride:
+    """A student write must not be able to name another student."""
+
+    def test_no_write_tool_accepts_an_identity_parameter(self):
+        tools = get_tools(STUDENT_WRITE_TOOLS=ALL_WRITE_TOOLS)
+        for name, fn in tools.items():
+            params = set(inspect.signature(fn).parameters)
+            offending = params & IDENTITY_PARAMS
+            assert not offending, f"{name} exposes identity parameter(s): {offending}"
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "as_user_id",
+            "submission[user_id]",
+            "user_id",
+            "submission[group_id]",
+            "group_id",
+            "student_id",
+        ],
+    )
+    def test_guard_rejects_each_identity_field(self, field):
+        """The wire-level guard, not just the Python signature.
+
+        This matters because the submit endpoint is NOT structurally
+        self-scoped: Canvas honours submission[user_id] there when the token
+        carries grading permission, and a person can hold both student and TA
+        enrollments.
+        """
+        with pytest.raises(ValueError, match="identity-override"):
+            assert_no_identity_override({"submission[body]": "x", field: "999"})
+
+    def test_guard_allows_a_legitimate_body(self):
+        assert_no_identity_override(
+            {
+                "submission[submission_type]": "online_text_entry",
+                "submission[body]": "my essay",
+                "comment[text_comment]": "here you go",
+            }
+        )
+
+    @pytest.mark.asyncio
+    async def test_submitted_body_carries_no_identity_fields(self):
+        """Assert on what actually goes over the wire."""
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS=ALL_WRITE_TOOLS, COURSE_AGENT_POLICY_ENABLED="false"
+        )
+        assignment = {
+            "id": 42, "name": "Essay", "submission_types": ["online_text_entry"],
+            "allowed_attempts": -1,
+        }
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [assignment, {"attempt": 0}]
+            preview = await tools["submit_assignment"](
+                course_identifier="T", assignment_id=42,
+                submission_type="online_text_entry", body="essay",
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+            request.side_effect = [assignment, {"attempt": 0}, {"attempt": 1}]
+            await tools["submit_assignment"](
+                course_identifier="T", assignment_id=42,
+                submission_type="online_text_entry", body="essay",
+                confirmation_token=token,
+            )
+
+        post = [c for c in request.call_args_list if c.args[0] == "post"][0]
+        sent = post.kwargs["data"]
+        assert set(sent) <= {
+            "submission[submission_type]", "submission[body]",
+            "submission[url]", "submission[file_ids][]", "comment[text_comment]",
+        }, f"unexpected outbound fields: {set(sent)}"
+
+
+class TestHostedFileIngress:
+    """file_paths reads the SERVER's disk. That must not be reachable remotely."""
+
+    @pytest.mark.asyncio
+    async def test_local_paths_refused_over_http_transport(self):
+        """Otherwise a remote caller could exfiltrate server files.
+
+        They would name any path the server process can read and upload it into
+        their own Canvas submission.
+        """
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS=ALL_WRITE_TOOLS, COURSE_AGENT_POLICY_ENABLED="false"
+        )
+        assignment = {
+            "id": 42, "name": "E", "submission_types": ["online_upload"],
+            "allowed_attempts": -1,
+        }
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request, patch(
+            "canvas_mcp.tools.student_write.is_http_request_active", return_value=True
+        ):
+            request.side_effect = [assignment, {"attempt": 0}]
+            result = await tools["submit_assignment"](
+                course_identifier="T", assignment_id=42,
+                submission_type="online_upload", file_paths=["/etc/passwd"],
+            )
+
+        assert "only available on a local (stdio) server" in result
+        assert not [c for c in request.call_args_list if c.args[0] == "post"]
+
+
+class TestPolicyParsing:
+    """A policy only grants when it definitively says so."""
+
+    def test_deny_is_parsed(self):
+        assert parse_policy_body("agent_writes: deny").allow_writes is False
+
+    def test_allow_is_parsed(self):
+        policy = parse_policy_body("agent_writes: allow")
+        assert policy.allow_writes is True
+        assert policy.allow_tools is None
+
+    def test_allow_can_narrow_to_named_tools(self):
+        policy = parse_policy_body(
+            "agent_writes: allow\nallow_tools: submit_assignment"
+        )
+        assert policy.allow_tools == frozenset({"submit_assignment"})
+
+    def test_survives_canvas_rich_text_markup(self):
+        policy = parse_policy_body("<p>agent_writes: allow</p><p>note: go ahead</p>")
+        assert policy.allow_writes is True
+        assert policy.note == "go ahead"
+
+    def test_malformed_policy_denies(self):
+        """A typo must never become a grant."""
+        assert parse_policy_body("agent_writes: yes please").allow_writes is False
+        assert parse_policy_body("total gibberish").allow_writes is False
+        assert parse_policy_body("").allow_writes is False
+
+
+class TestPolicyResolution:
+    """Failure modes must all fail closed, except a definitively absent policy."""
+
+    @pytest.mark.asyncio
+    async def test_read_error_denies_even_when_default_is_allow(self):
+        """A Canvas outage must not silently grant writes everywhere."""
+        with patch.dict(
+            "os.environ", {"COURSE_AGENT_POLICY_DEFAULT": "allow"}, clear=False
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(return_value={"error": "HTTP error: 500"}),
+            ):
+                policy = await get_course_policy("123")
+        assert policy.allow_writes is False
+        assert policy.source == "read_error"
+
+    @pytest.mark.asyncio
+    async def test_absent_policy_uses_configured_default(self):
+        for posture, expected in (("allow", True), ("deny", False)):
+            reset_policy_cache()
+            with patch.dict(
+                "os.environ", {"COURSE_AGENT_POLICY_DEFAULT": posture}, clear=False
+            ):
+                reset_config()
+                with patch(
+                    "canvas_mcp.core.course_policy.make_canvas_request",
+                    new=AsyncMock(return_value={"syllabus_body": "<p>Welcome!</p>"}),
+                ):
+                    policy = await get_course_policy("123")
+            assert policy.allow_writes is expected
+            assert policy.source == "default"
+
+    @pytest.mark.asyncio
+    async def test_default_posture_is_deny(self):
+        reset_config()
+        assert get_config().course_agent_policy_default == "deny"
+
+    @pytest.mark.asyncio
+    async def test_syllabus_is_the_default_carrier(self):
+        """The carrier must be one students cannot edit."""
+        reset_config()
+        assert get_config().course_agent_policy_source == "syllabus"
+
+    @pytest.mark.asyncio
+    async def test_student_editable_page_is_not_trusted(self):
+        """A page a student could have written is not an instructor statement."""
+        with patch.dict(
+            "os.environ",
+            {"COURSE_AGENT_POLICY_SOURCE": "page", "COURSE_AGENT_POLICY_DEFAULT": "allow"},
+            clear=False,
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(
+                    return_value={
+                        "body": "agent_writes: allow",
+                        "editing_roles": "teachers,students",
+                    }
+                ),
+            ):
+                policy = await get_course_policy("123")
+        assert policy.allow_writes is False
+        assert policy.source == "untrusted_artifact"
+
+    @pytest.mark.asyncio
+    async def test_teacher_only_page_is_trusted(self):
+        with patch.dict(
+            "os.environ", {"COURSE_AGENT_POLICY_SOURCE": "page"}, clear=False
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(
+                    return_value={
+                        "body": "agent_writes: allow",
+                        "editing_roles": "teachers",
+                    }
+                ),
+            ):
+                policy = await get_course_policy("123")
+        assert policy.allow_writes is True
+
+
+class TestLayering:
+    """A course artifact can restrict within the operator ceiling, never past it."""
+
+    @pytest.mark.asyncio
+    async def test_course_cannot_enable_a_tool_the_operator_disabled(self):
+        with patch.dict(
+            "os.environ", {"STUDENT_WRITE_TOOLS": "comment_on_my_submission"}, clear=False
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(
+                    return_value={
+                        "syllabus_body": "agent_writes: allow\n"
+                                         "allow_tools: submit_assignment"
+                    }
+                ),
+            ):
+                allowed, reason = await check_student_write_allowed(
+                    "123", "submit_assignment"
+                )
+        assert allowed is False
+        assert "STUDENT_WRITE_TOOLS" in reason
+
+    @pytest.mark.asyncio
+    async def test_course_can_restrict_within_the_ceiling(self):
+        with patch.dict(
+            "os.environ", {"STUDENT_WRITE_TOOLS": ALL_WRITE_TOOLS}, clear=False
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(
+                    return_value={
+                        "syllabus_body": "agent_writes: allow\n"
+                                         "allow_tools: comment_on_my_submission"
+                    }
+                ),
+            ):
+                allowed_comment, _ = await check_student_write_allowed(
+                    "123", "comment_on_my_submission"
+                )
+                allowed_submit, reason = await check_student_write_allowed(
+                    "123", "submit_assignment"
+                )
+        assert allowed_comment is True
+        assert allowed_submit is False
+        assert "not 'submit_assignment'" in reason
+
+    @pytest.mark.asyncio
+    async def test_course_deny_blocks_an_operator_enabled_tool(self):
+        with patch.dict(
+            "os.environ", {"STUDENT_WRITE_TOOLS": ALL_WRITE_TOOLS}, clear=False
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(
+                    return_value={
+                        "syllabus_body": "agent_writes: deny\n"
+                                         "note: Please submit in Canvas directly."
+                    }
+                ),
+            ):
+                allowed, reason = await check_student_write_allowed(
+                    "123", "submit_assignment"
+                )
+        assert allowed is False
+        assert "Please submit in Canvas directly." in reason

--- a/tests/security/test_student_write_invariants.py
+++ b/tests/security/test_student_write_invariants.py
@@ -116,27 +116,35 @@ class TestNoIdentityOverride:
             "id": 42, "name": "Essay", "submission_types": ["online_text_entry"],
             "allowed_attempts": -1,
         }
+        posts = []
+
+        async def responder(method, endpoint, **kwargs):
+            if method == "get":
+                if endpoint.endswith("/submissions/self"):
+                    return {"attempt": 0}
+                return assignment
+            posts.append(kwargs.get("data"))
+            return {"submitted_at": "2026-07-30T10:00:00Z", "attempt": 1}
+
         with patch(
             "canvas_mcp.tools.student_write.get_course_id",
             new=AsyncMock(return_value="123"),
         ), patch(
-            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
-        ) as request:
-            request.side_effect = [assignment, {"attempt": 0}]
+            "canvas_mcp.tools.student_write.make_canvas_request", new=responder
+        ):
             preview = await tools["submit_assignment"](
                 course_identifier="T", assignment_id=42,
                 submission_type="online_text_entry", body="essay",
             )
             token = preview.split("confirmation_token='")[1].split("'")[0]
-            request.side_effect = [assignment, {"attempt": 0}, {"attempt": 1}]
             await tools["submit_assignment"](
                 course_identifier="T", assignment_id=42,
                 submission_type="online_text_entry", body="essay",
                 confirmation_token=token,
             )
 
-        post = [c for c in request.call_args_list if c.args[0] == "post"][0]
-        sent = post.kwargs["data"]
+        assert posts, "nothing was submitted"
+        sent = posts[0]
         assert set(sent) <= {
             "submission[submission_type]", "submission[body]",
             "submission[url]", "submission[file_ids][]", "comment[text_comment]",
@@ -413,6 +421,24 @@ class TestPolicyParsing:
         )
         assert policy.allow_writes is False
         assert policy.source == "course_artifact_conflict"
+
+    def test_present_but_empty_allow_tools_denies(self):
+        """The most restrictive directive must not become the least restrictive.
+
+        `tools or None` collapsed an empty allowlist into "no narrowing", i.e.
+        every operator-enabled tool. An instructor who wrote `allow_tools:` and
+        stopped, or deliberately named nothing, would have been granting
+        everything.
+        """
+        policy = parse_policy_body("agent_writes: allow\nallow_tools:")
+        assert policy.allow_writes is False
+        assert policy.source == "course_artifact_empty_allowlist"
+
+    def test_omitted_allow_tools_means_no_narrowing(self):
+        """Absent is different from present-but-empty."""
+        policy = parse_policy_body("agent_writes: allow")
+        assert policy.allow_writes is True
+        assert policy.allow_tools is None
 
     def test_malformed_policy_denies(self):
         """A typo must never become a grant."""

--- a/tests/security/test_student_write_invariants.py
+++ b/tests/security/test_student_write_invariants.py
@@ -210,14 +210,55 @@ class TestInlineFilenames:
         assert ".." not in prepared[0].name
         assert "/" not in prepared[0].name
 
-    def test_disallowed_extension_is_refused(self):
+    def test_the_assignment_decides_which_types_are_allowed(self):
+        """The instructor's allowed_extensions is the authority, not a global list.
+
+        An earlier version enforced a hard-coded allowlist here, which could only
+        ever disagree with the instructor, and which rejected ordinary student
+        work such as .heic photos.
+        """
         from canvas_mcp.tools.student_write import _prepare_files
 
         _, error = _prepare_files(
-            None, [{"name": "payload.exe", "content_base64": "TVo="}]
+            None,
+            [{"name": "photo.heic", "content_base64": "YWJj"}],
+            allowed_extensions=frozenset({".pdf"}),
         )
         assert error is not None
-        assert "not an allowed file type" in error
+        assert "does not accept" in error
+        assert ".pdf" in error, "the student should be told what IS accepted"
+
+    def test_types_the_assignment_permits_are_accepted(self):
+        from canvas_mcp.tools.student_write import _prepare_files
+
+        prepared, error = _prepare_files(
+            None,
+            [{"name": "photo.heic", "content_base64": "YWJj"}],
+            allowed_extensions=frozenset({".heic", ".jpg"}),
+        )
+        assert error is None
+        assert prepared[0].name == "photo.heic"
+
+    def test_unrestricted_assignments_accept_any_type(self):
+        """No global allowlist: .heic and .tex must both go through."""
+        from canvas_mcp.tools.student_write import _prepare_files
+
+        for name in ["photo.heic", "paper.tex", "data.dta"]:
+            prepared, error = _prepare_files(
+                None, [{"name": name, "content_base64": "YWJj"}]
+            )
+            assert error is None, f"{name} was rejected with no assignment restriction"
+            assert prepared[0].name == name
+
+    def test_canvas_extension_format_is_normalized(self):
+        """Canvas stores allowed_extensions without dots and in mixed case."""
+        from canvas_mcp.tools.student_write import _normalize_extensions
+
+        assert _normalize_extensions(["PDF", "docx", ".Heic"]) == frozenset(
+            {".pdf", ".docx", ".heic"}
+        )
+        assert _normalize_extensions([]) is None
+        assert _normalize_extensions(None) is None
 
     def test_odd_extension_returns_an_error_not_an_exception(self):
         from canvas_mcp.tools.student_write import _prepare_files
@@ -343,6 +384,36 @@ class TestPolicyParsing:
         assert policy.allow_writes is True
         assert policy.note == "go ahead"
 
+    def test_a_later_deny_is_never_discarded(self):
+        """An appended revocation must not be swallowed by an earlier allow.
+
+        Keeping only the first occurrence of a key would let an instructor who
+        adds "agent_writes: deny" below an existing "agent_writes: allow" have
+        their revocation silently ignored, which is the worst direction for this
+        to fail.
+        """
+        policy = parse_policy_body("agent_writes: allow\nagent_writes: deny")
+        assert policy.allow_writes is False
+        assert policy.source == "course_artifact_conflict"
+
+    def test_conflict_denies_in_either_order(self):
+        assert parse_policy_body(
+            "agent_writes: deny\nagent_writes: allow"
+        ).allow_writes is False
+
+    def test_repeating_the_same_directive_is_not_a_conflict(self):
+        policy = parse_policy_body("agent_writes: allow\nagent_writes: allow")
+        assert policy.allow_writes is True
+
+    def test_conflicting_allow_tools_denies(self):
+        policy = parse_policy_body(
+            "agent_writes: allow\n"
+            "allow_tools: submit_assignment\n"
+            "allow_tools: mark_module_item_done"
+        )
+        assert policy.allow_writes is False
+        assert policy.source == "course_artifact_conflict"
+
     def test_malformed_policy_denies(self):
         """A typo must never become a grant."""
         assert parse_policy_body("agent_writes: yes please").allow_writes is False
@@ -390,79 +461,44 @@ class TestPolicyResolution:
         assert get_config().course_agent_policy_default == "deny"
 
     @pytest.mark.asyncio
-    async def test_syllabus_is_the_default_carrier(self):
-        """The carrier must be one students cannot edit."""
-        reset_config()
-        assert get_config().course_agent_policy_source == "syllabus"
+    async def test_the_syllabus_is_the_only_carrier(self):
+        """There is deliberately no way to select a weaker policy carrier.
 
-    @pytest.mark.asyncio
-    async def test_student_editable_page_is_not_trusted(self):
-        """A page a student could have written is not an instructor statement."""
-        with patch.dict(
-            "os.environ",
-            {"COURSE_AGENT_POLICY_SOURCE": "page", "COURSE_AGENT_POLICY_DEFAULT": "allow"},
-            clear=False,
-        ):
-            reset_config()
-            with patch(
-                "canvas_mcp.core.course_policy.make_canvas_request",
-                new=AsyncMock(
-                    return_value={
-                        "body": "agent_writes: allow",
-                        "editing_roles": "teachers,students",
-                    }
-                ),
-            ):
-                policy = await get_course_policy("123")
-        assert policy.allow_writes is False
-        assert policy.source == "untrusted_artifact"
-
-    @pytest.mark.parametrize(
-        "editing_roles",
-        [None, "", "teachers,students", "students", "anyone", "members", "public"],
-    )
-    @pytest.mark.asyncio
-    async def test_page_is_trusted_only_when_explicitly_teacher_only(self, editing_roles):
-        """Ambiguity must fail closed.
-
-        A denylist of known-bad role names would trust a page whose
-        editing_roles is missing, empty, or a value Canvas introduces later.
+        A course-page carrier was implemented and then removed: editing_roles
+        describes who may edit a page NOW, not who wrote it, so a student who
+        can create pages could author the policy and lock it teacher-only
+        afterwards. Authorship cannot be established from a student's own token,
+        so a page can never be trustworthy here however it is screened. This
+        test exists to keep that option from being reintroduced as a config knob.
         """
-        reset_policy_cache()
-        with patch.dict(
-            "os.environ",
-            {"COURSE_AGENT_POLICY_SOURCE": "page", "COURSE_AGENT_POLICY_DEFAULT": "allow"},
-            clear=False,
-        ):
-            reset_config()
-            page = {"body": "agent_writes: allow"}
-            if editing_roles is not None:
-                page["editing_roles"] = editing_roles
-            with patch(
-                "canvas_mcp.core.course_policy.make_canvas_request",
-                new=AsyncMock(return_value=page),
-            ):
-                policy = await get_course_policy("123")
-        assert policy.allow_writes is False
-        assert policy.source == "untrusted_artifact"
+        reset_config()
+        config = get_config()
+        assert not hasattr(config, "course_agent_policy_source")
+        assert not hasattr(config, "course_agent_policy_page")
 
     @pytest.mark.asyncio
-    async def test_teacher_only_page_is_trusted(self):
+    async def test_policy_is_read_from_the_course_syllabus(self):
+        reset_policy_cache()
+        seen = {}
+
+        async def recorder(method, endpoint, **kwargs):
+            seen["endpoint"] = endpoint
+            seen["params"] = kwargs.get("params")
+            return {"syllabus_body": "agent_writes: allow"}
+
         with patch.dict(
-            "os.environ", {"COURSE_AGENT_POLICY_SOURCE": "page"}, clear=False
+            "os.environ", {"STUDENT_WRITE_TOOLS": ALL_WRITE_TOOLS}, clear=False
         ):
             reset_config()
             with patch(
-                "canvas_mcp.core.course_policy.make_canvas_request",
-                new=AsyncMock(
-                    return_value={
-                        "body": "agent_writes: allow",
-                        "editing_roles": "teachers",
-                    }
-                ),
+                "canvas_mcp.core.course_policy.make_canvas_request", new=recorder
             ):
                 policy = await get_course_policy("123")
+
         assert policy.allow_writes is True
+        assert seen["endpoint"] == "/courses/123"
+        assert "syllabus_body" in seen["params"]["include[]"]
+        assert "pages" not in seen["endpoint"]
 
 
 class TestErrorClassification:
@@ -563,27 +599,6 @@ class TestErrorClassification:
                 real = await get_course_policy("999")
         assert real.allow_writes is False
         assert real.source == "course_artifact"
-
-    @pytest.mark.asyncio
-    async def test_ambiguous_page_404_is_not_cached(self):
-        """In page mode a 404 could be "no page" or "no access". Never cache it."""
-        from canvas_mcp.core.course_policy import _policy_cache
-
-        reset_policy_cache()
-        with patch.dict(
-            "os.environ",
-            {"COURSE_AGENT_POLICY_SOURCE": "page", "COURSE_AGENT_POLICY_DEFAULT": "allow"},
-            clear=False,
-        ):
-            reset_config()
-            with patch(
-                "canvas_mcp.core.course_policy.make_canvas_request",
-                new=AsyncMock(return_value={"error": "HTTP error: 404"}),
-            ):
-                policy = await get_course_policy("777")
-        assert policy.allow_writes is True  # default posture honoured
-        assert policy.source == "default_uncached"
-        assert "777" not in _policy_cache
 
     @pytest.mark.asyncio
     async def test_unmarked_syllabus_is_a_cacheable_absence(self):

--- a/tests/security/test_student_write_invariants.py
+++ b/tests/security/test_student_write_invariants.py
@@ -474,7 +474,88 @@ class TestErrorClassification:
         assert policy.allow_writes is True
 
     @pytest.mark.asyncio
-    async def test_genuine_404_is_treated_as_absent(self):
+    async def test_inaccessible_course_denies_and_is_not_cached(self):
+        """A 404 on the course means this caller cannot see it, not "no policy".
+
+        Caching that as an absence would let one caller without access install a
+        global verdict, and under a permissive default that verdict would
+        override an instructor's explicit denial.
+        """
+        from canvas_mcp.core.course_policy import _policy_cache
+
+        reset_policy_cache()
+        with patch.dict(
+            "os.environ", {"COURSE_AGENT_POLICY_DEFAULT": "allow"}, clear=False
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(return_value={"error": "HTTP error: 404"}),
+            ):
+                policy = await get_course_policy("999")
+            assert policy.allow_writes is False
+            assert "999" not in _policy_cache
+
+            # An instructor's actual denial is what a real student then sees.
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(
+                    return_value={"syllabus_body": "agent_writes: deny"}
+                ),
+            ):
+                real = await get_course_policy("999")
+        assert real.allow_writes is False
+        assert real.source == "course_artifact"
+
+    @pytest.mark.asyncio
+    async def test_ambiguous_page_404_is_not_cached(self):
+        """In page mode a 404 could be "no page" or "no access". Never cache it."""
+        from canvas_mcp.core.course_policy import _policy_cache
+
+        reset_policy_cache()
+        with patch.dict(
+            "os.environ",
+            {"COURSE_AGENT_POLICY_SOURCE": "page", "COURSE_AGENT_POLICY_DEFAULT": "allow"},
+            clear=False,
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(return_value={"error": "HTTP error: 404"}),
+            ):
+                policy = await get_course_policy("777")
+        assert policy.allow_writes is True  # default posture honoured
+        assert policy.source == "default_uncached"
+        assert "777" not in _policy_cache
+
+    @pytest.mark.asyncio
+    async def test_unmarked_syllabus_is_a_cacheable_absence(self):
+        """A successful course read with no marker IS caller-independent."""
+        from canvas_mcp.core.course_policy import _policy_cache
+
+        reset_policy_cache()
+        with patch.dict(
+            "os.environ", {"COURSE_AGENT_POLICY_DEFAULT": "deny"}, clear=False
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(return_value={"syllabus_body": "<p>Welcome</p>"}),
+            ):
+                policy = await get_course_policy("555")
+        assert policy.allow_writes is False
+        assert policy.source == "default"
+        assert "555" in _policy_cache
+
+    @pytest.mark.asyncio
+    async def test_syllabus_mode_404_denies_rather_than_assuming_absence(self):
+        """Deliberately stricter than an earlier version of this test.
+
+        In syllabus mode the request is for the COURSE, so a 404 means this
+        caller cannot see the course — not that the course states no policy.
+        Reading it as an absence would, under a permissive default, hand a
+        caller without access an allow (and cache it for everyone).
+        """
         reset_policy_cache()
         with patch.dict(
             "os.environ", {"COURSE_AGENT_POLICY_DEFAULT": "allow"}, clear=False
@@ -485,8 +566,8 @@ class TestErrorClassification:
                 new=AsyncMock(return_value={"error": "HTTP error: 404"}),
             ):
                 policy = await get_course_policy("123")
-        assert policy.allow_writes is True
-        assert policy.source == "default"
+        assert policy.allow_writes is False
+        assert policy.source == "read_error"
 
 
 class TestLayering:

--- a/tests/security/test_student_write_invariants.py
+++ b/tests/security/test_student_write_invariants.py
@@ -440,6 +440,40 @@ class TestErrorClassification:
         assert policy.source == "read_error"
 
     @pytest.mark.asyncio
+    async def test_read_errors_are_never_cached(self):
+        """One bad caller must not deny writes for a whole course.
+
+        A read error reflects the caller's request (expired token, not enrolled,
+        transient failure), not a property of the course. Caching it under the
+        course id alone would let any caller block every legitimate student in
+        that course for a full deny TTL.
+        """
+        from canvas_mcp.core.course_policy import _policy_cache
+
+        reset_policy_cache()
+        with patch.dict(
+            "os.environ", {"STUDENT_WRITE_TOOLS": ALL_WRITE_TOOLS}, clear=False
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(return_value={"error": "HTTP error: 401"}),
+            ):
+                denied = await get_course_policy("123")
+            assert denied.allow_writes is False
+            assert "123" not in _policy_cache, "read error poisoned the cache"
+
+            # A legitimate caller immediately afterwards sees the real policy.
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(
+                    return_value={"syllabus_body": "agent_writes: allow"}
+                ),
+            ):
+                policy = await get_course_policy("123")
+        assert policy.allow_writes is True
+
+    @pytest.mark.asyncio
     async def test_genuine_404_is_treated_as_absent(self):
         reset_policy_cache()
         with patch.dict(

--- a/tests/security/test_student_write_invariants.py
+++ b/tests/security/test_student_write_invariants.py
@@ -318,6 +318,39 @@ class TestUploadResourceBounds:
         assert "total more than" in error
         assert _MAX_TOTAL_UPLOAD_BYTES > 0
 
+    def test_pre_decode_size_estimate_is_exact(self):
+        """The size check must not overshoot, or it rejects legal uploads.
+
+        The naive len(encoded)//4*3 overshoots by the padding count, so a file
+        whose decoded size is exactly the documented limit would be refused
+        before it was ever decoded. Checked across all three padding cases.
+        """
+        import base64
+
+        from canvas_mcp.tools.student_write import _decoded_size
+
+        for length in range(0, 40):
+            payload = b"x" * length
+            encoded = base64.b64encode(payload).decode()
+            assert _decoded_size(encoded) == length, (
+                f"estimate wrong for {length} bytes "
+                f"(padding={encoded.count('=')})"
+            )
+
+    def test_boundary_file_is_not_rejected_by_the_estimate(self):
+        """Exercise the limit comparison itself without allocating 100 MB."""
+        import base64
+
+        from canvas_mcp.tools.student_write import _decoded_size
+
+        # Worst case for the naive formula: two padding characters.
+        payload = b"x" * 100
+        encoded = base64.b64encode(payload).decode()
+        assert encoded.endswith("=="), "expected two padding characters"
+        assert _decoded_size(encoded) == 100
+        # The naive formula would have said 102 and could refuse a limit-sized file.
+        assert len(encoded) // 4 * 3 == 102
+
     def test_a_normal_submission_still_works(self):
         """The bounds must not break the ordinary case."""
         import base64

--- a/tests/security/test_student_write_invariants.py
+++ b/tests/security/test_student_write_invariants.py
@@ -322,6 +322,53 @@ class TestPolicyResolution:
         assert policy.allow_writes is True
 
 
+class TestErrorClassification:
+    """Only a real 404 may be read as "no policy artifact"."""
+
+    @pytest.mark.parametrize(
+        "error_message",
+        [
+            "HTTP error: 500, Details: {'message': 'upstream 404 from origin'}",
+            "HTTP error: 403",
+            "HTTP error: 429",
+            "Request failed: connection reset after 404 retries",
+            "Max retries exceeded",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_non_404_failures_still_deny_under_permissive_default(
+        self, error_message
+    ):
+        """A substring test for "404" would turn a 500 into a grant."""
+        reset_policy_cache()
+        with patch.dict(
+            "os.environ", {"COURSE_AGENT_POLICY_DEFAULT": "allow"}, clear=False
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(return_value={"error": error_message}),
+            ):
+                policy = await get_course_policy("123")
+        assert policy.allow_writes is False
+        assert policy.source == "read_error"
+
+    @pytest.mark.asyncio
+    async def test_genuine_404_is_treated_as_absent(self):
+        reset_policy_cache()
+        with patch.dict(
+            "os.environ", {"COURSE_AGENT_POLICY_DEFAULT": "allow"}, clear=False
+        ):
+            reset_config()
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(return_value={"error": "HTTP error: 404"}),
+            ):
+                policy = await get_course_policy("123")
+        assert policy.allow_writes is True
+        assert policy.source == "default"
+
+
 class TestLayering:
     """A course artifact can restrict within the operator ceiling, never past it."""
 

--- a/tests/security/test_student_write_invariants.py
+++ b/tests/security/test_student_write_invariants.py
@@ -229,6 +229,63 @@ class TestInlineFilenames:
             assert isinstance(error, (str, type(None)))
 
 
+class TestUploadResourceBounds:
+    """A per-file cap alone lets one request exhaust server memory."""
+
+    def test_file_count_is_capped(self):
+        import base64
+
+        from canvas_mcp.tools.student_write import _MAX_UPLOAD_FILES, _prepare_files
+
+        tiny = base64.b64encode(b"x").decode()
+        _, error = _prepare_files(
+            None,
+            [
+                {"name": f"f{i}.txt", "content_base64": tiny}
+                for i in range(_MAX_UPLOAD_FILES + 1)
+            ],
+        )
+        assert error is not None
+        assert "Too many files" in error
+
+    def test_aggregate_size_is_capped_without_decoding(self):
+        """Many individually-legal files must not add up to an illegal request.
+
+        The check runs on the encoded length, so an oversized request is refused
+        before its bytes are ever materialized.
+        """
+        from canvas_mcp.tools.student_write import (
+            _MAX_TOTAL_UPLOAD_BYTES,
+            _prepare_files,
+        )
+
+        # Six ~20MB claims: each under the per-file cap, together over the total.
+        chunk = "A" * ((20 * 1024 * 1024) // 3 * 4)
+        _, error = _prepare_files(
+            None,
+            [{"name": f"f{i}.pdf", "content_base64": chunk} for i in range(6)],
+        )
+        assert error is not None
+        assert "total more than" in error
+        assert _MAX_TOTAL_UPLOAD_BYTES > 0
+
+    def test_a_normal_submission_still_works(self):
+        """The bounds must not break the ordinary case."""
+        import base64
+
+        from canvas_mcp.tools.student_write import _prepare_files
+
+        prepared, error = _prepare_files(
+            None,
+            [
+                {"name": "essay.pdf", "content_base64": base64.b64encode(b"pdf").decode()},
+                {"name": "chart.png", "content_base64": base64.b64encode(b"png").decode()},
+            ],
+        )
+        assert error is None
+        assert [p.name for p in prepared] == ["essay.pdf", "chart.png"]
+
+
 class TestHostedFileIngress:
     """file_paths reads the SERVER's disk. That must not be reachable remotely."""
 

--- a/tests/security/test_student_write_invariants.py
+++ b/tests/security/test_student_write_invariants.py
@@ -274,6 +274,35 @@ class TestPolicyResolution:
         assert policy.allow_writes is False
         assert policy.source == "untrusted_artifact"
 
+    @pytest.mark.parametrize(
+        "editing_roles",
+        [None, "", "teachers,students", "students", "anyone", "members", "public"],
+    )
+    @pytest.mark.asyncio
+    async def test_page_is_trusted_only_when_explicitly_teacher_only(self, editing_roles):
+        """Ambiguity must fail closed.
+
+        A denylist of known-bad role names would trust a page whose
+        editing_roles is missing, empty, or a value Canvas introduces later.
+        """
+        reset_policy_cache()
+        with patch.dict(
+            "os.environ",
+            {"COURSE_AGENT_POLICY_SOURCE": "page", "COURSE_AGENT_POLICY_DEFAULT": "allow"},
+            clear=False,
+        ):
+            reset_config()
+            page = {"body": "agent_writes: allow"}
+            if editing_roles is not None:
+                page["editing_roles"] = editing_roles
+            with patch(
+                "canvas_mcp.core.course_policy.make_canvas_request",
+                new=AsyncMock(return_value=page),
+            ):
+                policy = await get_course_policy("123")
+        assert policy.allow_writes is False
+        assert policy.source == "untrusted_artifact"
+
     @pytest.mark.asyncio
     async def test_teacher_only_page_is_trusted(self):
         with patch.dict(

--- a/tests/security/test_student_write_invariants.py
+++ b/tests/security/test_student_write_invariants.py
@@ -143,6 +143,92 @@ class TestNoIdentityOverride:
         }, f"unexpected outbound fields: {set(sent)}"
 
 
+class TestConfirmationIsCallerBound:
+    """On a hosted server every request carries a different student's token."""
+
+    def test_fingerprint_differs_per_caller(self):
+        """Otherwise one student could redeem another's confirmation.
+
+        Without caller binding, two students at the same attempt number on the
+        same assignment produce the same fingerprint, so a token issued to one
+        would verify for the other.
+        """
+        import canvas_mcp.tools.student_write as sw
+
+        class _Creds:
+            def __init__(self, token):
+                self.api_token = token
+
+        with patch.object(sw, "get_request_credentials", return_value=_Creds("aaa")):
+            first = sw._fingerprint("1", "2", "online_text_entry", "digest", 0)
+        with patch.object(sw, "get_request_credentials", return_value=_Creds("bbb")):
+            second = sw._fingerprint("1", "2", "online_text_entry", "digest", 0)
+
+        assert first != second
+
+    def test_token_issued_to_one_student_fails_for_another(self):
+        import canvas_mcp.tools.student_write as sw
+
+        class _Creds:
+            def __init__(self, token):
+                self.api_token = token
+
+        with patch.object(sw, "get_request_credentials", return_value=_Creds("aaa")):
+            fingerprint = sw._fingerprint("1", "2", "online_text_entry", "d", 0)
+            token = sw._issue_token(fingerprint)
+        with patch.object(sw, "get_request_credentials", return_value=_Creds("bbb")):
+            other = sw._fingerprint("1", "2", "online_text_entry", "d", 0)
+
+        assert sw._check_token(token, fingerprint) is None
+        assert sw._check_token(token, other) is not None
+
+    def test_caller_identity_does_not_expose_the_credential(self):
+        """The handle must not be the token, nor reversible to it."""
+        import canvas_mcp.tools.student_write as sw
+
+        class _Creds:
+            api_token = "super-secret-canvas-token"
+
+        with patch.object(sw, "get_request_credentials", return_value=_Creds()):
+            identity = sw._caller_identity()
+
+        assert "super-secret-canvas-token" not in identity
+        assert len(identity) == 64  # sha256 hex
+
+
+class TestInlineFilenames:
+    """A hosted caller supplies the filename, so it is untrusted input."""
+
+    def test_path_traversal_in_a_supplied_name_is_stripped(self):
+        from canvas_mcp.tools.student_write import _prepare_files
+
+        prepared, error = _prepare_files(
+            None,
+            [{"name": "../../essay.pdf", "content_base64": "cGRmYnl0ZXM="}],
+        )
+        assert error is None
+        assert ".." not in prepared[0].name
+        assert "/" not in prepared[0].name
+
+    def test_disallowed_extension_is_refused(self):
+        from canvas_mcp.tools.student_write import _prepare_files
+
+        _, error = _prepare_files(
+            None, [{"name": "payload.exe", "content_base64": "TVo="}]
+        )
+        assert error is not None
+        assert "not an allowed file type" in error
+
+    def test_odd_extension_returns_an_error_not_an_exception(self):
+        from canvas_mcp.tools.student_write import _prepare_files
+
+        for name in ["noextension", "trailing.", "x" * 300 + ".pdf", ".hidden"]:
+            _, error = _prepare_files(
+                None, [{"name": name, "content_base64": "YWJj"}]
+            )
+            assert isinstance(error, (str, type(None)))
+
+
 class TestHostedFileIngress:
     """file_paths reads the SERVER's disk. That must not be reachable remotely."""
 

--- a/tests/tools/test_student_write.py
+++ b/tests/tools/test_student_write.py
@@ -530,6 +530,53 @@ class TestConfirmationIntegrity:
         assert sum("✅ Submitted." in r for r in results) == 1
         assert sum("already used" in r for r in results) == 1
 
+    def test_fingerprint_covers_the_attempt_limit(self):
+        """An instructor can change allowed_attempts between preview and confirm.
+
+        A preview that said "unlimited" must not be confirmable against a
+        freshly capped assignment, spending what is now the final attempt.
+        """
+        import canvas_mcp.tools.student_write as sw
+
+        unlimited = sw._fingerprint("1", "2", "online_text_entry", "d", 0, -1)
+        capped = sw._fingerprint("1", "2", "online_text_entry", "d", 0, 1)
+        assert unlimited != capped
+
+    @pytest.mark.asyncio
+    async def test_changed_attempt_limit_voids_the_token(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [
+                _mock_assignment(allowed_attempts=-1), {"attempt": 0},
+            ]
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+            )
+            assert "unlimited" in preview
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+
+            # Instructor caps attempts in the meantime.
+            request.side_effect = [
+                _mock_assignment(allowed_attempts=1), {"attempt": 0},
+            ]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+                confirmation_token=token,
+            )
+
+        assert "does not match" in result
+        assert not [c for c in request.call_args_list if c.args[0] == "post"]
+
     def test_token_does_not_verify_under_a_forged_signature(self):
         import canvas_mcp.tools.student_write as sw
 
@@ -743,7 +790,8 @@ class TestBinaryUpload:
         assert "not valid base64" in result
 
     @pytest.mark.asyncio
-    async def test_disallowed_extension_rejected(self):
+    async def test_assignment_restriction_is_enforced_end_to_end(self):
+        """The instructor's allowed_extensions reaches the upload check."""
         tools = get_tools(
             STUDENT_WRITE_TOOLS="submit_assignment",
             COURSE_AGENT_POLICY_ENABLED="false",
@@ -757,14 +805,17 @@ class TestBinaryUpload:
             "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
         ) as request:
             request.side_effect = [
-                _mock_assignment(submission_types=["online_upload"]),
+                _mock_assignment(
+                    submission_types=["online_upload"], allowed_extensions=["pdf"]
+                ),
                 {"attempt": 0},
             ]
             result = await tools["submit_assignment"](
                 course_identifier="TEST", assignment_id=42,
                 submission_type="online_upload",
                 file_contents=[
-                    {"name": "evil.exe", "content_base64": base64.b64encode(b"MZ").decode()}
+                    {"name": "notes.txt", "content_base64": base64.b64encode(b"hi").decode()}
                 ],
             )
-        assert "Cannot submit" in result
+        assert "does not accept" in result
+        assert not [c for c in request.call_args_list if c.args[0] == "post"]

--- a/tests/tools/test_student_write.py
+++ b/tests/tools/test_student_write.py
@@ -695,6 +695,121 @@ class TestConfirmationIntegrity:
         assert "attempt count" in result
         assert not posts
 
+    @pytest.mark.asyncio
+    async def test_policy_revoked_during_upload_aborts_the_submit(self):
+        """The authoritative policy check is the last one before the write.
+
+        An instructor can revoke agent writes while uploads are running, and the
+        grant used earlier may have come from a cache that has since expired.
+        """
+        import base64
+
+        tools = get_tools(STUDENT_WRITE_TOOLS="submit_assignment")
+        encoded = base64.b64encode(JPEG_BYTES).decode()
+        assignment = _mock_assignment(submission_types=["online_upload"])
+        posts = []
+        syllabus = {"body": "agent_writes: allow"}
+
+        async def policy_reader(method, endpoint, **kwargs):
+            return {"syllabus_body": syllabus["body"]}
+
+        async def responder(method, endpoint, **kwargs):
+            if method == "get":
+                if endpoint.endswith("/submissions/self"):
+                    return {"attempt": 0}
+                return assignment
+            if endpoint.endswith("/submissions/self/files"):
+                return {"upload_url": "https://storage.example/x", "upload_params": {}}
+            posts.append(endpoint)
+            return {"attempt": 1}
+
+        async def storage_then_revoke(**kwargs):
+            # Instructor revokes while the bytes are in flight.
+            syllabus["body"] = "agent_writes: deny"
+            reset_policy_cache()
+            return {"id": 999}
+
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new=responder
+        ), patch(
+            "canvas_mcp.core.course_policy.make_canvas_request", new=policy_reader
+        ), patch(
+            "canvas_mcp.tools.student_write.upload_file_to_storage",
+            new=storage_then_revoke,
+        ):
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+                confirmation_token=token,
+            )
+
+        assert "blocked" in result
+        assert not posts, "submitted after the instructor revoked agent writes"
+
+    @pytest.mark.asyncio
+    async def test_becoming_a_group_assignment_during_upload_aborts(self):
+        """The group refusal must hold at submit time, not only at preview."""
+        import base64
+
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        encoded = base64.b64encode(JPEG_BYTES).decode()
+        state = {"assignment": _mock_assignment(submission_types=["online_upload"])}
+        posts = []
+
+        async def responder(method, endpoint, **kwargs):
+            if method == "get":
+                if endpoint.endswith("/submissions/self"):
+                    return {"attempt": 0}
+                return state["assignment"]
+            if endpoint.endswith("/submissions/self/files"):
+                return {"upload_url": "https://storage.example/x", "upload_params": {}}
+            posts.append(endpoint)
+            return {"attempt": 1}
+
+        async def storage_then_convert(**kwargs):
+            state["assignment"] = _mock_assignment(
+                submission_types=["online_upload"], group_category_id=7
+            )
+            return {"id": 999}
+
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new=responder
+        ), patch(
+            "canvas_mcp.tools.student_write.upload_file_to_storage",
+            new=storage_then_convert,
+        ):
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+                confirmation_token=token,
+            )
+
+        assert "group assignment" in result
+        assert not posts, "submitted on behalf of a group"
+
     def test_token_does_not_verify_under_a_forged_signature(self):
         import canvas_mcp.tools.student_write as sw
 

--- a/tests/tools/test_student_write.py
+++ b/tests/tools/test_student_write.py
@@ -463,6 +463,129 @@ class TestConfirmationIntegrity:
         assert len(sw._pending_confirmations) == 1
 
 
+class TestPreviewShowsWhatIsAuthorized:
+    """The token covers the whole body, so the preview must show the whole body."""
+
+    @pytest.mark.asyncio
+    async def test_long_essay_is_not_truncated_in_the_preview(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        essay = "Paragraph. " * 300  # well past any excerpt limit
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(), {"attempt": 0}]
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body=essay,
+            )
+
+        assert essay in preview, "the student must see everything the token authorizes"
+        assert "..." not in preview.split("Content (")[1][:len(essay) + 50]
+
+
+class TestUploadFailureHandling:
+    """An upload problem must not cost the student their confirmation."""
+
+    @pytest.mark.asyncio
+    async def test_upload_failure_preserves_the_token(self):
+        import canvas_mcp.tools.student_write as sw
+
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        import base64
+
+        encoded = base64.b64encode(JPEG_BYTES).decode()
+        assignment = _mock_assignment(submission_types=["online_upload"])
+
+        async def failing_storage(**kwargs):
+            return {"error": "Upload timed out"}
+
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request, patch(
+            "canvas_mcp.tools.student_write.upload_file_to_storage", new=failing_storage
+        ):
+            request.side_effect = [assignment, {"attempt": 0}]
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+
+            request.side_effect = [
+                assignment, {"attempt": 0},
+                {"upload_url": "https://storage.example/x", "upload_params": {}},
+            ]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+                confirmation_token=token,
+            )
+
+        assert "Nothing was submitted" in result
+        assert token in sw._pending_confirmations, "token burned on an upload failure"
+
+    @pytest.mark.asyncio
+    async def test_id_recovered_from_nested_attachment_shape(self):
+        """Canvas storage does not always answer with a top-level id."""
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        import base64
+
+        encoded = base64.b64encode(JPEG_BYTES).decode()
+        assignment = _mock_assignment(submission_types=["online_upload"])
+
+        async def nested_storage(**kwargs):
+            return {"attachment": {"id": 4242}}
+
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request, patch(
+            "canvas_mcp.tools.student_write.upload_file_to_storage", new=nested_storage
+        ):
+            request.side_effect = [assignment, {"attempt": 0}]
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+
+            request.side_effect = [
+                assignment, {"attempt": 0},
+                {"upload_url": "https://storage.example/x", "upload_params": {}},
+                {"submitted_at": "2026-07-30T10:00:00Z", "attempt": 1},
+            ]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+                confirmation_token=token,
+            )
+
+        assert "✅ Submitted." in result
+        post = [c for c in request.call_args_list if c.args[0] == "post"][-1]
+        assert post.kwargs["data"]["submission[file_ids][]"] == ["4242"]
+
+
 class TestBinaryUpload:
     """Michigan's requirement A: real binary files, not text."""
 

--- a/tests/tools/test_student_write.py
+++ b/tests/tools/test_student_write.py
@@ -345,6 +345,124 @@ class TestSubmitAssignment:
         assert "must be one of" in result
 
 
+class TestConfirmationIntegrity:
+    """Regressions found by code review. Each was a real bypass."""
+
+    def test_digest_frames_fields_unambiguously(self):
+        """Concatenation would let one payload impersonate another.
+
+        Without length-prefixing, a file named 'a.txt' holding b'XPAYLOAD'
+        digests identically to one named 'a.txtX' holding b'PAYLOAD', so a
+        token could authorize content that was never previewed.
+        """
+        from canvas_mcp.tools.student_write import _digest_payload, _PreparedFile
+
+        first = _digest_payload(
+            None, None, None, [_PreparedFile("a.txt", b"XPAYLOAD", "text/plain")]
+        )
+        second = _digest_payload(
+            None, None, None, [_PreparedFile("a.txtX", b"PAYLOAD", "text/plain")]
+        )
+        assert first != second
+
+    def test_digest_covers_the_comment(self):
+        from canvas_mcp.tools.student_write import _digest_payload
+
+        assert _digest_payload("essay", None, "please regrade", []) != _digest_payload(
+            "essay", None, "something else entirely", []
+        )
+
+    @pytest.mark.asyncio
+    async def test_swapping_the_comment_voids_the_token(self):
+        """The preview shows the comment, so confirmation must commit to it."""
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+                comment="Sorry this is late.",
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+                comment="My professor said this was fine.",
+                confirmation_token=token,
+            )
+
+        assert "changed since the preview" in result
+        assert not [c for c in request.call_args_list if c.args[0] == "post"]
+
+    @pytest.mark.asyncio
+    async def test_unreadable_attempt_state_stops_everything(self):
+        """A false attempt count would make the drift check vacuous."""
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(), {"error": "HTTP error: 500"}]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+            )
+
+        assert "attempt count is unknown" in result
+        assert "Nothing was submitted" in result
+        assert not [c for c in request.call_args_list if c.args[0] == "post"]
+
+    @pytest.mark.asyncio
+    async def test_abandoned_previews_are_purged(self):
+        """Otherwise the map grows without bound on a long-running server."""
+        import canvas_mcp.tools.student_write as sw
+
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="abandoned",
+            )
+            assert len(sw._pending_confirmations) == 1
+            # Age the outstanding record past its TTL.
+            stale = next(iter(sw._pending_confirmations))
+            _, fingerprint = sw._pending_confirmations[stale]
+            sw._pending_confirmations[stale] = (0.0, fingerprint)
+
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="fresh",
+            )
+
+        assert stale not in sw._pending_confirmations
+        assert len(sw._pending_confirmations) == 1
+
+
 class TestBinaryUpload:
     """Michigan's requirement A: real binary files, not text."""
 

--- a/tests/tools/test_student_write.py
+++ b/tests/tools/test_student_write.py
@@ -1,0 +1,451 @@
+"""Tests for Tier 1 student write tools (#170).
+
+These cover the behaviour an operator and a student see. The security
+invariants that must hold regardless of behaviour live in
+``tests/security/test_student_write_invariants.py``.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp import FastMCP
+
+from canvas_mcp.core.config import reset_config
+from canvas_mcp.core.course_policy import reset_policy_cache
+from canvas_mcp.tools.student_write import (
+    register_student_write_tools,
+    reset_pending_confirmations,
+)
+
+# A real 1x1 JPEG. Used to prove binary content survives the upload path byte
+# for byte, which is the specific failure another implementation hit (it OCR'd
+# the image and demanded text instead).
+JPEG_BYTES = bytes.fromhex(
+    "ffd8ffe000104a46494600010100000100010000ffdb00430008060607060508070707"
+    "0909080a0c140d0c0b0b0c1912130f141d1a1f1e1d1a1c1c20242e2720222c231c1c28"
+    "37292c30313434341f27393d38323c2e333432ffc0000b080001000101011100ffc400"
+    "1f0000010501010101010100000000000000000102030405060708090a0bffc400b510"
+    "0002010303020403050504040000017d01020300041105122131410613516107227114"
+    "328191a1082342b1c11552d1f02433627282090a161718191a25262728292a3435363738"
+    "393a434445464748494a535455565758595a636465666768696a737475767778797a8384"
+    "85868788898a92939495969798999aa2a3a4a5a6a7a8a9aab2b3b4b5b6b7b8b9bac2c3c4"
+    "c5c6c7c8c9cad2d3d4d5d6d7d8d9dae1e2e3e4e5e6e7e8e9eaf1f2f3f4f5f6f7f8f9fa"
+    "ffda0008010100003f00fbfeffd9"
+)
+
+
+def get_tools(**env):
+    """Register the write tools under a given operator configuration.
+
+    Returns a dict of tool name -> callable. A tool the operator has not
+    enabled is genuinely absent from this dict, which is the point: it was
+    never registered, so no agent can see it.
+    """
+    captured = {}
+    mcp = FastMCP("test")
+    original_tool = mcp.tool
+
+    def capturing_tool(*args, **kwargs):
+        decorator = original_tool(*args, **kwargs)
+
+        def wrapper(fn):
+            captured[fn.__name__] = fn
+            return decorator(fn)
+
+        return wrapper
+
+    mcp.tool = capturing_tool
+    with patch.dict("os.environ", env, clear=False):
+        reset_config()
+        register_student_write_tools(mcp)
+    return captured
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    reset_config()
+    reset_policy_cache()
+    reset_pending_confirmations()
+    yield
+    reset_config()
+    reset_policy_cache()
+    reset_pending_confirmations()
+
+
+class TestOperatorCeiling:
+    """STUDENT_WRITE_TOOLS is the campus-wide ceiling. Default is nothing."""
+
+    def test_no_write_tools_by_default(self):
+        tools = get_tools(STUDENT_WRITE_TOOLS="")
+        assert "submit_assignment" not in tools
+        assert "comment_on_my_submission" not in tools
+        assert "mark_module_item_done" not in tools
+
+    def test_read_tool_always_registered(self):
+        tools = get_tools(STUDENT_WRITE_TOOLS="")
+        assert "get_my_submission" in tools
+
+    def test_only_named_tools_register(self):
+        tools = get_tools(STUDENT_WRITE_TOOLS="submit_assignment")
+        assert "submit_assignment" in tools
+        assert "comment_on_my_submission" not in tools
+
+    def test_accepts_comma_and_space_separated(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment, mark_module_item_done"
+        )
+        assert "submit_assignment" in tools
+        assert "mark_module_item_done" in tools
+
+    def test_unknown_names_do_not_register_anything(self):
+        tools = get_tools(STUDENT_WRITE_TOOLS="take_quiz_for_me")
+        assert "submit_assignment" not in tools
+
+
+def _mock_assignment(**overrides):
+    base = {
+        "id": 42,
+        "name": "Essay 1",
+        "submission_types": ["online_text_entry"],
+        "allowed_attempts": 3,
+        "due_at": "2026-08-01T23:59:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSubmitAssignment:
+    """The preview/confirm protocol and its guards."""
+
+    @pytest.mark.asyncio
+    async def test_preview_does_not_submit(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+            )
+
+        assert "NOTHING has been submitted" in result
+        assert "confirmation_token=" in result
+        # Only the two reads happened. No POST.
+        assert all(call.args[0] == "get" for call in request.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_confirm_submits(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+
+            request.side_effect = [
+                _mock_assignment(),
+                {"attempt": 1},
+                {"submitted_at": "2026-07-30T10:00:00Z", "attempt": 2},
+            ]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+                confirmation_token=token,
+            )
+
+        assert "✅ Submitted." in result
+        post = [c for c in request.call_args_list if c.args[0] == "post"]
+        assert len(post) == 1
+        assert post[0].args[1] == "/courses/123/assignments/42/submissions"
+
+    @pytest.mark.asyncio
+    async def test_token_is_single_use(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+
+            request.side_effect = [
+                _mock_assignment(), {"attempt": 1}, {"attempt": 2},
+                _mock_assignment(), {"attempt": 1},
+            ]
+            await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+                confirmation_token=token,
+            )
+            second = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+                confirmation_token=token,
+            )
+
+        assert "already-used" in second
+
+    @pytest.mark.asyncio
+    async def test_changed_content_voids_token(self):
+        """The token commits to the previewed bytes, not just the target."""
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="original",
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="SWAPPED",
+                confirmation_token=token,
+            )
+
+        assert "changed since the preview" in result
+        assert not [c for c in request.call_args_list if c.args[0] == "post"]
+
+    @pytest.mark.asyncio
+    async def test_attempt_drift_voids_token(self):
+        """A submission landing between preview and confirm invalidates it."""
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+
+            # Attempt count moved from 1 to 2 in the meantime.
+            request.side_effect = [_mock_assignment(), {"attempt": 2}]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+                confirmation_token=token,
+            )
+
+        assert "changed since the preview" in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_token_rejected(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+                confirmation_token="made-up-token",
+            )
+
+        assert "Unknown or already-used" in result
+
+    @pytest.mark.asyncio
+    async def test_group_assignment_refused(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(group_category_id=7)]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+            )
+
+        assert "group assignment" in result
+
+    @pytest.mark.asyncio
+    async def test_rejects_type_the_assignment_does_not_accept(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [_mock_assignment(submission_types=["online_upload"])]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+            )
+
+        assert "does not accept" in result
+
+    @pytest.mark.asyncio
+    async def test_unsupported_submission_type_rejected(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        result = await tools["submit_assignment"](
+            course_identifier="TEST", assignment_id=42,
+            submission_type="online_quiz",
+        )
+        assert "must be one of" in result
+
+
+class TestBinaryUpload:
+    """Michigan's requirement A: real binary files, not text."""
+
+    @pytest.mark.asyncio
+    async def test_jpeg_bytes_survive_unmodified(self):
+        """The exact bytes handed in must reach Canvas storage untouched."""
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        import base64
+
+        encoded = base64.b64encode(JPEG_BYTES).decode()
+        seen = {}
+
+        async def fake_storage(upload_url, upload_params, file_path, filename, content_type):
+            with open(file_path, "rb") as handle:
+                seen["bytes"] = handle.read()
+            seen["content_type"] = content_type
+            return {"id": 999}
+
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request, patch(
+            "canvas_mcp.tools.student_write.upload_file_to_storage", new=fake_storage
+        ):
+            assignment = _mock_assignment(submission_types=["online_upload"])
+            request.side_effect = [assignment, {"attempt": 0}]
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+
+            request.side_effect = [
+                assignment,
+                {"attempt": 0},
+                {"upload_url": "https://storage.example/x", "upload_params": {}},
+                {"submitted_at": "2026-07-30T10:00:00Z", "attempt": 1},
+            ]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+                confirmation_token=token,
+            )
+
+        assert "✅ Submitted." in result
+        assert seen["bytes"] == JPEG_BYTES, "JPEG bytes were altered in transit"
+        assert seen["content_type"] == "image/jpeg"
+
+    @pytest.mark.asyncio
+    async def test_invalid_base64_rejected(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [
+                _mock_assignment(submission_types=["online_upload"]),
+                {"attempt": 0},
+            ]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "x.jpg", "content_base64": "not!base64!"}],
+            )
+        assert "not valid base64" in result
+
+    @pytest.mark.asyncio
+    async def test_disallowed_extension_rejected(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        import base64
+
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
+        ) as request:
+            request.side_effect = [
+                _mock_assignment(submission_types=["online_upload"]),
+                {"attempt": 0},
+            ]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[
+                    {"name": "evil.exe", "content_base64": base64.b64encode(b"MZ").decode()}
+                ],
+            )
+        assert "Cannot submit" in result

--- a/tests/tools/test_student_write.py
+++ b/tests/tools/test_student_write.py
@@ -20,6 +20,9 @@ from canvas_mcp.tools.student_write import (
 # A real 1x1 JPEG. Used to prove binary content survives the upload path byte
 # for byte, which is the specific failure another implementation hit (it OCR'd
 # the image and demanded text instead).
+# Comfortably past the confirmation TTL.
+_EXPIRED_BY = 10_000
+
 JPEG_BYTES = bytes.fromhex(
     "ffd8ffe000104a46494600010100000100010000ffdb00430008060607060508070707"
     "0909080a0c140d0c0b0b0c1912130f141d1a1f1e1d1a1c1c20242e2720222c231c1c28"
@@ -209,7 +212,7 @@ class TestSubmitAssignment:
                 confirmation_token=token,
             )
 
-        assert "already-used" in second
+        assert "already used" in second
 
     @pytest.mark.asyncio
     async def test_changed_content_voids_token(self):
@@ -290,7 +293,7 @@ class TestSubmitAssignment:
                 confirmation_token="made-up-token",
             )
 
-        assert "Unknown or already-used" in result
+        assert "malformed" in result
 
     @pytest.mark.asyncio
     async def test_group_assignment_refused(self):
@@ -427,40 +430,40 @@ class TestConfirmationIntegrity:
         assert "Nothing was submitted" in result
         assert not [c for c in request.call_args_list if c.args[0] == "post"]
 
-    @pytest.mark.asyncio
-    async def test_abandoned_previews_are_purged(self):
-        """Otherwise the map grows without bound on a long-running server."""
+    def test_abandoned_previews_hold_no_server_state(self):
+        """Tokens are self-contained, so an abandoned preview costs nothing.
+
+        The previous design kept every issued token in a process-global map,
+        which a caller could grow without bound by previewing and never
+        confirming. Signed tokens remove the map entirely.
+        """
         import canvas_mcp.tools.student_write as sw
 
-        tools = get_tools(
-            STUDENT_WRITE_TOOLS="submit_assignment",
-            COURSE_AGENT_POLICY_ENABLED="false",
-        )
-        with patch(
-            "canvas_mcp.tools.student_write.get_course_id",
-            new=AsyncMock(return_value="123"),
-        ), patch(
-            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
-        ) as request:
-            request.side_effect = [_mock_assignment(), {"attempt": 1}]
-            await tools["submit_assignment"](
-                course_identifier="TEST", assignment_id=42,
-                submission_type="online_text_entry", body="abandoned",
-            )
-            assert len(sw._pending_confirmations) == 1
-            # Age the outstanding record past its TTL.
-            stale = next(iter(sw._pending_confirmations))
-            _, fingerprint = sw._pending_confirmations[stale]
-            sw._pending_confirmations[stale] = (0.0, fingerprint)
+        for _ in range(1000):
+            sw._issue_token("some-fingerprint")
+        assert not sw._redeemed
 
-            request.side_effect = [_mock_assignment(), {"attempt": 1}]
-            await tools["submit_assignment"](
-                course_identifier="TEST", assignment_id=42,
-                submission_type="online_text_entry", body="fresh",
-            )
+    def test_expired_token_is_rejected(self):
+        import time as time_module
 
-        assert stale not in sw._pending_confirmations
-        assert len(sw._pending_confirmations) == 1
+        import canvas_mcp.tools.student_write as sw
+
+        expired = sw._issue_token("fp", now=time_module.time() - _EXPIRED_BY)
+        assert "expired" in (sw._check_token(expired, "fp") or "")
+
+    def test_token_does_not_verify_against_a_different_payload(self):
+        import canvas_mcp.tools.student_write as sw
+
+        token = sw._issue_token("fingerprint-a")
+        assert sw._check_token(token, "fingerprint-a") is None
+        assert sw._check_token(token, "fingerprint-b") is not None
+
+    def test_token_does_not_verify_under_a_forged_signature(self):
+        import canvas_mcp.tools.student_write as sw
+
+        token = sw._issue_token("fp")
+        expiry, _, _mac = token.partition(".")
+        assert sw._check_token(f"{expiry}.{'0' * 32}", "fp") is not None
 
 
 class TestPreviewShowsWhatIsAuthorized:
@@ -536,7 +539,10 @@ class TestUploadFailureHandling:
             )
 
         assert "Nothing was submitted" in result
-        assert token in sw._pending_confirmations, "token burned on an upload failure"
+        # The token must survive: the failure had nothing to do with the
+        # student's content, so it should not cost them a fresh preview.
+        assert not sw._redeemed, "token retired despite nothing being submitted"
+        assert token  # issued and still syntactically usable for a retry
 
     @pytest.mark.asyncio
     async def test_id_recovered_from_nested_attachment_shape(self):

--- a/tests/tools/test_student_write.py
+++ b/tests/tools/test_student_write.py
@@ -105,6 +105,36 @@ class TestOperatorCeiling:
         assert "submit_assignment" not in tools
 
 
+def make_responder(assignment, submission=None, submit_result=None, upload=None):
+    """Answer Canvas calls by endpoint rather than by call order.
+
+    Ordered side_effect lists are brittle here: the confirm path re-reads
+    attempt state immediately before submitting, so the number of GETs is an
+    implementation detail that tests should not encode.
+    """
+    submission = submission if submission is not None else {"attempt": 0}
+    posts = []
+
+    async def responder(method, endpoint, **kwargs):
+        if method == "get":
+            if endpoint.endswith("/submissions/self"):
+                return submission
+            return assignment
+        if endpoint.endswith("/submissions/self/files"):
+            return upload or {
+                "upload_url": "https://storage.example/x",
+                "upload_params": {},
+            }
+        posts.append({"endpoint": endpoint, "data": kwargs.get("data")})
+        return submit_result or {
+            "submitted_at": "2026-07-30T10:00:00Z",
+            "attempt": (submission.get("attempt") or 0) + 1,
+        }
+
+    responder.posts = posts
+    return responder
+
+
 def _mock_assignment(**overrides):
     base = {
         "id": 42,
@@ -149,24 +179,18 @@ class TestSubmitAssignment:
             STUDENT_WRITE_TOOLS="submit_assignment",
             COURSE_AGENT_POLICY_ENABLED="false",
         )
+        responder = make_responder(_mock_assignment(), {"attempt": 1})
         with patch(
             "canvas_mcp.tools.student_write.get_course_id",
             new=AsyncMock(return_value="123"),
         ), patch(
-            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
-        ) as request:
-            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            "canvas_mcp.tools.student_write.make_canvas_request", new=responder
+        ):
             preview = await tools["submit_assignment"](
                 course_identifier="TEST", assignment_id=42,
                 submission_type="online_text_entry", body="hello",
             )
             token = preview.split("confirmation_token='")[1].split("'")[0]
-
-            request.side_effect = [
-                _mock_assignment(),
-                {"attempt": 1},
-                {"submitted_at": "2026-07-30T10:00:00Z", "attempt": 2},
-            ]
             result = await tools["submit_assignment"](
                 course_identifier="TEST", assignment_id=42,
                 submission_type="online_text_entry", body="hello",
@@ -174,9 +198,8 @@ class TestSubmitAssignment:
             )
 
         assert "✅ Submitted." in result
-        post = [c for c in request.call_args_list if c.args[0] == "post"]
-        assert len(post) == 1
-        assert post[0].args[1] == "/courses/123/assignments/42/submissions"
+        assert len(responder.posts) == 1
+        assert responder.posts[0]["endpoint"] == "/courses/123/assignments/42/submissions"
 
     @pytest.mark.asyncio
     async def test_token_is_single_use(self):
@@ -188,19 +211,14 @@ class TestSubmitAssignment:
             "canvas_mcp.tools.student_write.get_course_id",
             new=AsyncMock(return_value="123"),
         ), patch(
-            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
-        ) as request:
-            request.side_effect = [_mock_assignment(), {"attempt": 1}]
+            "canvas_mcp.tools.student_write.make_canvas_request",
+            new=make_responder(_mock_assignment(), {"attempt": 1}),
+        ):
             preview = await tools["submit_assignment"](
                 course_identifier="TEST", assignment_id=42,
                 submission_type="online_text_entry", body="hello",
             )
             token = preview.split("confirmation_token='")[1].split("'")[0]
-
-            request.side_effect = [
-                _mock_assignment(), {"attempt": 1}, {"attempt": 2},
-                _mock_assignment(), {"attempt": 1},
-            ]
             await tools["submit_assignment"](
                 course_identifier="TEST", assignment_id=42,
                 submission_type="online_text_entry", body="hello",
@@ -577,6 +595,106 @@ class TestConfirmationIntegrity:
         assert "does not match" in result
         assert not [c for c in request.call_args_list if c.args[0] == "post"]
 
+    @pytest.mark.asyncio
+    async def test_attempt_landing_during_upload_aborts_the_submit(self):
+        """State is re-verified after uploads, immediately before the POST.
+
+        A file upload is a multi-step round trip per file. Another submission can
+        land during it, so confirming against the attempt count read before the
+        uploads would spend an attempt the student never agreed to.
+        """
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        import base64
+
+        encoded = base64.b64encode(JPEG_BYTES).decode()
+        assignment = _mock_assignment(submission_types=["online_upload"])
+        state = {"attempt": 0}
+        posts = []
+
+        async def responder(method, endpoint, **kwargs):
+            if method == "get":
+                if endpoint.endswith("/submissions/self"):
+                    return dict(state)
+                return assignment
+            if endpoint.endswith("/submissions/self/files"):
+                return {"upload_url": "https://storage.example/x", "upload_params": {}}
+            posts.append(endpoint)
+            return {"submitted_at": "2026-07-30T10:00:00Z", "attempt": 2}
+
+        async def storage_then_race(**kwargs):
+            # Someone else submits while this upload is in flight.
+            state["attempt"] = 1
+            return {"id": 999}
+
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new=responder
+        ), patch(
+            "canvas_mcp.tools.student_write.upload_file_to_storage",
+            new=storage_then_race,
+        ):
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_upload",
+                file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
+                confirmation_token=token,
+            )
+
+        assert "changed while this was being prepared" in result
+        assert not posts, "submitted despite the attempt count moving"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_state_at_submit_time_aborts(self):
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        calls = {"n": 0}
+        posts = []
+
+        async def responder(method, endpoint, **kwargs):
+            if method == "get":
+                if endpoint.endswith("/submissions/self"):
+                    calls["n"] += 1
+                    # Fine during the preview, broken at submit time.
+                    if calls["n"] > 1:
+                        return {"error": "HTTP error: 500"}
+                    return {"attempt": 0}
+                return _mock_assignment()
+            posts.append(endpoint)
+            return {"attempt": 1}
+
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new=responder
+        ):
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+            result = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+                confirmation_token=token,
+            )
+
+        assert "attempt count" in result
+        assert not posts
+
     def test_token_does_not_verify_under_a_forged_signature(self):
         import canvas_mcp.tools.student_write as sw
 
@@ -678,27 +796,21 @@ class TestUploadFailureHandling:
         async def nested_storage(**kwargs):
             return {"attachment": {"id": 4242}}
 
+        responder = make_responder(assignment)
         with patch(
             "canvas_mcp.tools.student_write.get_course_id",
             new=AsyncMock(return_value="123"),
         ), patch(
-            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
-        ) as request, patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new=responder
+        ), patch(
             "canvas_mcp.tools.student_write.upload_file_to_storage", new=nested_storage
         ):
-            request.side_effect = [assignment, {"attempt": 0}]
             preview = await tools["submit_assignment"](
                 course_identifier="TEST", assignment_id=42,
                 submission_type="online_upload",
                 file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
             )
             token = preview.split("confirmation_token='")[1].split("'")[0]
-
-            request.side_effect = [
-                assignment, {"attempt": 0},
-                {"upload_url": "https://storage.example/x", "upload_params": {}},
-                {"submitted_at": "2026-07-30T10:00:00Z", "attempt": 1},
-            ]
             result = await tools["submit_assignment"](
                 course_identifier="TEST", assignment_id=42,
                 submission_type="online_upload",
@@ -707,8 +819,7 @@ class TestUploadFailureHandling:
             )
 
         assert "✅ Submitted." in result
-        post = [c for c in request.call_args_list if c.args[0] == "post"][-1]
-        assert post.kwargs["data"]["submission[file_ids][]"] == ["4242"]
+        assert responder.posts[-1]["data"]["submission[file_ids][]"] == ["4242"]
 
 
 class TestBinaryUpload:
@@ -736,25 +847,17 @@ class TestBinaryUpload:
             "canvas_mcp.tools.student_write.get_course_id",
             new=AsyncMock(return_value="123"),
         ), patch(
-            "canvas_mcp.tools.student_write.make_canvas_request", new_callable=AsyncMock
-        ) as request, patch(
+            "canvas_mcp.tools.student_write.make_canvas_request",
+            new=make_responder(_mock_assignment(submission_types=["online_upload"])),
+        ), patch(
             "canvas_mcp.tools.student_write.upload_file_to_storage", new=fake_storage
         ):
-            assignment = _mock_assignment(submission_types=["online_upload"])
-            request.side_effect = [assignment, {"attempt": 0}]
             preview = await tools["submit_assignment"](
                 course_identifier="TEST", assignment_id=42,
                 submission_type="online_upload",
                 file_contents=[{"name": "photo.jpg", "content_base64": encoded}],
             )
             token = preview.split("confirmation_token='")[1].split("'")[0]
-
-            request.side_effect = [
-                assignment,
-                {"attempt": 0},
-                {"upload_url": "https://storage.example/x", "upload_params": {}},
-                {"submitted_at": "2026-07-30T10:00:00Z", "attempt": 1},
-            ]
             result = await tools["submit_assignment"](
                 course_identifier="TEST", assignment_id=42,
                 submission_type="online_upload",

--- a/tests/tools/test_student_write.py
+++ b/tests/tools/test_student_write.py
@@ -458,6 +458,78 @@ class TestConfirmationIntegrity:
         assert sw._check_token(token, "fingerprint-a") is None
         assert sw._check_token(token, "fingerprint-b") is not None
 
+    def test_reservation_is_exclusive(self):
+        import canvas_mcp.tools.student_write as sw
+
+        assert sw._reserve_confirmation("fp") is True
+        assert sw._reserve_confirmation("fp") is False
+
+    def test_released_reservation_can_be_reclaimed(self):
+        import canvas_mcp.tools.student_write as sw
+
+        assert sw._reserve_confirmation("fp") is True
+        sw._release_confirmation("fp")
+        assert sw._reserve_confirmation("fp") is True
+
+    def test_redeemed_claims_expire(self):
+        """Otherwise memory grows with the lifetime submission count."""
+        import canvas_mcp.tools.student_write as sw
+
+        sw._reserve_confirmation("old")
+        sw._redeemed["old"] = 0.0  # already past
+        sw._reserve_confirmation("new")
+        assert "old" not in sw._redeemed
+        assert "new" in sw._redeemed
+
+    @pytest.mark.asyncio
+    async def test_concurrent_confirmations_submit_only_once(self):
+        """Two overlapping confirms must not both spend an attempt.
+
+        The reservation is taken before any awaited work precisely so that the
+        gap between validating a token and claiming it cannot be interleaved.
+        """
+        import asyncio
+
+        tools = get_tools(
+            STUDENT_WRITE_TOOLS="submit_assignment",
+            COURSE_AGENT_POLICY_ENABLED="false",
+        )
+        assignment = _mock_assignment()
+        posts = []
+
+        async def responder(method, endpoint, **kwargs):
+            if method == "get" and endpoint.endswith("/submissions/self"):
+                return {"attempt": 1}
+            if method == "get":
+                return assignment
+            posts.append(endpoint)
+            return {"submitted_at": "2026-07-30T10:00:00Z", "attempt": 2}
+
+        with patch(
+            "canvas_mcp.tools.student_write.get_course_id",
+            new=AsyncMock(return_value="123"),
+        ), patch(
+            "canvas_mcp.tools.student_write.make_canvas_request", new=responder
+        ):
+            preview = await tools["submit_assignment"](
+                course_identifier="TEST", assignment_id=42,
+                submission_type="online_text_entry", body="hello",
+            )
+            token = preview.split("confirmation_token='")[1].split("'")[0]
+
+            results = await asyncio.gather(*[
+                tools["submit_assignment"](
+                    course_identifier="TEST", assignment_id=42,
+                    submission_type="online_text_entry", body="hello",
+                    confirmation_token=token,
+                )
+                for _ in range(2)
+            ])
+
+        assert len(posts) == 1, f"submitted {len(posts)} times, expected exactly 1"
+        assert sum("✅ Submitted." in r for r in results) == 1
+        assert sum("already used" in r for r in results) == 1
+
     def test_token_does_not_verify_under_a_forged_signature(self):
         import canvas_mcp.tools.student_write as sw
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -116,8 +116,11 @@ the second call, carrying the token from the preview, actually submits.
 dates, attempts remaining, and exactly what would be sent. On the second, the
 submission result including whether Canvas marked it late.
 
-**Files are sent as raw bytes** of any allowed type. Images and PDFs are uploaded
-as-is, never converted to text or run through OCR.
+**Files are sent as raw bytes.** Images and PDFs are uploaded as-is, never
+converted to text or run through OCR. There is no global list of permitted
+extensions: whatever the assignment's own `allowed_extensions` permits is
+accepted, so `.heic` photos and `.tex` sources work wherever the instructor
+allows them. Limits are 100 MB per file, 100 MB and 20 files per submission.
 
 **Not supported:** group assignments (submitting would bind your whole group) and
 quizzes (a separate institutional decision).
@@ -183,10 +186,16 @@ note: Allowed for the weekly labs. Ask me before using it on the final project.
 `COURSE_AGENT_POLICY_DEFAULT` decides what happens in a course that says nothing:
 `deny` (the default, instructors opt in) or `allow` (instructors opt out).
 
-Operators who would rather not put this in the syllabus can set
-`COURSE_AGENT_POLICY_SOURCE=page` and use a course page instead. That option is
-weaker and the server knows it: a Canvas page can be student-editable, so any
-page whose `editing_roles` is not teacher-only is ignored rather than trusted.
+The syllabus is the only supported carrier, and that is deliberate. Students can
+read it but cannot edit it, so instructor authorship is structural rather than
+assumed. A course-page carrier was built and then removed: a page's
+`editing_roles` tells you who may edit it *now*, not who wrote it, so a student
+who can create pages could author the policy and set it teacher-only in the same
+breath. Authorship cannot be established from a student's own token.
+
+Anything ambiguous denies: a malformed policy, contradictory directives (an
+`agent_writes: deny` appended under an earlier `allow`), a failed read, or a
+course this caller cannot see.
 
 ---
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -64,6 +64,132 @@ Check your submission status across assignments.
 
 ---
 
+#### `get_my_submission`
+View your own submission for a single assignment, including how many attempts
+you have used and any instructor comments.
+
+**Parameters:**
+- `course_identifier` (required): Course code or Canvas ID
+- `assignment_id` (required): Canvas assignment ID
+
+**Example:**
+```
+"Did my essay for BADM 350 go through?"
+"How many attempts do I have left on assignment 4821?"
+```
+
+**Returns:** Status, submitted time, due and lock dates, attempts used vs allowed,
+grade if any, and submission comments.
+
+---
+
+### Student Write Tools
+
+> **Off by default.** These tools only exist if the server operator enabled them
+> via `STUDENT_WRITE_TOOLS`, and an instructor can additionally block them in
+> their own course. See [Student write configuration](#student-write-configuration).
+
+#### `submit_assignment`
+Submit one of your own assignments. **Consumes an attempt.**
+
+This is a deliberate two-call flow. The first call previews and submits nothing;
+the second call, carrying the token from the preview, actually submits.
+
+**Parameters:**
+- `course_identifier` (required): Course code or Canvas ID
+- `assignment_id` (required): Canvas assignment ID
+- `submission_type` (required): `online_text_entry`, `online_url`, or `online_upload`
+- `body` (for text entry): The content to submit
+- `url` (for URL submissions): The URL
+- `file_paths` (for uploads, local servers only): Local file paths, any file type
+- `file_contents` (for uploads, hosted servers): `[{"name": ..., "content_base64": ...}]`
+- `comment` (optional): A comment to include with the submission
+- `confirmation_token` (optional): Token from the preview call; omit to preview
+
+**Example:**
+```
+"Submit my essay draft to assignment 4821"        → returns a preview
+"Yes, submit it"                                   → confirms with the token
+```
+
+**Returns:** On the first call, a preview showing the assignment, due and lock
+dates, attempts remaining, and exactly what would be sent. On the second, the
+submission result including whether Canvas marked it late.
+
+**Files are sent as raw bytes** of any allowed type. Images and PDFs are uploaded
+as-is, never converted to text or run through OCR.
+
+**Not supported:** group assignments (submitting would bind your whole group) and
+quizzes (a separate institutional decision).
+
+---
+
+#### `comment_on_my_submission`
+Add a comment to your own submission.
+
+**Parameters:**
+- `course_identifier` (required): Course code or Canvas ID
+- `assignment_id` (required): Canvas assignment ID
+- `comment` (required): The comment text
+
+**Example:**
+```
+"Add a note to my submission explaining the late turn-in"
+```
+
+---
+
+#### `mark_module_item_done`
+Mark a module item complete for yourself, for modules using "mark as done"
+requirements.
+
+**Parameters:**
+- `course_identifier` (required): Course code or Canvas ID
+- `module_id` (required): Canvas module ID
+- `item_id` (required): Canvas module item ID
+
+---
+
+#### Student write configuration
+
+Two independent gates, and the second can only ever narrow the first.
+
+**1. Operator ceiling — `STUDENT_WRITE_TOOLS`**
+
+Comma- or space-separated tool names. Empty (the default) means no student write
+tool is registered at all.
+
+```bash
+STUDENT_WRITE_TOOLS=submit_assignment,comment_on_my_submission
+```
+
+**2. Per-course instructor policy**
+
+An instructor states their course's stance in the course syllabus (the default
+carrier, because students cannot edit it):
+
+```
+agent_writes: deny
+```
+
+or, to allow with limits:
+
+```
+agent_writes: allow
+allow_tools: submit_assignment
+note: Allowed for the weekly labs. Ask me before using it on the final project.
+```
+
+`COURSE_AGENT_POLICY_DEFAULT` decides what happens in a course that says nothing:
+`deny` (the default, instructors opt in) or `allow` (instructors opt out).
+
+Operators who would rather not put this in the syllabus can set
+`COURSE_AGENT_POLICY_SOURCE=page` and use a course page instead. That option is
+weaker and the server knows it: a Canvas page can be student-editable, so any
+page whose `editing_roles` is not teacher-only is ignored rather than trusted.
+
+---
+
 ### Academic Performance
 
 #### `get_my_course_grades`

--- a/tools/TOOL_MANIFEST.json
+++ b/tools/TOOL_MANIFEST.json
@@ -23,6 +23,11 @@
       "id": "developer",
       "name": "Developer Tools",
       "description": "Bulk operations, code execution, and tool discovery"
+    },
+    {
+      "id": "student_write",
+      "name": "Student Write Tools",
+      "description": "Tools that act on Canvas for the student. Off by default: enabled per-tool by the operator via STUDENT_WRITE_TOOLS, and further restrictable per course by an instructor."
     }
   ],
   "tools": [
@@ -725,8 +730,159 @@
           "description": "Only count active enrollments"
         }
       ],
-      "returns": "Yes/no plus minimal enrollment metadata (state, role, matched field) — never the roster",
+      "returns": "Yes/no plus minimal enrollment metadata (state, role, matched field) \u2014 never the roster",
       "notes": "Data-minimizing roster-membership check for external access gating. Requires a teacher-scoped token; a student token yields a clean Canvas 403."
+    },
+    {
+      "name": "get_my_submission",
+      "category": "student",
+      "description": "Get your own submission for one assignment, including attempts used",
+      "parameters": [
+        {
+          "name": "course_identifier",
+          "type": "string",
+          "required": true,
+          "description": "Course code or Canvas ID"
+        },
+        {
+          "name": "assignment_id",
+          "type": "string",
+          "required": true,
+          "description": "Canvas assignment ID"
+        }
+      ],
+      "returns": "Status, submitted time, due/lock dates, attempts used vs allowed, grade, comments",
+      "examples": [
+        "Did my essay go through?",
+        "How many attempts do I have left?"
+      ]
+    },
+    {
+      "name": "submit_assignment",
+      "category": "student_write",
+      "description": "Submit your own assignment. Consumes an attempt. Requires a confirmation token from a preview call.",
+      "parameters": [
+        {
+          "name": "course_identifier",
+          "type": "string",
+          "required": true,
+          "description": "Course code or Canvas ID"
+        },
+        {
+          "name": "assignment_id",
+          "type": "string",
+          "required": true,
+          "description": "Canvas assignment ID"
+        },
+        {
+          "name": "submission_type",
+          "type": "string",
+          "required": true,
+          "description": "online_text_entry, online_url, or online_upload"
+        },
+        {
+          "name": "body",
+          "type": "string",
+          "required": false,
+          "description": "Content for online_text_entry"
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "required": false,
+          "description": "URL for online_url"
+        },
+        {
+          "name": "file_paths",
+          "type": "array",
+          "required": false,
+          "description": "Local file paths, any type (local stdio servers only)"
+        },
+        {
+          "name": "file_contents",
+          "type": "array",
+          "required": false,
+          "description": "Inline files as [{name, content_base64}] (required on hosted servers)"
+        },
+        {
+          "name": "comment",
+          "type": "string",
+          "required": false,
+          "description": "Optional comment to include"
+        },
+        {
+          "name": "confirmation_token",
+          "type": "string",
+          "required": false,
+          "description": "Token from the preview call; omit to preview"
+        }
+      ],
+      "returns": "A preview plus confirmation token on the first call; the submission result on the second",
+      "examples": [
+        "Submit my essay to assignment 4821",
+        "Yes, submit it"
+      ],
+      "notes": "Disabled unless the operator lists it in STUDENT_WRITE_TOOLS, and an instructor can block it per course. Group assignments and quizzes are not supported."
+    },
+    {
+      "name": "comment_on_my_submission",
+      "category": "student_write",
+      "description": "Add a comment to your own submission",
+      "parameters": [
+        {
+          "name": "course_identifier",
+          "type": "string",
+          "required": true,
+          "description": "Course code or Canvas ID"
+        },
+        {
+          "name": "assignment_id",
+          "type": "string",
+          "required": true,
+          "description": "Canvas assignment ID"
+        },
+        {
+          "name": "comment",
+          "type": "string",
+          "required": true,
+          "description": "The comment text"
+        }
+      ],
+      "returns": "Confirmation the comment was added",
+      "examples": [
+        "Add a note to my submission explaining the late turn-in"
+      ],
+      "notes": "Disabled unless the operator lists it in STUDENT_WRITE_TOOLS."
+    },
+    {
+      "name": "mark_module_item_done",
+      "category": "student_write",
+      "description": "Mark a module item done for yourself",
+      "parameters": [
+        {
+          "name": "course_identifier",
+          "type": "string",
+          "required": true,
+          "description": "Course code or Canvas ID"
+        },
+        {
+          "name": "module_id",
+          "type": "string",
+          "required": true,
+          "description": "Canvas module ID"
+        },
+        {
+          "name": "item_id",
+          "type": "string",
+          "required": true,
+          "description": "Canvas module item ID"
+        }
+      ],
+      "returns": "Confirmation the item was marked done",
+      "examples": [
+        "Mark the week 3 reading as done"
+      ],
+      "notes": "Disabled unless the operator lists it in STUDENT_WRITE_TOOLS."
     }
   ],
   "workflows": [


### PR DESCRIPTION
Implements the Tier 1 scope committed in #170 (the U-M evaluation's stated decision factor). Design details and the two public corrections are in the [#170 design comment](https://github.com/vishalsachdev/canvas-mcp/issues/170#issuecomment-5125231050).

## Tools

`get_my_submission` (read, always registered) plus three writes: `submit_assignment` (text / URL / binary file upload), `comment_on_my_submission`, `mark_module_item_done`.

## Three gates, layered so a lower one can only restrict

1. **`STUDENT_WRITE_TOOLS` operator ceiling, default EMPTY** — an unlisted tool never registers, so it never appears in any agent's tool list.
2. **Per-course instructor policy, carried by the course syllabus** (students structurally cannot edit it; a page carrier was built and deliberately deleted — `editing_roles` proves current permission, not authorship). Malformed / conflicting / unreadable policy all deny; deny-by-default when a course states nothing (operator-configurable; U-M asked for their preferred default in the issue).
3. **HMAC-signed, single-use confirmation token** bound to caller credential + payload hash + attempt state. Preview shows the full body; token dies on any drift; atomic claim prevents concurrent double-submit; all preconditions re-verified immediately before the POST.

Also: `file_paths` refused over HTTP transport (server-file disclosure); inline base64 with count/size caps checked before decode; binary bytes pass through verbatim (JPEG byte-equality fixture); group assignments refused; quiz-taking excluded by design.

## Verification

- 90 feature tests incl. simulated races (concurrent confirms → exactly one POST; state mutated mid-upload → abort). Suite 750 passed / 21 skipped.
- Codex review: **10 rounds to clean** (findings per round: 5, 3, 4, 3, 1, 5, 2, 3, 0). Several rounds found defects in prior rounds' fixes; two reversed design decisions (shared token secret; page policy carrier).

## Held open deliberately

U-M has been asked two questions in the issue that could adjust defaults before release: the no-policy default posture, and whether a student-visible syllabus policy is acceptable to their service owner. Merging is safe regardless (everything defaults off), but this PR merits a human look before it lands — it is the flagship deliverable of the evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)