### PR TITLE
triage: GitHub activity brief 2026-08-01

### DIFF
--- a/internal/issue-triage/2026-08-01.md
+++ b/internal/issue-triage/2026-08-01.md
@@ -1,0 +1,98 @@
+# GitHub Activity Triage — 2026-08-01
+
+**Read path used:** GitHub MCP tools (`gh` CLI not installed in this sandbox).
+**Cutoff:** 2026-07-31 (date of the newest prior brief, `internal/issue-triage/2026-07-31.md`). Confirmed against that brief's actual content — it covers #199/#198/#200/#201/#191 and nothing past PR #202 (merged 2026-07-31T05:47 UTC), so anything after that point is new to this run.
+
+---
+
+## Needs your reply
+
+None. No open issue has a comment posted since the cutoff whose most recent commenter is someone other than you — the two new items below are freshly filed issues with zero comments yet (see "New since cutoff"), not pending replies on existing threads.
+
+---
+
+## PRs
+
+One open PR.
+
+### #191 — feat: Add dual-engine read tools for Canvas Quizzes (Classic and New)
+- Draft, **`mergeable_state` is now `dirty`** (was `blocked` at last triage) — main has moved further since (PRs #201 and #205 merged 2026-07-31), so this branch now has real conflicts, not just "behind." **0 checks reported**, still on the same head commit (`8a7e393`) as last cycle.
+- Targets #172 (Tier A quiz read layer).
+- **No response from Copilot since your 2026-07-30T10:25 blocking review.** That review flagged: (1) the New Quizzes detection logic (`is_quiz_assignment AND external_tool`) is unverified and, per your own live measurement, `is_quiz_assignment=True` marks *Classic* quizzes — so the filter may always return empty for New Quizzes, silently defeating the tool; (2) `engine` is an unvalidated free string branched inconsistently across three tools; (3) a housekeeping ask to rebase onto main.
+- **Next action:** none from you — still waiting on Copilot to address the review and resolve the now-real merge conflicts. Worth flagging next cycle if it stays stalled at the same SHA a third time; two full days with no response to a detailed blocking review plus fresh conflicts is trending toward needing a nudge or reassignment rather than another silent wait.
+
+---
+
+## New since 2026-07-31
+
+Both new issues are from **zqian (University of Michigan)**, filed within ~3 minutes of each other on 2026-07-31 evening.
+
+### #207 — [Bug]: bulk_update_pages fails with Canvas error
+zqian asked to bulk-unpublish 3 pages in course 505; Canvas returned `HTTP 500 internal_server_error` for all three pages, so none were updated. They also separately note `bulk_update_pages` can't change page titles — only settings like publish state, roles, and notify — and suggest renaming the tool to `bulk_update_pages_settings` to make that explicit.
+
+I read `tools/pages.py:99-187`. The request the tool builds looks correct on its face: a form-encoded `PUT /courses/:id/pages/:page_url` with `wiki_page: {published: false}` (`use_form_data=True` is already set, matching Canvas's documented requirement for this endpoint). I don't see an obvious code-level bug that would produce a 500 specifically — that status code usually indicates a server-side failure rather than a malformed request, which a 400/422 would more typically signal. I can't rule out something more specific to their course (e.g. the pages' current state, or the literal `-slash-` in their URL slugs, which suggests the page titles contained a `/` character that Canvas's own slugifier rewrote — unrelated to this bug, just worth noting as a detail from their screenshot). **This one needs more data before I'd trust any fix**, not a case where I have a confident lead the way #208 below does.
+
+The tool-naming point (support settings, not titles) is accurate as-is — the docstring already says "Update settings for multiple pages," so it's not mislabeled, but a rename is a reasonable low-cost clarity improvement if you want to take it.
+
+```
+Thanks for the report. The request this tool builds looks correct to me on a
+read of the code (form-encoded PUT with just the published flag, which
+matches what Canvas expects here), so I don't have a confident root cause
+yet — a 500 usually points to something server-side rather than a bad
+request, but I don't want to guess. Two things would help me narrow it
+down:
+
+1. The full Canvas error response body (not just the screenshot) — Canvas's
+   500 responses sometimes include an internal error reference or a hint
+   at what failed.
+2. Whether those pages have anything unusual about them (very large body
+   content, recently renamed, front_page history, etc.) that might trip a
+   server-side edge case on unpublish specifically.
+
+On the naming point — you're right that bulk_update_pages only touches
+settings, not titles/body. The docstring says that today but I agree a
+rename would make it clearer up front; I'll consider bulk_update_pages_settings
+as a follow-up, separate from this bug.
+```
+
+### #208 — [Bug]: Canvas error returned for mark_conversations_read tool
+zqian tried to mark conversation ID 319 as read and got an error back (shown only as a screenshot, no error text or logs included in the report).
+
+**Likely root cause, fairly confident** — `tools/messaging.py:127-157`. The `mark_conversations_read` tool sends its request as:
+```python
+response = await make_canvas_request("put", "/conversations", data=data)
+```
+with no `use_form_data=True`. Compare this to the sibling `send_conversation` tool three lines away (`tools/messaging.py:236`), which sends the *same* `/conversations` endpoint and is explicitly commented `# Make the API request using form data (required by Canvas)` with `use_form_data=True` set. This repo's own `CLAUDE.md` states as a standing rule: "Messaging requires form data: Use `use_form_data=True` for `/conversations` endpoints." `mark_conversations_read` is the one messaging tool that doesn't follow that rule — it would send `conversation_ids[]` as a JSON body key instead of a form-encoded repeated parameter, which Canvas's `/conversations` PUT endpoint likely doesn't parse as an array the way it expects. This is a plausible, well-supported match to a known convention this file itself documents elsewhere, but I haven't run it against a live instance to confirm Canvas's exact rejection behavior — treat it as an unverified diagnosis, not a confirmed fix.
+
+**Suggested fix (unverified, not applied):** add `use_form_data=True` to the `make_canvas_request` call at `tools/messaging.py:144`, matching `send_conversation`.
+
+```
+Thanks for flagging this. I think I see it — mark_conversations_read is
+sending its request as a JSON body, but this repo's other /conversations
+call (send_conversation) sends form data instead, with a code comment
+noting Canvas requires that for this endpoint. mark_conversations_read
+looks like it was written without that flag, which would explain the
+error you're seeing. I want to verify against a live instance before
+shipping a fix, but this looks like a one-line change. Could you paste
+the actual error text/status code from that screenshot (not just the
+image) if you still have it? That would let me confirm rather than just
+match the pattern.
+```
+
+---
+
+## Going stale
+
+- **#106** — Address 186 mypy errors uncovered by adding mypy to dev deps. No non-you activity since the sole `claude[bot]` labeling comment on 2026-05-14 (~90 days idle). Pure backlog, nobody waiting.
+- **#157** — Harden `execute_typescript` sandbox. No non-you activity since the `claude[bot]` labeling comment on 2026-07-04 (your own follow-up on 07-10 was the last word). Backlog; already downgraded priority in-thread (self-hosted-only, hosted has the flag disabled).
+
+---
+
+## Checked, nothing needed
+
+- **#142** (mcp v2 pin watch) — last comment is yours (2026-07-30); no action pending.
+- **#170** (student write tools) — last comment is yours; two questions to zqian remain open in-thread but that's on him, not you.
+- **#179** (anonymization consolidation) — last comment is yours (status update); no action pending.
+- **#173** (TOOL_MANIFEST coverage) — only comment is the `claude[bot]` labeling pass on 2026-07-29; not yet 5 days stale.
+- **#168** (weekly maintenance report) — covered by existing `weekly-maintenance.yml` automation per standing instructions; not duplicated here despite crossing 5 days since its last (bot) comment.
+- **#201, #205** (merged 2026-07-31) — both closed cleanly since last brief; #201 shipped the annotation fix for #200, #205 completed the annotation contract for #204. No action needed.


### PR DESCRIPTION
Automated daily triage sweep of repo activity since 2026-07-31 (date of the prior brief). Adds `internal/issue-triage/2026-08-01.md` — no other files touched, no comments/labels/merges posted anywhere.

## Items needing your reply
None — no existing thread has a post-cutoff comment from someone other than you.

## New since cutoff (draft replies included in the brief)
- #207 — `bulk_update_pages` fails with a Canvas 500 error unpublishing pages; also a tool-naming suggestion (settings vs. title support). No confident root cause yet — the request the tool builds looks correct on read; draft reply asks for the full Canvas error body.
- #208 — `mark_conversations_read` returns a Canvas error. Likely root cause: `tools/messaging.py:144` is missing `use_form_data=True`, unlike the sibling `send_conversation` call which explicitly requires it per this repo's own `/conversations` convention. Unverified against a live instance.

## PRs to watch
- #191 (Copilot, targets #172) — draft, still on the same head commit as last cycle, no response to your 2026-07-30 blocking review, and `mergeable_state` has now flipped from `blocked` to `dirty` (real conflicts, not just behind). Flagged as trending toward needing a nudge if it stays stalled another cycle.

## Checked, nothing needed
#142, #170, #179, #173, #168 — all last-touched by you or covered by existing automation. #201 and #205 merged cleanly since the last brief.

Full detail, root-cause citations, and draft reply text are in the brief itself.


---
_Generated by [Claude Code](https://claude.ai/code/session_014EnW1QbHh6rVqTYB7yuRUm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single new internal markdown file with triage notes and draft replies; no runtime or API changes.
> 
> **Overview**
> Adds **`internal/issue-triage/2026-08-01.md`**, continuing the daily triage series with activity since the **2026-07-31** brief.
> 
> The new brief records **no threads needing your reply**, flags draft PR **#191** as **dirty** (merge conflicts) with still no response to the blocking review, and documents two **new bugs from zqian**: **#207** (`bulk_update_pages` / Canvas 500 — needs more data; includes draft reply) and **#208** (`mark_conversations_read` — likely missing `use_form_data=True`; includes draft reply). It also notes **going stale** issues **#106** and **#157**, and lists several issues/merged PRs **#201** / **#205** as checked with no action.
> 
> No application code, tests, or automation behavior changes — documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2acf21b701a9616120f1981b30012b3c51861b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->