### PR TITLE
fix: form-data/JSON mismatches in bulk_update_pages (#207) and mark_conversations_read (#208)

### DIFF
--- a/src/canvas_mcp/tools/messaging.py
+++ b/src/canvas_mcp/tools/messaging.py
@@ -141,7 +141,9 @@ def register_shared_messaging_tools(mcp: FastMCP) -> None:
                 "event": "mark_as_read"
             }
 
-            response = await make_canvas_request("put", "/conversations", data=data)
+            # /conversations requires form data: the "conversation_ids[]" bracket
+            # key only means an array in form encoding, not in a JSON body (#208)
+            response = await make_canvas_request("put", "/conversations", data=data, use_form_data=True)
 
             if "error" in response:
                 return response

--- a/src/canvas_mcp/tools/pages.py
+++ b/src/canvas_mcp/tools/pages.py
@@ -105,6 +105,9 @@ def register_page_tools(mcp: FastMCP):
     ) -> str:
         """Update settings for multiple pages at once.
 
+        Settings only — this tool cannot rename pages or change page content.
+        Use edit_page_content to change a page's body.
+
         Args:
             course_identifier: Course code or Canvas ID
             page_urls: Comma-separated list of page URL slugs
@@ -146,11 +149,12 @@ def register_page_tools(mcp: FastMCP):
         updated_pages = []
 
         for page_url in urls:
+            # Nested wiki_page payload must go as JSON; form encoding turns the
+            # inner dict into its Python repr, which Canvas rejects with a 500 (#207)
             response = await make_canvas_request(
                 "put",
                 f"/courses/{course_id}/pages/{page_url}",
-                data=update_data,
-                use_form_data=True
+                data=update_data
             )
 
             if isinstance(response, dict) and "error" in response:

--- a/tests/tools/test_messaging.py
+++ b/tests/tools/test_messaging.py
@@ -7,6 +7,66 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 
+def get_tool_function(tool_name: str):
+    """Get a tool function by name by capturing it during registration."""
+    from fastmcp import FastMCP
+
+    from canvas_mcp.tools.messaging import register_shared_messaging_tools
+
+    mcp = FastMCP("test")
+    captured_functions = {}
+
+    original_tool = mcp.tool
+    def capturing_tool(*args, **kwargs):
+        decorator = original_tool(*args, **kwargs)
+        def wrapper(fn):
+            captured_functions[fn.__name__] = fn
+            return decorator(fn)
+        return wrapper
+
+    mcp.tool = capturing_tool
+    register_shared_messaging_tools(mcp)
+
+    return captured_functions.get(tool_name)
+
+
+class TestMarkConversationsRead:
+    """Tests for the mark_conversations_read tool."""
+
+    @pytest.mark.asyncio
+    async def test_sends_form_data(self):
+        """Regression for #208: /conversations batch update requires form data.
+
+        Sent as JSON, the literal key "conversation_ids[]" is not recognized
+        by Canvas (bracket syntax only means an array in form encoding), so
+        the update fails. The request must use use_form_data=True like every
+        other /conversations write in this repo.
+        """
+        with patch('canvas_mcp.tools.messaging.make_canvas_request', new_callable=AsyncMock) as mock_request:
+            mock_request.return_value = [{"id": 319, "workflow_state": "read"}]
+
+            mark_conversations_read = get_tool_function("mark_conversations_read")
+            result = await mark_conversations_read(conversation_ids=["319"])
+
+            assert result.get("success") is True
+            call = mock_request.call_args
+            assert call.kwargs.get("use_form_data") is True
+            assert call.kwargs.get("data") == {
+                "conversation_ids[]": ["319"],
+                "event": "mark_as_read",
+            }
+
+    @pytest.mark.asyncio
+    async def test_empty_ids_rejected(self):
+        """Empty conversation_ids returns an error without calling Canvas."""
+        with patch('canvas_mcp.tools.messaging.make_canvas_request', new_callable=AsyncMock) as mock_request:
+            mark_conversations_read = get_tool_function("mark_conversations_read")
+            result = await mark_conversations_read(conversation_ids=[])
+
+            assert "error" in result
+            mock_request.assert_not_called()
+
+
 class TestMessagingTools:
     """Test messaging tool functions."""
 

--- a/tests/tools/test_pages.py
+++ b/tests/tools/test_pages.py
@@ -267,6 +267,28 @@ class TestBulkUpdatePages:
         assert "2" in result or "success" in result.lower()
 
     @pytest.mark.asyncio
+    async def test_bulk_update_sends_nested_payload_as_json(self, mock_canvas_request, mock_course_id, mock_course_code):
+        """Regression for #207: the nested wiki_page dict must be sent as JSON.
+
+        With use_form_data=True, httpx form-encodes the nested dict as its
+        Python repr (wiki_page={'published': False}), which Canvas rejects
+        with HTTP 500 on every page. The payload must go as JSON, matching
+        update_page_settings.
+        """
+        mock_canvas_request.return_value = {"url": "page-1", "title": "Page 1", "published": False}
+
+        bulk_update_pages = get_tool_function("bulk_update_pages")
+        await bulk_update_pages(
+            course_identifier="67619",
+            page_urls="page-1",
+            published=False
+        )
+
+        call = mock_canvas_request.call_args
+        assert call.kwargs.get("data") == {"wiki_page": {"published": False}}
+        assert call.kwargs.get("use_form_data", False) is False
+
+    @pytest.mark.asyncio
     async def test_bulk_update_partial_failure(self, mock_canvas_request, mock_course_id, mock_course_code):
         """Test handling when some pages fail to update."""
         mock_canvas_request.side_effect = [


### PR DESCRIPTION
## Summary

Two wire-format bugs reported by @zqian on 2026-07-31, both one-line form-data/JSON mismatches in opposite directions:

- **#207 — `bulk_update_pages` returned HTTP 500 for every page.** The tool sent the nested `{"wiki_page": {...}}` payload with `use_form_data=True`. Form encoding can't represent a nested dict, so httpx sent its Python repr on the wire (`wiki_page={'published': False}`), which Canvas rejects with a 500. Fix: send JSON, exactly like the working single-page sibling `update_page_settings`.
- **#208 — `mark_conversations_read` failed with a Canvas error.** The tool sent JSON with the literal key `"conversation_ids[]"`. The bracket suffix only means "array" in form encoding — in a JSON body Canvas sees no `conversation_ids` param at all. Fix: `use_form_data=True`, matching this repo's `/conversations` convention (`send_conversation` already does this).

Also addresses the secondary report in #207: the `bulk_update_pages` docstring now states explicitly that it is settings-only and cannot rename pages or change content.

## Verification

Wire bodies confirmed empirically with httpx (not just reasoned about):

| Payload | Body on the wire |
|---|---|
| #207 before (form) | `wiki_page=%7B%27published%27%3A+False%7D` ← Python repr, Canvas 500s |
| #207 after (JSON) | `{"wiki_page":{"published":false}}` |
| #208 before (JSON) | `{"conversation_ids[]":["319"],...}` ← literal bracket key, ignored |
| #208 after (form) | `conversation_ids%5B%5D=319&event=mark_as_read` |

Regression tests assert the **call shape** (payload + `use_form_data` kwarg) rather than mocked success, so a reintroduction fails CI. Full suite: 971 passed, 21 skipped. Ruff clean.

Not verified against a live Canvas instance (would require live writes to pages/conversations); the JSON path for #207 is byte-identical to `update_page_settings`, which works in production, and the form path for #208 matches the documented Canvas batch-update API.

Fixes #207
Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)