### PR TITLE
Merge #194: harden create_rubric_from_csv result semantics (#190)

### DIFF
--- a/src/canvas_mcp/tools/rubrics.py
+++ b/src/canvas_mcp/tools/rubrics.py
@@ -989,9 +989,11 @@ def register_rubric_tools(mcp: FastMCP) -> None:
         status = response.get("workflow_state", "created")
         result_response = response
 
+        terminal_states = {"succeeded", "failed", "completed"}
+
         # Poll up to 10 times (20 seconds) for it to finish processing
         for _ in range(10):
-            if status in ["succeeded", "failed", "completed"]:
+            if status in terminal_states:
                 break
 
             await asyncio.sleep(2)
@@ -1007,14 +1009,38 @@ def register_rubric_tools(mcp: FastMCP) -> None:
 
         course_display = await get_course_code(course_id) or course_identifier
 
+        if status not in terminal_states:
+            return unconfirmed_write_warning(
+                "the rubric CSV import completed",
+                {
+                    "Course": course_display,
+                    "Import ID": import_id,
+                    "Last known workflow_state": status,
+                },
+                "Canvas may still be processing this import. Check Canvas and retry shortly.",
+            )
+
         result = f"Rubric CSV import process finished with status: {status}\n\n"
         result += f"Course: {course_display}\n"
         result += f"Import ID: {import_id}\n"
 
-        # Check if a rubric was returned in the final response
-        if "rubric" in result_response and result_response["rubric"]:
-            result += f"Created Rubric ID: {result_response['rubric'].get('id')}\n"
-            result += f"Rubric Title: {result_response['rubric'].get('title')}\n"
+        # Canvas may return either a single rubric or a list for CSV imports.
+        created_rubrics: list[dict[str, Any]] = []
+        if isinstance(result_response, dict):
+            single = result_response.get("rubric")
+            if isinstance(single, dict):
+                created_rubrics.append(single)
+            many = result_response.get("rubrics")
+            if isinstance(many, list):
+                created_rubrics.extend([rubric for rubric in many if isinstance(rubric, dict)])
+
+        if len(created_rubrics) == 1:
+            result += f"Created Rubric ID: {created_rubrics[0].get('id')}\n"
+            result += f"Rubric Title: {created_rubrics[0].get('title')}\n"
+        elif created_rubrics:
+            result += "Created Rubrics:\n"
+            for rubric in created_rubrics:
+                result += f"- ID: {rubric.get('id')} | Title: {rubric.get('title')}\n"
 
         return result
 

--- a/src/canvas_mcp/tools/rubrics.py
+++ b/src/canvas_mcp/tools/rubrics.py
@@ -2,7 +2,9 @@
 
 import ast
 import asyncio
+import csv
 import json
+from io import StringIO
 from typing import Any
 
 from fastmcp import FastMCP
@@ -437,6 +439,38 @@ def unconfirmed_write_warning(what: str, facts: dict[str, Any], remedy: str) -> 
     lines += [f"{label}: {value}\n" for label, value in facts.items() if value is not None]
     lines.append(f"{remedy}\n")
     return "".join(lines)
+
+
+def count_csv_rubrics(csv_content: str) -> int | None:
+    """Count distinct rubric names in a Canvas rubric CSV.
+
+    Returns None when the CSV cannot be parsed or does not include a
+    ``Rubric Name`` column.
+    """
+    try:
+        reader = csv.DictReader(StringIO(csv_content))
+    except csv.Error:
+        return None
+
+    if not reader.fieldnames:
+        return None
+
+    rubric_name_field = next(
+        (name for name in reader.fieldnames if isinstance(name, str) and name.strip().lower() == "rubric name"),
+        None,
+    )
+    if not rubric_name_field:
+        return None
+
+    names: set[str] = set()
+    for row in reader:
+        if not isinstance(row, dict):
+            continue
+        raw_name = row.get(rubric_name_field)
+        if isinstance(raw_name, str) and raw_name.strip():
+            names.add(raw_name.strip())
+
+    return len(names)
 
 
 async def _ensure_course_bookmark(response: Any, course_id: str | int) -> str:
