### PR TITLE
ci: run Ruff checks in CI

### DIFF
--- a/.github/workflows/canvas-mcp-testing.yml
+++ b/.github/workflows/canvas-mcp-testing.yml
@@ -10,6 +10,23 @@ on:
     branches: [ main ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Install Ruff
+      run: python -m pip install ruff
+
+    - name: Run Ruff
+      run: ruff check src/ tests/
+
   test-enhancements:
     runs-on: ubuntu-latest
     

--- a/src/canvas_mcp/core/access/factory.py
+++ b/src/canvas_mcp/core/access/factory.py
@@ -62,7 +62,7 @@ class _AzureTableBackend:
             raise ConcurrencyConflict(str(exc)) from exc
 
     def query(self, pk):
-        flt = "PartitionKey eq '%s'" % pk.replace("'", "''")
+        flt = "PartitionKey eq '{}'".format(pk.replace("'", "''"))
         return [_entity_to_row(e) for e in self._t.query_entities(flt)]
 
     def delete(self, pk, rk):
@@ -93,6 +93,7 @@ def build_email_sender(config):
     # without the [hosted] extra is unaffected; degrade to None on any failure.
     try:
         import asyncio
+
         from azure.communication.email import EmailClient
         from azure.identity import DefaultAzureCredential
         client = EmailClient(config.acs_endpoint, DefaultAzureCredential())

--- a/tests/core/access/test_factory.py
+++ b/tests/core/access/test_factory.py
@@ -1,11 +1,18 @@
 from types import SimpleNamespace
+
 from canvas_mcp.core.access import factory
 
 
 def _cfg(**kw):
-    base = dict(access_request_enabled=True, access_token_secret="s",
-                access_table_account="acct", access_table_name="t",
-                acs_endpoint="https://acs", acs_sender="x@d", access_admin_emails=["a@x"])
+    base = {
+        "access_request_enabled": True,
+        "access_token_secret": "s",
+        "access_table_account": "acct",
+        "access_table_name": "t",
+        "acs_endpoint": "https://acs",
+        "acs_sender": "x@d",
+        "access_admin_emails": ["a@x"],
+    }
     base.update(kw)
     return SimpleNamespace(**base)
 

--- a/tests/core/access/test_notify.py
+++ b/tests/core/access/test_notify.py
@@ -1,4 +1,5 @@
 import pytest
+
 from canvas_mcp.core.access.notify import build_request_email, notify_access_request
 from canvas_mcp.core.access.store import AccessStore, InMemoryBackend, Requester
 
@@ -19,9 +20,16 @@ async def test_notify_sends_once_and_dedups():
     sent = []
     async def fake_send(recipients, subject, html, plain):
         sent.append((recipients, subject))
-    kw = dict(store=store, requester=REQ, secret="s",
-              approve_base_url="https://h.edu", admin_emails=["a@x.edu"],
-              cooldown_hours=24, ttl_seconds=86400, send_email=fake_send)
+    kw = {
+        "store": store,
+        "requester": REQ,
+        "secret": "s",
+        "approve_base_url": "https://h.edu",
+        "admin_emails": ["a@x.edu"],
+        "cooldown_hours": 24,
+        "ttl_seconds": 86400,
+        "send_email": fake_send,
+    }
     assert await notify_access_request(jti="j1", now=0, now_iso="2026-06-29T00:00:00Z", **kw) is True
     assert await notify_access_request(jti="j2", now=60, now_iso="2026-06-29T00:01:00Z", **kw) is False
     assert len(sent) == 1 and sent[0][0] == ["a@x.edu"]

--- a/tests/core/access/test_routes.py
+++ b/tests/core/access/test_routes.py
@@ -1,5 +1,7 @@
-import pytest
 from unittest.mock import AsyncMock
+
+import pytest
+
 import canvas_mcp.core.audit as audit
 from canvas_mcp.core.access import routes
 from canvas_mcp.core.access.store import AccessStore, InMemoryBackend, Requester

--- a/tests/core/access/test_store.py
+++ b/tests/core/access/test_store.py
@@ -1,5 +1,8 @@
 from canvas_mcp.core.access.store import (
-    AccessStore, InMemoryBackend, Requester, ConcurrencyConflict,
+    AccessStore,
+    ConcurrencyConflict,
+    InMemoryBackend,
+    Requester,
 )
 
 REQ = Requester(oid="oid-1", upn="j@x.edu", display_name="Jane Doe")

--- a/tests/core/access/test_tokens.py
+++ b/tests/core/access/test_tokens.py
@@ -1,4 +1,4 @@
-from canvas_mcp.core.access.tokens import mint_token, verify_token, TokenClaims
+from canvas_mcp.core.access.tokens import TokenClaims, mint_token, verify_token
 
 SECRET = "test-secret-key"
 

--- a/tests/core/test_audit_access.py
+++ b/tests/core/test_audit_access.py
@@ -1,4 +1,5 @@
 import pytest
+
 import canvas_mcp.core.audit as audit
 
 

--- a/tests/core/test_config_access.py
+++ b/tests/core/test_config_access.py
@@ -1,4 +1,5 @@
 import pytest
+
 from canvas_mcp.core.config import get_config, reset_config
 
 

--- a/tests/test_cli_access.py
+++ b/tests/test_cli_access.py
@@ -1,8 +1,8 @@
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from canvas_mcp.server import _cmd_list_grants, _cmd_revoke
 from canvas_mcp.core.access.store import AccessStore, InMemoryBackend, Requester
+from canvas_mcp.server import _cmd_list_grants, _cmd_revoke
 
 
 def _store_with_one():

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -945,12 +945,20 @@ class TestAccessOverlayGate:
     def _cfg(self, **kw):
         # Minimal config double with feature enabled + an in-memory store.
         from types import SimpleNamespace
-        base = dict(entra_auth_enabled=True, mcp_entra_allowed_oids=frozenset({"oid-env"}),
-                    canvas_api_url="https://c.edu/api/v1", mcp_access_keys=frozenset(),
-                    access_request_enabled=True, access_token_secret="s",
-                    access_table_account="acct", access_admin_emails=["a@x"],
-                    access_approve_base_url="https://h.edu", acs_endpoint="https://acs",
-                    acs_sender="x@d", access_notify_cooldown_hours=24)
+        base = {
+            "entra_auth_enabled": True,
+            "mcp_entra_allowed_oids": frozenset({"oid-env"}),
+            "canvas_api_url": "https://c.edu/api/v1",
+            "mcp_access_keys": frozenset(),
+            "access_request_enabled": True,
+            "access_token_secret": "s",
+            "access_table_account": "acct",
+            "access_admin_emails": ["a@x"],
+            "access_approve_base_url": "https://h.edu",
+            "acs_endpoint": "https://acs",
+            "acs_sender": "x@d",
+            "access_notify_cooldown_hours": 24,
+        }
         base.update(kw)
         return SimpleNamespace(**base)
 


### PR DESCRIPTION
## Summary

- add a dedicated Ruff lint job to the test workflow
- run `ruff check src/ tests/` for pull requests targeting `main`
- clean up the 13 existing Ruff findings so the new check starts green

## Validation

- `ruff check src/ tests/`
- `pytest tests/core/access/ tests/core/test_audit_access.py tests/core/test_config_access.py tests/test_cli_access.py tests/test_http_transport.py::TestAccessOverlayGate` — 37 passed
- workflow YAML parsed and the lint command was verified
- `git diff --check`

The full test suite was deferred to CI; the targeted tests cover the modules touched by the lint cleanup.

Fixes #175
