### PR TITLE
docs: fix create_rubric_from_csv format — it created zero rubrics as documented

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ Course management, grading, and analytics. Requires instructor/TA role.
 | `get_rubric` | View rubric details (by rubric_id or assignment_id) |
 | `get_rubric_assessment` | View rubric assessment for a student submission |
 | `create_rubric` | Create rubric with criteria, ratings, and optional assignment association |
-| `create_rubric_from_csv` | Create rubric from a CSV string |
+| `create_rubric_from_csv` | Create rubric(s) from a CSV string. Requires a `Rubric Name` column; imported rubrics are `Draft` and do **not** appear in `list_rubrics` |
 | `associate_rubric` | Associate existing rubric with an assignment |
 | `grade_with_rubric` | Grade single submission with rubric |
 | `bulk_grade_submissions` | Grade multiple submissions efficiently |

--- a/src/canvas_mcp/tools/rubrics.py
+++ b/src/canvas_mcp/tools/rubrics.py
@@ -954,10 +954,26 @@ def register_rubric_tools(mcp: FastMCP) -> None:
         course_identifier: str | int,
         csv_content: str,
     ) -> str:
-        """Create a rubric in a course from a CSV string.
+        """Create one or more rubrics in a course from a CSV string.
 
         Uses Canvas's native rubric CSV import endpoint, then polls the import
-        job until it reaches a terminal workflow_state (succeeded/failed).
+        job until it reaches a terminal workflow_state.
+
+        A ``Rubric Name`` column is REQUIRED — Canvas rejects the import without
+        it and creates nothing. Required format (repeat the rating triple per
+        rating level; a distinct Rubric Name per row creates multiple rubrics)::
+
+            Rubric Name,Criteria Name,Criteria Description,Criteria Enable Range,Rating Name,Rating Description,Rating Points
+            Essay Rubric,Clarity,Is the argument clear,false,Excellent,Very clear,10
+
+        Two Canvas behaviours to be aware of:
+
+        - Imported rubrics land in the ``Draft`` state and are **not** returned
+          by ``list_rubrics`` / ``GET /courses/:id/rubrics``, though they do
+          appear on the course Rubrics page. An empty ``list_rubrics`` result is
+          not evidence the import failed.
+        - ``succeeded_with_errors`` is a terminal state, not a transient one, and
+          can mean zero rubrics were created.
 
         Args:
             course_identifier: Course code or Canvas ID

--- a/tools/README.md
+++ b/tools/README.md
@@ -447,15 +447,29 @@ Uses bracket-notation form-data encoding required by the Canvas rubric API.
 ---
 
 #### `create_rubric_from_csv`
-Create a rubric in a course from a CSV string using Canvas's native rubric CSV import endpoint. Uploads the CSV, then polls the import job until it succeeds or fails.
+Create one or more rubrics in a course from a CSV string using Canvas's native rubric CSV import endpoint. Uploads the CSV, then polls the import job until it reaches a terminal state.
 
 **Parameters:**
 - `course_identifier`: Course code or ID
-- `csv_content`: The CSV content as a string (e.g. `"Title,Rating 1,Rating 2\nCriterion 1,10,5"`)
+- `csv_content`: The CSV content as a string. **A `Rubric Name` column is required** — Canvas rejects the import without it.
+
+**Required CSV format:**
+
+```csv
+Rubric Name,Criteria Name,Criteria Description,Criteria Enable Range,Rating Name,Rating Description,Rating Points,Rating Name,Rating Description,Rating Points
+Essay Rubric,Clarity,Is the argument clear,false,Excellent,Very clear,10,Poor,Unclear,2
+```
+
+Repeat the `Rating Name,Rating Description,Rating Points` triple for each rating level. Use a distinct `Rubric Name` per row to create multiple rubrics in one import.
+
+**Two behaviours worth knowing:**
+
+- **Imported rubrics land in Canvas's `Draft` state and are NOT returned by `list_rubrics`.** They *are* visible in the course's Rubrics page. Do not treat an empty `list_rubrics` result as evidence the import failed.
+- Canvas returns `succeeded_with_errors` when the file parses but some rows are rejected. That is a terminal state, not a transient one, and it can mean **zero** rubrics were created — check the reported error messages rather than assuming partial success.
 
 **Example:**
 ```
-"Create a rubric in CS101 from this CSV: Title,Excellent,Poor / Clarity,10,2"
+"Create a rubric in CS101 from this CSV: Rubric Name,Criteria Name,Criteria Description,Criteria Enable Range,Rating Name,Rating Description,Rating Points / Essay Rubric,Clarity,Is it clear,false,Excellent,Very clear,10"
 ```
 
 ---


### PR DESCRIPTION
Refs #190. **Docs only, no behaviour change** — but it fixes a tool that did not work at all for anyone following our documentation.

## The bug

`tools/README.md:454` and the tool's docstring documented this format:

```
Title,Rating 1,Rating 2
Criterion 1,10,5
```

Canvas rejects it. Measured against a live Canvas instance:

```
workflow_state:  'succeeded_with_errors'
error_count:     1
error_data:      [{"message": "Missing 'Rubric Name' in some rows."}]
rubrics created: 0
```

The tool then reported `Rubric CSV import process finished with status: succeeded_with_errors` and surfaced none of that error text. Same shape as #181 and #180: a write that reports completion while producing nothing.

## The fix

Canvas requires a `Rubric Name` column. This format is **verified working** against the same instance (`workflow_state: 'succeeded'`, `error_count: 0`, 2 rubrics created from a 2-row file):

```csv
Rubric Name,Criteria Name,Criteria Description,Criteria Enable Range,Rating Name,Rating Description,Rating Points,Rating Name,Rating Description,Rating Points
Essay Rubric,Clarity,Is the argument clear,false,Excellent,Very clear,10,Poor,Unclear,2
```

Also documents two Canvas behaviours found while measuring, both of which lead an agent to conclude a successful import failed:

- **Imported rubrics land in `Draft` state and are NOT returned by `list_rubrics`** (verified against `include[]=associations`, `include[]=account_associations`, and `state=draft` — all returned 0 while the Rubrics page showed both). They are visible on the course Rubrics page.
- **`succeeded_with_errors` is terminal, not transient**, and can mean zero rubrics were created.

## Files

| File | Why |
|---|---|
| `tools/README.md` | human-facing tool docs — the format, plus both caveats |
| `src/canvas_mcp/tools/rubrics.py` | docstring only. This is the **agent-facing** contract — verified it reaches `list_tools()`, so an agent now sees the `Rubric Name` requirement and the `Draft` caveat before calling the tool |
| `AGENTS.md` | one-line table entry, per this repo's agent source-of-truth convention |

## Verification

```
full suite                908 passed, 21 skipped
ruff check src/ tests/    All checks passed
list_tools() docstring    'Rubric Name' present: True | 'Draft' present: True
```

## Deliberately out of scope

The code-side fixes are tracked in #190 and being handled in #194: adding `succeeded_with_errors` to the terminal states, surfacing `error_count`/`error_data`, and removing the dead rubric-ID parsing (the import payload contains neither a `rubric` nor a `rubrics` key). Test fixtures still carrying the old format are left alone to avoid conflicting with #194, which is actively editing `tests/tools/test_rubrics.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)