### PR TITLE
fix: associate_rubric never attached the rubric (#181) + shared write-confirmation guard

### DIFF
--- a/src/canvas_mcp/tools/rubrics.py
+++ b/src/canvas_mcp/tools/rubrics.py
@@ -1103,24 +1103,28 @@ def register_rubric_tools(mcp: FastMCP) -> None:
         rubric_id_str = str(rubric_id)
         assignment_id_str = str(assignment_id)
 
-        # Update the rubric with association
+        # Canvas needs bracket-notation FORM data on the dedicated
+        # rubric_associations endpoint (#181). The previous implementation sent a
+        # nested JSON body to PUT /courses/:id/rubrics/:id; Canvas returned 200
+        # because the rubric itself is valid, but the association was never
+        # created, so the tool reported success while nothing attached to the
+        # assignment. This mirrors _ensure_course_bookmark, which works.
         request_data = {
-            "rubric_association": {
-                "association_id": assignment_id_str,
-                "association_type": "Assignment",
-                "use_for_grading": use_for_grading,
-                "purpose": purpose
-            }
+            "rubric_association[rubric_id]": rubric_id_str,
+            "rubric_association[association_id]": assignment_id_str,
+            "rubric_association[association_type]": "Assignment",
+            "rubric_association[use_for_grading]": "1" if use_for_grading else "0",
+            "rubric_association[purpose]": purpose,
         }
 
-        # Make the API request
         response = await make_canvas_request(
-            "put",
-            f"/courses/{course_id}/rubrics/{rubric_id_str}",
-            data=request_data
+            "post",
+            f"/courses/{course_id}/rubric_associations",
+            data=request_data,
+            use_form_data=True,
         )
 
-        if "error" in response:
+        if isinstance(response, dict) and "error" in response:
             return f"Error associating rubric with assignment: {response['error']}"
 
         # Get assignment details for confirmation
@@ -1135,10 +1139,27 @@ def register_rubric_tools(mcp: FastMCP) -> None:
 
         course_display = await get_course_code(course_id) or course_identifier
 
+        # A 200 carrying no association id means Canvas accepted the request but
+        # created nothing. Reporting success there is exactly the #181/#180
+        # failure: the user is told it worked and finds nothing in the UI.
+        association_id = (response or {}).get("id") if isinstance(response, dict) else None
+        if not association_id:
+            return (
+                "⚠️  Could not confirm the rubric was associated with the "
+                "assignment. Canvas accepted the request but returned no "
+                "association, so the rubric will most likely not appear on the "
+                "assignment page.\n\n"
+                f"Course: {course_display}\n"
+                f"Assignment: {assignment_name} (ID: {assignment_id})\n"
+                f"Rubric ID: {rubric_id}\n"
+                "Verify in Canvas before relying on this association.\n"
+            )
+
         result = "Rubric associated with assignment successfully!\n\n"
         result += f"Course: {course_display}\n"
         result += f"Assignment: {assignment_name} (ID: {assignment_id})\n"
         result += f"Rubric ID: {rubric_id}\n"
+        result += f"Association ID: {association_id}\n"
         result += f"Used for Grading: {'Yes' if use_for_grading else 'No'}\n"
         result += f"Purpose: {purpose}\n"
 

--- a/src/canvas_mcp/tools/rubrics.py
+++ b/src/canvas_mcp/tools/rubrics.py
@@ -395,6 +395,50 @@ def build_rubric_create_form_data(
     return form_data
 
 
+def rubric_association_id(response: Any) -> Any | None:
+    """Return the id of a rubric association Canvas actually created, or None.
+
+    Canvas answers ``200`` for rubric writes whose association parameters it
+    silently ignored, so an HTTP success is not evidence that an association
+    exists. The only reliable evidence is an id in the payload. This has now
+    bitten three separate call sites — #180 (create, invisible in the Rubrics
+    UI), #181 (assignment association never attached), and the CSV import path
+    (#190) — so the shapes Canvas uses are recognised in exactly one place
+    rather than re-derived per tool.
+
+    Handles the three payload shapes:
+
+    - ``{"rubric": {...}, "rubric_association": {"id": N, ...}}`` — rubric create
+    - ``{"id": N, "association_type": "...", ...}`` — POST /rubric_associations
+    - ``{"rubric_association": null}`` / ``{}`` — accepted, created nothing
+    """
+    if not isinstance(response, dict):
+        return None
+
+    association = response.get("rubric_association")
+    if isinstance(association, dict):
+        return association.get("id") or None
+
+    # POST /courses/:id/rubric_associations returns the association itself.
+    if response.get("association_type") or response.get("association_id"):
+        return response.get("id") or None
+
+    return None
+
+
+def unconfirmed_write_warning(what: str, facts: dict[str, Any], remedy: str) -> str:
+    """Format the 'Canvas accepted this but created nothing' warning.
+
+    Every rubric write shares one rule: never report success for a state the
+    user cannot see in Canvas. Centralising the wording keeps that failure
+    legible and identical across tools instead of drifting per call site.
+    """
+    lines = [f"⚠️  Could not confirm {what}.\n"]
+    lines += [f"{label}: {value}\n" for label, value in facts.items() if value is not None]
+    lines.append(f"{remedy}\n")
+    return "".join(lines)
+
+
 async def _ensure_course_bookmark(response: Any, course_id: str | int) -> str:
     """Guarantee a created rubric is actually bookmarked into the course.
 
@@ -405,15 +449,16 @@ async def _ensure_course_bookmark(response: Any, course_id: str | int) -> str:
 
     Returns a line to append to the tool output.
     """
-    if isinstance(response, dict) and response.get("rubric_association"):
+    if rubric_association_id(response):
         return ""
 
     rubric = (response or {}).get("rubric") or {}
     rubric_id = rubric.get("id") or (response or {}).get("id")
     if not rubric_id:
-        return (
-            "\n⚠️  Could not confirm this rubric was added to the course's Rubrics "
-            "list, and Canvas returned no rubric ID to retry with. Check Canvas.\n"
+        return "\n" + unconfirmed_write_warning(
+            "this rubric was added to the course's Rubrics list",
+            {},
+            "Canvas returned no rubric ID to retry with. Check Canvas.",
         )
 
     retry = await make_canvas_request(
@@ -1142,17 +1187,18 @@ def register_rubric_tools(mcp: FastMCP) -> None:
         # A 200 carrying no association id means Canvas accepted the request but
         # created nothing. Reporting success there is exactly the #181/#180
         # failure: the user is told it worked and finds nothing in the UI.
-        association_id = (response or {}).get("id") if isinstance(response, dict) else None
+        association_id = rubric_association_id(response)
         if not association_id:
-            return (
-                "⚠️  Could not confirm the rubric was associated with the "
-                "assignment. Canvas accepted the request but returned no "
-                "association, so the rubric will most likely not appear on the "
-                "assignment page.\n\n"
-                f"Course: {course_display}\n"
-                f"Assignment: {assignment_name} (ID: {assignment_id})\n"
-                f"Rubric ID: {rubric_id}\n"
-                "Verify in Canvas before relying on this association.\n"
+            return unconfirmed_write_warning(
+                "the rubric was associated with the assignment",
+                {
+                    "Course": course_display,
+                    "Assignment": f"{assignment_name} (ID: {assignment_id})",
+                    "Rubric ID": rubric_id,
+                },
+                "Canvas accepted the request but returned no association, so the "
+                "rubric will most likely not appear on the assignment page. "
+                "Verify in Canvas before relying on it.",
             )
 
         result = "Rubric associated with assignment successfully!\n\n"

--- a/tests/tools/test_rubrics.py
+++ b/tests/tools/test_rubrics.py
@@ -12,6 +12,8 @@ from canvas_mcp.tools.rubrics import (
     build_rubric_create_form_data,
     preprocess_criteria_string,
     register_rubric_tools,
+    rubric_association_id,
+    unconfirmed_write_warning,
     validate_rubric_criteria,
 )
 
@@ -362,6 +364,39 @@ class TestRubricTools:
         assert "Added to the course's Rubrics list." in result.content[0].text
 
     @pytest.mark.asyncio
+    async def test_create_rubric_retries_when_association_has_no_id(
+        self, mcp, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """An association dict with no id must not count as confirmation.
+
+        Latent hole closed by centralising the check in
+        ``rubric_association_id``: the previous truthiness test accepted this
+        payload as a successful bookmark, leaving the #180 symptom in place for
+        a shape Canvas can actually return.
+        """
+        mock_canvas_request.side_effect = [
+            {"rubric": {"id": 7371, "title": "R", "points_possible": 5},
+             "rubric_association": {"association_type": "Course"}},
+            {"id": 99, "association_type": "Course", "purpose": "bookmark"},
+        ]
+        criteria = json.dumps(
+            {"c1": {"description": "C", "points": 5,
+                    "ratings": [{"description": "Good", "points": 5}]}}
+        )
+
+        register_rubric_tools(mcp)
+        result = await _call_tool(mcp, "create_rubric", {
+            "course_identifier": "TEST101",
+            "title": "R",
+            "criteria": criteria,
+        })
+
+        calls = mock_canvas_request.call_args_list
+        assert len(calls) == 2, "an id-less association must trigger the retry"
+        assert calls[1].args[1].endswith("/rubric_associations")
+        assert "Added to the course's Rubrics list." in result.content[0].text
+
+    @pytest.mark.asyncio
     async def test_create_rubric_warns_when_association_retry_fails(
         self, mcp, mock_canvas_request, mock_course_id, mock_course_code
     ):
@@ -635,6 +670,73 @@ class TestRubricTools:
         assert mock_canvas_request.call_count == 1
         assert "finished with status: failed" in output
         assert "Created Rubric ID" not in output
+
+
+class TestRubricAssociationId:
+    """The single shared guard behind #180, #181 and #190.
+
+    Canvas returns 200 for rubric writes whose association params it ignored,
+    so only an id in the payload proves an association exists.
+    """
+
+    def test_rubric_create_shape(self):
+        assert rubric_association_id(
+            {"rubric": {"id": 7371}, "rubric_association": {"id": 99, "association_type": "Course"}}
+        ) == 99
+
+    def test_post_rubric_associations_shape(self):
+        assert rubric_association_id(
+            {"id": 99, "association_id": 5030, "association_type": "Assignment"}
+        ) == 99
+
+    def test_null_association_is_not_confirmation(self):
+        assert rubric_association_id({"rubric": {"id": 7371}, "rubric_association": None}) is None
+
+    def test_empty_response_is_not_confirmation(self):
+        assert rubric_association_id({}) is None
+
+    def test_association_dict_without_id_is_not_confirmation(self):
+        """A truthy association dict carrying no id proves nothing.
+
+        The pre-refactor bookmark check tested ``response.get(
+        "rubric_association")`` for truthiness, so this shape was accepted as
+        success even though Canvas created nothing.
+        """
+        assert rubric_association_id(
+            {"rubric": {"id": 7371}, "rubric_association": {"association_type": "Course"}}
+        ) is None
+
+    def test_bare_rubric_id_is_not_an_association(self):
+        """A rubric id alone must not be mistaken for an association id."""
+        assert rubric_association_id({"id": 7371, "title": "R"}) is None
+
+    def test_non_dict_response(self):
+        assert rubric_association_id(None) is None
+        assert rubric_association_id("boom") is None
+        assert rubric_association_id([{"id": 99}]) is None
+
+
+class TestUnconfirmedWriteWarning:
+    def test_includes_subject_facts_and_remedy(self):
+        out = unconfirmed_write_warning(
+            "the rubric was associated with the assignment",
+            {"Course": "TEST101", "Rubric ID": 361},
+            "Verify in Canvas.",
+        )
+        assert out.startswith("⚠️  Could not confirm")
+        assert "the rubric was associated with the assignment" in out
+        assert "Course: TEST101" in out
+        assert "Rubric ID: 361" in out
+        assert "Verify in Canvas." in out
+
+    def test_omits_facts_with_no_value(self):
+        out = unconfirmed_write_warning("x happened", {"Course": "T", "Rubric ID": None}, "Check.")
+        assert "Course: T" in out
+        assert "Rubric ID" not in out
+
+    def test_never_contains_success_language(self):
+        out = unconfirmed_write_warning("x happened", {}, "Check.")
+        assert "success" not in out.lower()
 
 
 class TestAssociateRubric:

--- a/tests/tools/test_rubrics.py
+++ b/tests/tools/test_rubrics.py
@@ -637,5 +637,156 @@ class TestRubricTools:
         assert "Created Rubric ID" not in output
 
 
+class TestAssociateRubric:
+    """Regression coverage for #181: association silently never attached."""
+
+    @pytest.fixture
+    def mcp(self):
+        return FastMCP("test-associate-rubric")
+
+    @pytest.fixture
+    def mock_canvas_request(self):
+        with patch('canvas_mcp.tools.rubrics.make_canvas_request', new_callable=AsyncMock) as mock:
+            yield mock
+
+    @pytest.fixture
+    def mock_course_id(self):
+        with patch('canvas_mcp.tools.rubrics.get_course_id', new_callable=AsyncMock) as mock:
+            mock.return_value = 505
+            yield mock
+
+    @pytest.fixture
+    def mock_course_code(self):
+        with patch('canvas_mcp.tools.rubrics.get_course_code', new_callable=AsyncMock) as mock:
+            mock.return_value = "UIUC_MCP_Test_Course"
+            yield mock
+
+    async def test_associate_rubric_registered(self, mcp):
+        register_rubric_tools(mcp)
+        assert "associate_rubric" in {t.name for t in await mcp.list_tools()}
+
+    @pytest.mark.asyncio
+    async def test_uses_rubric_associations_endpoint_with_form_data(
+        self, mcp, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """#181: must POST bracket-notation form data to /rubric_associations.
+
+        The original implementation sent a nested JSON body to
+        ``PUT /courses/:id/rubrics/:id``. Canvas answered 200 (the rubric
+        itself is valid) but never created the association, so the tool
+        reported success while nothing attached to the assignment.
+        """
+        mock_canvas_request.side_effect = [
+            {"id": 99, "rubric_id": 361, "association_id": 5030,
+             "association_type": "Assignment", "purpose": "grading"},
+            {"id": 5030, "name": "Assignment 2"},
+        ]
+
+        register_rubric_tools(mcp)
+        await _call_tool(mcp, "associate_rubric", {
+            "course_identifier": "UIUC_MCP_Test_Course",
+            "rubric_id": 361,
+            "assignment_id": 5030,
+        })
+
+        create = mock_canvas_request.call_args_list[0]
+        assert create.args[0] == "post"
+        assert create.args[1].endswith("/courses/505/rubric_associations")
+        assert create.kwargs["use_form_data"] is True
+
+        sent = create.kwargs["data"]
+        assert sent["rubric_association[rubric_id]"] == "361"
+        assert sent["rubric_association[association_id]"] == "5030"
+        assert sent["rubric_association[association_type]"] == "Assignment"
+        assert sent["rubric_association[purpose]"] == "grading"
+        # Flat bracket keys only — a nested dict would be JSON-encoded by httpx
+        assert not any(isinstance(v, dict) for v in sent.values())
+
+    @pytest.mark.asyncio
+    async def test_use_for_grading_encoded_as_form_boolean(
+        self, mcp, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """Python bools must be sent as Canvas form booleans, not ``True``."""
+        mock_canvas_request.side_effect = [
+            {"id": 99, "association_id": 5030},
+            {"id": 5030, "name": "Assignment 2"},
+        ]
+
+        register_rubric_tools(mcp)
+        await _call_tool(mcp, "associate_rubric", {
+            "course_identifier": "UIUC_MCP_Test_Course",
+            "rubric_id": 361,
+            "assignment_id": 5030,
+            "use_for_grading": True,
+        })
+
+        sent = mock_canvas_request.call_args_list[0].kwargs["data"]
+        assert sent["rubric_association[use_for_grading]"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_reports_error_when_association_call_fails(
+        self, mcp, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        mock_canvas_request.return_value = {"error": "not authorized"}
+
+        register_rubric_tools(mcp)
+        result = await _call_tool(mcp, "associate_rubric", {
+            "course_identifier": "UIUC_MCP_Test_Course",
+            "rubric_id": 361,
+            "assignment_id": 5030,
+        })
+
+        output = result.content[0].text
+        assert "not authorized" in output
+        assert "successfully" not in output.lower()
+
+    @pytest.mark.asyncio
+    async def test_never_claims_success_without_an_association_id(
+        self, mcp, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """#181's core failure: success reported on an association that isn't there.
+
+        A 200 with no association id means Canvas accepted the request but
+        created nothing. Same principle as #180 — never report success on a
+        state the user cannot see in the Canvas UI.
+        """
+        mock_canvas_request.side_effect = [
+            {},
+            {"id": 5030, "name": "Assignment 2"},
+        ]
+
+        register_rubric_tools(mcp)
+        result = await _call_tool(mcp, "associate_rubric", {
+            "course_identifier": "UIUC_MCP_Test_Course",
+            "rubric_id": 361,
+            "assignment_id": 5030,
+        })
+
+        output = result.content[0].text
+        assert "associated with assignment successfully" not in output
+        assert "could not confirm" in output.lower()
+
+    @pytest.mark.asyncio
+    async def test_success_output_reports_association_id(
+        self, mcp, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        mock_canvas_request.side_effect = [
+            {"id": 99, "association_id": 5030, "association_type": "Assignment"},
+            {"id": 5030, "name": "Assignment 2"},
+        ]
+
+        register_rubric_tools(mcp)
+        result = await _call_tool(mcp, "associate_rubric", {
+            "course_identifier": "UIUC_MCP_Test_Course",
+            "rubric_id": 361,
+            "assignment_id": 5030,
+        })
+
+        output = result.content[0].text
+        assert "successfully" in output.lower()
+        assert "Assignment 2" in output
+        assert "99" in output
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fixes #181. Reported by @zqian.

## Root cause

`associate_rubric` sent a **nested `rubric_association` JSON body** to `PUT /courses/:id/rubrics/:id`:

```python
request_data = {"rubric_association": {"association_id": ..., "association_type": "Assignment", ...}}
response = await make_canvas_request("put", f"/courses/{course_id}/rubrics/{rubric_id_str}", data=request_data)
```

No `use_form_data=True`, so httpx JSON-encoded it. Canvas answered **200** because the rubric itself is valid, but the nested association params were never parsed and no association was created. The tool then unconditionally printed `Rubric associated with assignment successfully!` — exactly what @zqian saw: a success message and an empty assignment page.

This is the same defect class as #180, and it is the "assignment-path" gap that #180's follow-up explicitly listed as still unverified. It is now verified.

Worth noting: when @zqian asked the model which API call was used, it answered `POST /courses/:id/rubric_associations` with form-encoded bracket params. That was a plausible guess rather than a report of the code, but it happened to name the correct endpoint — which is what this PR moves to.

## Fix

Use the dedicated association endpoint with flat bracket-notation form data, mirroring `_ensure_course_bookmark` — the path in this same file already proven to work against Canvas (#182):

```python
request_data = {
    "rubric_association[rubric_id]": rubric_id_str,
    "rubric_association[association_id]": assignment_id_str,
    "rubric_association[association_type]": "Assignment",
    "rubric_association[use_for_grading]": "1" if use_for_grading else "0",
    "rubric_association[purpose]": purpose,
}
response = await make_canvas_request("post", f"/courses/{course_id}/rubric_associations",
                                     data=request_data, use_form_data=True)
```

Python bools become `"1"`/`"0"` — `True` would serialize as the string `True`, which Canvas does not read as truthy.

**Second half of the fix:** stop reporting success when Canvas returns no association id. A 200 with an empty body means the request was accepted and nothing was created; the tool now warns and tells the user to verify, instead of asserting a state they cannot see. Same never-claim-invisible-success principle as #180. Successful output now also reports the `Association ID` so the result is checkable.

## Tests

`associate_rubric` had **zero** tests. Adds 6:

| Test | Guards |
|---|---|
| `test_associate_rubric_registered` | registration |
| `test_uses_rubric_associations_endpoint_with_form_data` | **#181 regression** — endpoint, `use_form_data=True`, bracket keys, no nested dicts |
| `test_use_for_grading_encoded_as_form_boolean` | bool → `"1"` |
| `test_reports_error_when_association_call_fails` | error path says nothing about success |
| `test_never_claims_success_without_an_association_id` | **#181 core symptom** — 200 + empty body must not report success |
| `test_success_output_reports_association_id` | happy path surfaces a verifiable id |

All 4 substantive tests were confirmed **failing against the old code** before the fix, and the empty-response test reproduces @zqian's report directly.

## Verification

```
tests/tools/test_rubrics.py::TestAssociateRubric   6 passed
full suite                                          897 passed, 21 skipped
ruff check src/ tests/                              All checks passed
```

## Notes / deliberately out of scope

- `association_type` stays hardcoded to `"Assignment"`. The #180 report flagged this, but assignment association is this tool's entire purpose; a general association tool would be a separate feature.
- No signature change, so `AGENTS.md` / `tools/README.md` need no update.
- Unrelated pre-existing doc drift spotted: `docs/learning-designer-guide.html:173` names a nonexistent `associate_rubric_with_assignment`. Not touched here.
- **Not verified against a live Canvas instance** — the fix follows the encoding that demonstrably works for `_ensure_course_bookmark`, but @zqian's repro on a real Canvas dev server would be the definitive confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)