@@ -957,7 +991,20 @@ def register_rubric_tools(mcp: FastMCP) -> None:
         """Create a rubric in a course from a CSV string.
 
         Uses Canvas's native rubric CSV import endpoint, then polls the import
-        job until it reaches a terminal workflow_state (succeeded/failed).
+        job until it reaches a terminal workflow_state.
+
+        Canvas expects the rubric-import CSV header format shown below; shorter
+        ad-hoc formats are accepted by this tool as strings but rejected by
+        Canvas during import.
+
+        Example:
+            Rubric Name,Criteria Name,Criteria Description,Criteria Enable Range,Rating Name,Rating Description,Rating Points,Rating Name,Rating Description,Rating Points
+            Example Rubric,Clarity,Is it clear,false,Excellent,Very clear,10,Poor,Unclear,2
+
+        Note:
+            Imported rubrics appear in the Canvas Rubrics UI as Draft. They may
+            not appear in list_rubrics immediately because that endpoint does
+            not currently return these Draft imports.
 
         Args:
             course_identifier: Course code or Canvas ID
@@ -988,8 +1035,9 @@ def register_rubric_tools(mcp: FastMCP) -> None:
         # Poll for completion
         status = response.get("workflow_state", "created")
         result_response = response
+        csv_rubric_count = count_csv_rubrics(csv_content)
 
-        terminal_states = {"succeeded", "failed", "completed"}
+        terminal_states = {"succeeded", "failed", "completed", "succeeded_with_errors"}
 
         # Poll up to 10 times (20 seconds) for it to finish processing
         for _ in range(10):
@@ -1020,27 +1068,34 @@ def register_rubric_tools(mcp: FastMCP) -> None:
                 "Canvas may still be processing this import. Check Canvas and retry shortly.",
             )
 
+        error_count = result_response.get("error_count") if isinstance(result_response, dict) else None
+        error_data = result_response.get("error_data") if isinstance(result_response, dict) else None
+        if isinstance(error_count, int) and error_count > 0:
+            warning = unconfirmed_write_warning(
+                "the rubric CSV import completed without errors",
+                {
+                    "Course": course_display,
+                    "Import ID": import_id,
+                    "workflow_state": status,
+                    "error_count": error_count,
+                },
+                "Fix the CSV issues and retry. Canvas can accept the upload while creating none or only some rubrics.",
+            )
+            if error_data:
+                warning += f"error_data: {error_data}\n"
+            if csv_rubric_count is not None:
+                warning += f"Rubrics defined in CSV: {csv_rubric_count}\n"
+            warning += "Open the course Rubrics page in Canvas to verify what was created.\n"
+            return warning
+
         result = f"Rubric CSV import process finished with status: {status}\n\n"
         result += f"Course: {course_display}\n"
         result += f"Import ID: {import_id}\n"
-
-        # Canvas may return either a single rubric or a list for CSV imports.
-        created_rubrics: list[dict[str, Any]] = []
-        if isinstance(result_response, dict):
-            single = result_response.get("rubric")
-            if isinstance(single, dict):
-                created_rubrics.append(single)
-            many = result_response.get("rubrics")
-            if isinstance(many, list):
-                created_rubrics.extend([rubric for rubric in many if isinstance(rubric, dict)])
-
-        if len(created_rubrics) == 1:
-            result += f"Created Rubric ID: {created_rubrics[0].get('id')}\n"
-            result += f"Rubric Title: {created_rubrics[0].get('title')}\n"
-        elif created_rubrics:
-            result += "Created Rubrics:\n"
-            for rubric in created_rubrics:
-                result += f"- ID: {rubric.get('id')} | Title: {rubric.get('title')}\n"
+        if csv_rubric_count is not None:
+            result += f"Rubrics defined in CSV: {csv_rubric_count}\n"
+        else:
+            result += "Rubrics defined in CSV: unknown (missing or unreadable 'Rubric Name' column)\n"
+        result += "Open the course Rubrics page in Canvas to review imported Draft rubrics.\n"
 
         return result
 

--- a/tests/tools/test_rubrics.py
+++ b/tests/tools/test_rubrics.py
@@ -671,6 +671,81 @@ class TestRubricTools:
         assert "finished with status: failed" in output
         assert "Created Rubric ID" not in output
 
+    @pytest.mark.asyncio
+    async def test_create_rubric_from_csv_timeout_reports_unconfirmed_warning(
+        self, mcp, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """A non-terminal status after polling must not be reported as finished."""
+        mock_canvas_request.side_effect = [
+            {"id": 1234, "workflow_state": "created"},
+            *([{"id": 1234, "workflow_state": "created"}] * 10),
+        ]
+
+        register_rubric_tools(mcp)
+        with patch("canvas_mcp.tools.rubrics.asyncio.sleep", new_callable=AsyncMock):
+            result = await _call_tool(mcp, "create_rubric_from_csv", {
+                "course_identifier": "TEST101",
+                "csv_content": "Title,Rating 1\nCrit,5",
+            })
+
+        output = result.content[0].text
+        assert mock_canvas_request.call_count == 11
+        assert "Could not confirm the rubric CSV import completed." in output
+        assert "Last known workflow_state: created" in output
+        assert "finished with status" not in output
+
+    @pytest.mark.asyncio
+    async def test_create_rubric_from_csv_missing_workflow_state_reports_unknown(
+        self, mcp, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """Missing workflow_state should surface as an unconfirmed import."""
+        mock_canvas_request.side_effect = [
+            {"id": 1234},
+            *([{"id": 1234}] * 10),
+        ]
+
+        register_rubric_tools(mcp)
+        with patch("canvas_mcp.tools.rubrics.asyncio.sleep", new_callable=AsyncMock):
+            result = await _call_tool(mcp, "create_rubric_from_csv", {
+                "course_identifier": "TEST101",
+                "csv_content": "Title,Rating 1\nCrit,5",
+            })
+
+        output = result.content[0].text
+        assert mock_canvas_request.call_count == 11
+        assert "Could not confirm the rubric CSV import completed." in output
+        assert "Last known workflow_state: unknown" in output
+        assert "finished with status" not in output
+
+    @pytest.mark.asyncio
+    async def test_create_rubric_from_csv_reports_multiple_created_rubrics(
+        self, mcp, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """List-shaped import payloads should report all returned rubrics."""
+        mock_canvas_request.side_effect = [
+            {"id": 1234, "workflow_state": "created"},
+            {
+                "id": 1234,
+                "workflow_state": "succeeded",
+                "rubrics": [
+                    {"id": 999, "title": "CSV Rubric A"},
+                    {"id": 1000, "title": "CSV Rubric B"},
+                ],
+            },
+        ]
+
+        register_rubric_tools(mcp)
+        result = await _call_tool(mcp, "create_rubric_from_csv", {
+            "course_identifier": "TEST101",
+            "csv_content": "Title,Rating 1\nCrit,5",
+        })
+
+        output = result.content[0].text
+        assert "finished with status: succeeded" in output
+        assert "Created Rubrics:" in output
+        assert "- ID: 999 | Title: CSV Rubric A" in output
+        assert "- ID: 1000 | Title: CSV Rubric B" in output
+
 
 class TestRubricAssociationId:
     """The single shared guard behind #180, #181 and #190.

