### PR TITLE
feat: thread api_root through fetch_all_paginated_results

### DIFF
--- a/src/canvas_mcp/core/client.py
+++ b/src/canvas_mcp/core/client.py
@@ -680,6 +680,7 @@ async def fetch_all_paginated_results(
     endpoint: str,
     params: dict[str, Any] | None = None,
     skip_anonymization: bool = False,
+    api_root: Literal["rest", "quiz"] = API_ROOT_REST,
 ) -> Any:
     """Fetch all results from a paginated Canvas API endpoint.
 
@@ -693,6 +694,13 @@ async def fetch_all_paginated_results(
             whose whole purpose is to see real identities — the local
             pseudonym-map export. Anonymizing that fetch maps pseudonyms to
             pseudonyms, which is not a privacy win, just a broken tool.
+        api_root: Which Canvas API root to call ("rest" => /api/v<N>,
+            "quiz" => /api/quiz/v1). Only the base URL changes; the
+            anonymization gate keys off ``endpoint``, so an alternate root
+            cannot route around it. Paginated quiz-root callers must use this
+            rather than looping over ``make_canvas_request`` themselves, or they
+            lose the single-anonymization-pass-over-the-complete-dataset
+            property this function exists to provide.
     """
     if params is None:
         params = {}
@@ -707,7 +715,9 @@ async def fetch_all_paginated_results(
     while True:
         current_params = {**params, "page": page}
         # Skip anonymization on individual pages - we'll anonymize the complete dataset
-        response = await make_canvas_request("get", endpoint, params=current_params, skip_anonymization=True)
+        response = await make_canvas_request(
+            "get", endpoint, params=current_params, skip_anonymization=True, api_root=api_root
+        )
 
         if isinstance(response, dict) and "error" in response:
             log_error(f"Error fetching page {page}", error=response['error'])

--- a/tests/core/test_client.py
+++ b/tests/core/test_client.py
@@ -98,3 +98,87 @@ class TestMakeCanvasRequestApiRoot:
         mock_anonymize.assert_called_once_with(
             {"id": 101, "name": "Alice"}, "/courses/42/users"
         )
+
+
+class TestPaginatedFetchApiRoot:
+    """`api_root` must reach the paginated path without weakening the gate.
+
+    A quiz-root caller that hand-rolls its own pagination over
+    ``make_canvas_request`` loses the single-anonymization-pass-over-the-
+    complete-dataset property, which is the #164 shortcut. So the paginated
+    helper has to support the alternate root itself.
+    """
+
+    @pytest.fixture(autouse=True)
+    def reset_client_state(self):
+        client_module._request_semaphore = None
+        client_module._semaphore_loop_ref = None
+        yield
+        client_module._request_semaphore = None
+        client_module._semaphore_loop_ref = None
+
+    @pytest.mark.asyncio
+    async def test_quiz_root_is_forwarded_to_every_page_request(self):
+        pages = [[{"id": i} for i in range(100)], [{"id": 100}]]
+
+        async def fake_request(method, endpoint, **kwargs):
+            return pages.pop(0) if pages else []
+
+        with patch.object(
+            client_module, "make_canvas_request", side_effect=fake_request
+        ) as mock_req:
+            await client_module.fetch_all_paginated_results(
+                "/courses/42/quizzes", api_root="quiz", skip_anonymization=True
+            )
+
+        assert mock_req.await_count == 2, "expected two page fetches"
+        for call in mock_req.await_args_list:
+            assert call.kwargs["api_root"] == "quiz"
+            assert call.kwargs["skip_anonymization"] is True
+
+    @pytest.mark.asyncio
+    async def test_rest_root_remains_the_default(self):
+        async def fake_request(method, endpoint, **kwargs):
+            return []
+
+        with patch.object(
+            client_module, "make_canvas_request", side_effect=fake_request
+        ) as mock_req:
+            await client_module.fetch_all_paginated_results("/courses/42/quizzes")
+
+        assert mock_req.await_args.kwargs["api_root"] == "rest"
+
+    @pytest.mark.asyncio
+    async def test_quiz_root_still_anonymizes_once_over_the_merged_dataset(self):
+        """The gate keys off `endpoint`, so the alternate root cannot bypass it."""
+        mock_config = SimpleNamespace(
+            enable_data_anonymization=True, anonymization_debug=False
+        )
+        pages = [
+            [{"id": 1, "name": "Alice"} for _ in range(100)],
+            [{"id": 2, "name": "Bob"}],
+        ]
+
+        async def fake_request(method, endpoint, **kwargs):
+            return pages.pop(0) if pages else []
+
+        with (
+            patch.object(client_module, "make_canvas_request", side_effect=fake_request),
+            patch("canvas_mcp.core.config.get_config", return_value=mock_config),
+            patch.object(
+                client_module,
+                "_anonymize_for_endpoint",
+                return_value=([{"id": 1, "name": "Student_x"}], "users"),
+            ) as mock_anon,
+        ):
+            result = await client_module.fetch_all_paginated_results(
+                "/courses/42/users", api_root="quiz"
+            )
+
+        # Exactly one anonymization pass, over all 101 merged records, keyed on
+        # the endpoint path rather than the base URL.
+        mock_anon.assert_called_once()
+        merged, endpoint_arg = mock_anon.call_args.args
+        assert len(merged) == 101
+        assert endpoint_arg == "/courses/42/users"
+        assert result == [{"id": 1, "name": "Student_x"}]


### PR DESCRIPTION
Follow-up to #193 (refs #192). Closes the one gap I flagged in review there.

## Why

#193 added `api_root` to `make_canvas_request` but not to `fetch_all_paginated_results`, so a **paginated** quiz-root fetch was impossible.

That's more than an incompleteness. The obvious workaround — looping over `make_canvas_request` directly — forfeits the single-anonymization-pass-over-the-complete-dataset property that `fetch_all_paginated_results` exists to provide. Reaching for exactly that shortcut is how #164 happened. And `list_quizzes` in #191 is a list endpoint, so it would have hit this immediately.

## Change

```python
async def fetch_all_paginated_results(
    endpoint: str,
    params: dict[str, Any] | None = None,
    skip_anonymization: bool = False,
    api_root: Literal["rest", "quiz"] = API_ROOT_REST,   # new
) -> Any:
```

Forwarded to `make_canvas_request` on each page fetch. Only the base URL changes — the anonymization gate keys off `endpoint`, so an alternate root cannot route around it.

## Tests

Three, asserting the security property rather than just the plumbing:

| Test | Asserts |
|---|---|
| `test_quiz_root_is_forwarded_to_every_page_request` | `api_root="quiz"` reaches **every** page call, not just the first |
| `test_rest_root_remains_the_default` | existing callers are unchanged — default is `"rest"` |
| `test_quiz_root_still_anonymizes_once_over_the_merged_dataset` | exactly **one** anonymization pass, over all **101** merged records, keyed on `/courses/42/users` rather than the base URL |

That third one is the point: it would fail if a future change moved anonymization per-page or keyed the gate off the full URL.

## Verification

```
full suite                928 passed, 21 skipped   (main is 925)
ruff check src/ tests/    All checks passed
```

Also added a docstring note telling paginated quiz-root callers to use this rather than hand-rolling a loop, with the reason — so the next person has the argument, not just the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)