--- a/tests/tools/test_rubrics.py
+++ b/tests/tools/test_rubrics.py
@@ -10,6 +10,7 @@ from fastmcp import Client, FastMCP
 
 from canvas_mcp.tools.rubrics import (
     build_rubric_create_form_data,
+    count_csv_rubrics,
     preprocess_criteria_string,
     register_rubric_tools,
     rubric_association_id,
@@ -606,13 +607,17 @@ class TestRubricTools:
         """create_rubric_from_csv successfully uploads CSV and polls for completion."""
         mock_canvas_request.side_effect = [
             {"id": 1234, "workflow_state": "created"},
-            {"id": 1234, "workflow_state": "succeeded", "rubric": {"id": 999, "title": "CSV Rubric"}}
+            {"id": 1234, "workflow_state": "succeeded", "error_count": 0, "error_data": []}
         ]
 
         register_rubric_tools(mcp)
         result = await _call_tool(mcp, "create_rubric_from_csv", {
             "course_identifier": "TEST101",
-            "csv_content": "Title,Rating 1\nCrit,5",
+            "csv_content": (
+                "Rubric Name,Criteria Name,Criteria Description,Criteria Enable Range,"
+                "Rating Name,Rating Description,Rating Points\n"
+                "Example Rubric,Clarity,Is it clear,false,Excellent,Very clear,10"
+            ),
         })
 
         output = result.content[0].text
@@ -632,8 +637,8 @@ class TestRubricTools:
 
         assert "Rubric CSV import process finished with status: succeeded" in output
         assert "Import ID: 1234" in output
-        assert "Created Rubric ID: 999" in output
-        assert "Rubric Title: CSV Rubric" in output
+        assert "Rubrics defined in CSV: 1" in output
+        assert "Rubrics page in Canvas" in output
 
     @pytest.mark.asyncio
     async def test_create_rubric_from_csv_upload_error(self, mcp, mock_canvas_request, mock_course_id, mock_course_code):
@@ -656,7 +661,12 @@ class TestRubricTools:
     async def test_create_rubric_from_csv_failed_state(self, mcp, mock_canvas_request, mock_course_id, mock_course_code):
         """A terminal 'failed' workflow_state is reported without further polling."""
         mock_canvas_request.side_effect = [
-            {"id": 1234, "workflow_state": "failed"},
+            {
+                "id": 1234,
+                "workflow_state": "failed",
+                "error_count": 1,
+                "error_data": [{"message": "Missing 'Rubric Name' in some rows."}],
+            },
         ]
 
         register_rubric_tools(mcp)
@@ -668,8 +678,10 @@ class TestRubricTools:
         output = result.content[0].text
         # 'failed' is terminal → loop breaks immediately, no GET poll
         assert mock_canvas_request.call_count == 1
-        assert "finished with status: failed" in output
-        assert "Created Rubric ID" not in output
+        assert "Could not confirm the rubric CSV import completed without errors." in output
+        assert "workflow_state: failed" in output
+        assert "error_count: 1" in output
+        assert "Missing 'Rubric Name' in some rows." in output
 
     @pytest.mark.asyncio
     async def test_create_rubric_from_csv_timeout_reports_unconfirmed_warning(
@@ -718,21 +730,16 @@ class TestRubricTools:
         assert "finished with status" not in output
 
     @pytest.mark.asyncio
-    async def test_create_rubric_from_csv_reports_multiple_created_rubrics(
+    async def test_create_rubric_from_csv_succeeded_with_errors_is_terminal(
         self, mcp, mock_canvas_request, mock_course_id, mock_course_code
     ):
-        """List-shaped import payloads should report all returned rubrics."""
-        mock_canvas_request.side_effect = [
-            {"id": 1234, "workflow_state": "created"},
-            {
-                "id": 1234,
-                "workflow_state": "succeeded",
-                "rubrics": [
-                    {"id": 999, "title": "CSV Rubric A"},
-                    {"id": 1000, "title": "CSV Rubric B"},
-                ],
-            },
-        ]
+        """succeeded_with_errors should not be polled as non-terminal."""
+        mock_canvas_request.side_effect = [{
+            "id": 1234,
+            "workflow_state": "succeeded_with_errors",
+            "error_count": 1,
+            "error_data": [{"message": "Missing 'Rubric Name' in some rows."}],
+        }]
 
         register_rubric_tools(mcp)
         result = await _call_tool(mcp, "create_rubric_from_csv", {
@@ -741,10 +748,25 @@ class TestRubricTools:
         })
 
         output = result.content[0].text
-        assert "finished with status: succeeded" in output
-        assert "Created Rubrics:" in output
-        assert "- ID: 999 | Title: CSV Rubric A" in output
-        assert "- ID: 1000 | Title: CSV Rubric B" in output
+        assert mock_canvas_request.call_count == 1
+        assert "workflow_state: succeeded_with_errors" in output
+        assert "error_count: 1" in output
+        assert "Missing 'Rubric Name' in some rows." in output
+
+
+class TestCountCsvRubrics:
+    def test_counts_distinct_rubric_names(self):
+        csv_content = (
+            "Rubric Name,Criteria Name,Criteria Description,Criteria Enable Range,"
+            "Rating Name,Rating Description,Rating Points\n"
+            "Example Rubric,Clarity,Is it clear,false,Excellent,Very clear,10\n"
+            "Example Rubric,Depth,Is it thorough,false,Excellent,Very thorough,10\n"
+            "Second Rubric,Clarity,Is it clear,false,Excellent,Very clear,10\n"
+        )
+        assert count_csv_rubrics(csv_content) == 2
+
+    def test_returns_none_when_rubric_name_column_missing(self):
+        assert count_csv_rubrics("Title,Rating 1\nCrit,5\n") is None
 
 
 class TestRubricAssociationId:

--- a/tools/README.md
+++ b/tools/README.md
@@ -451,12 +451,14 @@ Create a rubric in a course from a CSV string using Canvas's native rubric CSV i
 
 **Parameters:**
 - `course_identifier`: Course code or ID
-- `csv_content`: The CSV content as a string (e.g. `"Title,Rating 1,Rating 2\nCriterion 1,10,5"`)
+- `csv_content`: The CSV content as a string using Canvas's rubric import headers (e.g. `"Rubric Name,Criteria Name,Criteria Description,Criteria Enable Range,Rating Name,Rating Description,Rating Points\nExample Rubric,Clarity,Is it clear,false,Excellent,Very clear,10"`)
 
 **Example:**
 ```
-"Create a rubric in CS101 from this CSV: Title,Excellent,Poor / Clarity,10,2"
+"Create a rubric in CS101 from this CSV: Rubric Name,Criteria Name,Criteria Description,Criteria Enable Range,Rating Name,Rating Description,Rating Points / Example Rubric,Clarity,Is it clear,false,Excellent,Very clear,10"
 ```
+
+**Note:** CSV-imported rubrics appear in Canvas as **Draft** items. They may not appear immediately in `list_rubrics`; verify imports in the course Rubrics UI.
 
 ---
 


### PR DESCRIPTION
Merges @copilot-swe-agent's #194 and resolves its conflict with #195.

**Why this PR exists:** #194 is substantively correct and passes CI, but it conflicted with `main` because I merged #195 (the documentation half of #190) while #194 was in flight. That sequencing was my mistake, so I resolved it here rather than bouncing it back for a rebase.

**Conflict resolution:** kept `main`'s documentation from #195 in both `tools/README.md` and the `create_rubric_from_csv` docstring — both sides said the same thing and #195's is the fuller write-up. **All of #194's code changes are retained.**

## Code changes (from #194)

- **`succeeded_with_errors` added to the terminal states.** Previously it wasn't terminal, so the tool polled the full ~20s on an import that had already finished, then reported it as "finished".
- **`error_count` / `error_data` surfaced** whenever `error_count` is nonzero, and never presented as plain success. Canvas told us exactly what was wrong; we were discarding it.
- **`count_csv_rubrics()`** reports how many rubrics the CSV *defines*, replacing the dead `"rubric" in result_response` parsing. The import payload carries no rubric IDs at all, so that branch could never fire.
- **Genuine poll timeouts** still report via `unconfirmed_write_warning()` and are now distinguishable from terminal-with-errors — an earlier revision conflated them, which produced a new wrong answer ("may still be processing" for an import that had finished).

## Verification

Ran the exact failure case measured on live Canvas — `succeeded_with_errors`, `error_count: 1`, `"Missing 'Rubric Name' in some rows."`:

```
⚠️  Could not confirm the rubric CSV import completed without errors.
Course: T101
Import ID: 215
workflow_state: succeeded_with_errors
error_count: 1
Fix the CSV issues and retry. Canvas can accept the upload while creating none or only some rubrics.
error_data: [{'message': "Missing 'Rubric Name' in some rows."}]
Rubrics defined in CSV: 1
Open the course Rubrics page in Canvas to verify what was created.
```

Before this change that same response produced `Rubric CSV import process finished with status: succeeded_with_errors` with no error text.

```
says "still processing": False   (correct — it finished)
surfaces the error msg : True
full suite               913 passed, 21 skipped
ruff check src/ tests/   All checks passed
```

## Gap 1 — no code change, by design

Measured on live Canvas: CSV-imported rubrics **do** appear in the Canvas Rubrics UI (as `Draft`), so there is no bookmark problem and `_ensure_course_bookmark()` was correctly **not** added. The inverse mismatch — the API not listing them — is documented in the docstring and `tools/README.md` instead.

Closes #190. Credit to @copilot-swe-agent for the implementation in #194.

🤖 Generated with [Claude Code](https://claude.com/claude-code)