### PR TITLE
refactor: consolidate anonymization to the client layer (#179)

### DIFF
--- a/env.template
+++ b/env.template
@@ -14,6 +14,9 @@ LOG_LEVEL=INFO
 LOG_API_REQUESTS=false
 
 # Privacy and Security Configuration
+# ENABLE_DATA_ANONYMIZATION is honored at exactly one layer: the central Canvas
+# client (core/client.py) anonymizes responses from student-data endpoints
+# before any tool code sees them. Tool code never re-anonymizes (see issue #179).
 ENABLE_DATA_ANONYMIZATION=true
 ANONYMIZATION_DEBUG=false
 LOG_REDACT_PII=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ select = [
     "B",  # flake8-bugbear
     "C4", # flake8-comprehensions
     "UP", # pyupgrade
+    "TID251", # banned APIs (anonymization single-layer invariant, #179)
 ]
 ignore = [
     "E501", # line too long, handled by black
@@ -81,6 +82,13 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
+# core/ and tests may use the anonymization internals directly; everything else
+# must rely on the client-layer gate in core/client.py (#179)
+"src/canvas_mcp/core/**" = ["TID251"]
+"tests/**" = ["TID251"]
+
+[tool.ruff.lint.flake8-tidy-imports.banned-api]
+"canvas_mcp.core.anonymization.anonymize_response_data".msg = "Anonymization is applied once, at the client layer (core/client.py, gated by ENABLE_DATA_ANONYMIZATION). Do not re-anonymize in tool code — see issue #179."
 
 [tool.black]
 target-version = ['py310']

--- a/src/canvas_mcp/tools/admin_tools.py
+++ b/src/canvas_mcp/tools/admin_tools.py
@@ -4,10 +4,8 @@
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
-from ..core.anonymization import anonymize_response_data
 from ..core.cache import get_course_code, get_course_id
 from ..core.client import fetch_all_paginated_results, make_canvas_request
-from ..core.logging import log_warning
 from ..core.validation import validate_params
 
 
@@ -98,15 +96,8 @@ def register_admin_tools(mcp: FastMCP):
             elif not members:
                 output += "No members in this group.\n"
             else:
-                # Anonymize member data to protect student privacy
-                try:
-                    members = anonymize_response_data(members, data_type="users")
-                except Exception as e:
-                    log_warning(
-                        "Failed to anonymize group member data; continuing with original data",
-                        error_type=type(e).__name__,
-                    )
-                    # Continue with original data for functionality
+                # Anonymization happens at the client layer (core/client.py) per
+                # ENABLE_DATA_ANONYMIZATION (#179)
                 output += "Members:\n"
                 for member in members:
                     member_id = member.get("id")
@@ -140,16 +131,6 @@ def register_admin_tools(mcp: FastMCP):
 
         if not users:
             return f"No users found for course {course_identifier}."
-
-        # Anonymize user data to protect student privacy
-        try:
-            users = anonymize_response_data(users, data_type="users")
-        except Exception as e:
-            log_warning(
-                "Failed to anonymize user data; continuing with original data",
-                error_type=type(e).__name__,
-            )
-            # Continue with original data for functionality
 
         users_info = []
         for user in users:
@@ -211,14 +192,6 @@ def register_admin_tools(mcp: FastMCP):
         )
         if isinstance(students, dict) and "error" in students:
             students = []
-
-        try:
-            students = anonymize_response_data(students, data_type="users")
-        except Exception as e:
-            log_warning(
-                "Failed to anonymize student analytics data; continuing with original data",
-                error_type=type(e).__name__,
-            )
 
         by_id = {u.get("id"): u for u in students}
 

--- a/src/canvas_mcp/tools/assignments.py
+++ b/src/canvas_mcp/tools/assignments.py
@@ -8,11 +8,9 @@ from typing import Any
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
-from ..core.anonymization import anonymize_response_data
 from ..core.cache import get_course_code, get_course_id
 from ..core.client import fetch_all_paginated_results, make_canvas_request
 from ..core.dates import format_date, parse_date
-from ..core.logging import log_error
 from ..core.validation import validate_params
 from .rubrics import build_rubric_assessment_form_data
 
@@ -197,17 +195,8 @@ def register_educator_assignment_tools(mcp: FastMCP):
         if not submissions:
             return f"No submissions found for assignment {assignment_id}."
 
-        # Anonymize submission data to protect student privacy
-        try:
-            submissions = anonymize_response_data(submissions, data_type="submissions")
-        except Exception as e:
-            log_error(
-                "Failed to anonymize submission data in peer reviews",
-                exc=e,
-                course_id=course_id,
-                assignment_id=assignment_id
-            )
-            # Continue with original data for functionality
+        # Anonymization happens at the client layer (core/client.py) per
+        # ENABLE_DATA_ANONYMIZATION (#179)
 
         # Get all users in the course for name lookups
         users = await fetch_all_paginated_results(
@@ -217,18 +206,6 @@ def register_educator_assignment_tools(mcp: FastMCP):
 
         if isinstance(users, dict) and "error" in users:
             return f"Error fetching users: {users['error']}"
-
-        # Anonymize user data to protect student privacy
-        try:
-            users = anonymize_response_data(users, data_type="users")
-        except Exception as e:
-            log_error(
-                "Failed to anonymize user data in peer reviews",
-                exc=e,
-                course_id=course_id,
-                assignment_id=assignment_id
-            )
-            # Continue with original data for functionality
 
         # Create a mapping of user IDs to names
         user_map = {}
@@ -328,17 +305,8 @@ def register_educator_assignment_tools(mcp: FastMCP):
         if not submissions:
             return f"No submissions found for assignment {assignment_id}."
 
-        # Anonymize submission data to protect student privacy
-        try:
-            submissions = anonymize_response_data(submissions, data_type="submissions")
-        except Exception as e:
-            log_error(
-                "Failed to anonymize submission data",
-                exc=e,
-                course_id=course_id,
-                assignment_id=assignment_id
-            )
-            # Continue with original data for functionality
+        # Anonymization happens at the client layer (core/client.py) per
+        # ENABLE_DATA_ANONYMIZATION (#179)
 
         submissions_info = []
         for submission in submissions:
@@ -393,17 +361,8 @@ def register_educator_assignment_tools(mcp: FastMCP):
         if not students:
             return f"No students found for course {course_identifier}."
 
-        # Anonymize student data to protect privacy
-        try:
-            students = anonymize_response_data(students, data_type="users")
-        except Exception as e:
-            log_error(
-                "Failed to anonymize student data in analytics",
-                exc=e,
-                course_id=course_id,
-                assignment_id=assignment_id
-            )
-            # Continue with original data for functionality
+        # Anonymization happens at the client layer (core/client.py) per
+        # ENABLE_DATA_ANONYMIZATION (#179)
 
         # Get submissions for this assignment
         submissions = await fetch_all_paginated_results(
@@ -413,18 +372,6 @@ def register_educator_assignment_tools(mcp: FastMCP):
 
         if isinstance(submissions, dict) and "error" in submissions:
             return f"Error fetching submissions: {submissions['error']}"
-
-        # Anonymize submission data to protect student privacy
-        try:
-            submissions = anonymize_response_data(submissions, data_type="submissions")
-        except Exception as e:
-            log_error(
-                "Failed to anonymize submission data in analytics",
-                exc=e,
-                course_id=course_id,
-                assignment_id=assignment_id
-            )
-            # Continue with original data for functionality
 
         # Extract assignment details
         assignment_name = assignment.get("name", "Unknown Assignment")

--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -6,11 +6,10 @@ import re
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
-from ..core.anonymization import anonymize_response_data
 from ..core.cache import get_course_code, get_course_id
 from ..core.client import fetch_all_paginated_results, make_canvas_request
 from ..core.dates import format_date, parse_date, truncate_text
-from ..core.logging import log_error, log_warning
+from ..core.logging import log_warning
 from ..core.validation import validate_params
 
 
@@ -159,32 +158,8 @@ def register_shared_discussion_tools(mcp: FastMCP):
         if not entries:
             return f"No discussion entries found for topic {topic_id}."
 
-        # Anonymize entries to protect student privacy
-        try:
-            anonymized_entries = anonymize_response_data(entries, data_type="discussions")
-            # Basic validation: check that anonymization occurred
-            if anonymized_entries and isinstance(anonymized_entries, list) and len(anonymized_entries) > 0:
-                # Verify first entry was anonymized (has anonymous user_name)
-                first_entry = anonymized_entries[0]
-                if first_entry.get("user_name", "").startswith("Student_"):
-                    entries = anonymized_entries  # Use anonymized data
-                else:
-                    log_warning(
-                        "Anonymization may not have been applied properly",
-                        course_id=course_id,
-                        topic_id=topic_id
-                    )
-            else:
-                entries = anonymized_entries  # Use result even if validation unclear
-        except Exception as e:
-            # Log error but continue with original data rather than failing completely
-            log_error(
-                "Failed to anonymize discussion entries",
-                exc=e,
-                course_id=course_id,
-                topic_id=topic_id
-            )
-            # Continue with original data - this maintains functionality while logging the issue
+        # Anonymization happens at the client layer (core/client.py) per
+        # ENABLE_DATA_ANONYMIZATION -- this endpoint matches _should_anonymize_endpoint (#179)
 
         # Enhanced content fetching using multiple methods
         if include_full_content or include_replies:

--- a/src/canvas_mcp/tools/rubrics.py
+++ b/src/canvas_mcp/tools/rubrics.py
@@ -10,11 +10,9 @@ from typing import Any
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
-from ..core.anonymization import anonymize_response_data
 from ..core.cache import get_course_code, get_course_id
 from ..core.client import fetch_all_paginated_results, make_canvas_request
 from ..core.dates import format_date, truncate_text
-from ..core.logging import log_error
 from ..core.validation import validate_params
 
 
@@ -702,18 +700,8 @@ def register_rubric_tools(mcp: FastMCP) -> None:
         if "error" in response:
             return f"Error fetching submission rubric assessment: {response['error']}"
 
-        # Anonymize submission data to protect student privacy
-        try:
-            response = anonymize_response_data(response, data_type="submissions")
-        except Exception as e:
-            log_error(
-                "Failed to anonymize rubric assessment data",
-                exc=e,
-                course_id=course_id,
-                assignment_id=assignment_id,
-                user_id=user_id
-            )
-            # Continue with original data for functionality
+        # Anonymization happens at the client layer (core/client.py) per
+        # ENABLE_DATA_ANONYMIZATION (#179)
 
         # Check if submission has rubric assessment
         rubric_assessment = response.get("rubric_assessment")

--- a/tests/tools/test_admin_tools.py
+++ b/tests/tools/test_admin_tools.py
@@ -155,26 +155,8 @@ class TestListGroups:
 
         assert "Error" in result
 
-    @pytest.mark.asyncio
-    async def test_list_groups_anonymization_failure_logs_warning(self, mock_canvas_api):
-        """A failing member anonymization is reported via log_warning, not print."""
-        mock_canvas_api['fetch_all_paginated_results'].side_effect = [
-            [{"id": 1, "name": "Group A", "group_category_id": 10, "members_count": 1}],
-            [{"id": 101, "name": "Alice", "email": "alice@example.com"}],
-        ]
-
-        with patch(
-            'canvas_mcp.tools.admin_tools.anonymize_response_data',
-            side_effect=RuntimeError("alice@example.com"),
-        ), patch('canvas_mcp.tools.admin_tools.log_warning') as mock_warn:
-            fn = get_tool_function('list_groups')
-            result = await fn("badm_350_120251")
-
-        mock_warn.assert_called_once()
-        _, kwargs = mock_warn.call_args
-        assert kwargs.get("error_type") == "RuntimeError"
-        assert "alice@example.com" not in str(mock_warn.call_args)
-        assert "Group A" in result  # falls back to original data
+    # Tool-layer anonymization (and its failure-fallback tests) removed in #179:
+    # anonymization happens once, at the client layer, enforced by ruff TID251.
 
 
 # ---------------------------------------------------------------------------
@@ -228,36 +210,6 @@ class TestListUsers:
         result = await fn("badm_350_120251")
 
         assert "Error" in result
-
-    @pytest.mark.asyncio
-    async def test_list_users_anonymization_failure_logs_warning(self, mock_canvas_api):
-        """A failing anonymization is reported via log_warning (stderr), not print.
-
-        Bare print() would corrupt the MCP stdio JSON-RPC stream, and str(e) could
-        leak the PII that failed to scrub. The handler must route through
-        log_warning, log only the exception type, and continue with original data.
-        """
-        mock_canvas_api['fetch_all_paginated_results'].return_value = [
-            {"id": 201, "name": "Alice Smith", "email": "alice@example.com",
-             "enrollments": [{"role": "StudentEnrollment"}]},
-        ]
-
-        with patch(
-            'canvas_mcp.tools.admin_tools.anonymize_response_data',
-            side_effect=RuntimeError("alice@example.com"),
-        ), patch('canvas_mcp.tools.admin_tools.log_warning') as mock_warn:
-            fn = get_tool_function('list_users')
-            result = await fn("badm_350_120251")
-
-        # Warning routed to logger, not stdout
-        mock_warn.assert_called_once()
-        _, kwargs = mock_warn.call_args
-        # Only the exception type is logged — never the PII-bearing message
-        assert kwargs.get("error_type") == "RuntimeError"
-        assert "alice@example.com" not in str(mock_warn.call_args)
-        # Falls back to original (un-anonymized) data so the tool still works
-        assert "201" in result
-
 
 # ---------------------------------------------------------------------------
 # get_student_analytics
@@ -313,30 +265,6 @@ class TestGetStudentAnalytics:
         result = await fn("badm_350_120251")
 
         assert "0" in result or "No" in result or "students" in result.lower()
-
-    @pytest.mark.asyncio
-    async def test_get_student_analytics_anonymization_failure_logs_warning(self, mock_canvas_api):
-        """A failing student anonymization is reported via log_warning, not print."""
-        mock_canvas_api['make_canvas_request'].return_value = {
-            "id": 60366, "name": "Business Administration 350"
-        }
-        mock_canvas_api['fetch_all_paginated_results'].side_effect = [
-            [{"id": 301, "name": "Alice", "email": "alice@example.com"}],  # students
-            [{"id": 401, "name": "HW1", "published": True, "points_possible": 100}],  # assignments
-        ]
-
-        with patch(
-            'canvas_mcp.tools.admin_tools.anonymize_response_data',
-            side_effect=RuntimeError("alice@example.com"),
-        ), patch('canvas_mcp.tools.admin_tools.log_warning') as mock_warn:
-            fn = get_tool_function('get_student_analytics')
-            await fn("badm_350_120251")
-
-        mock_warn.assert_called_once()
-        _, kwargs = mock_warn.call_args
-        assert kwargs.get("error_type") == "RuntimeError"
-        assert "alice@example.com" not in str(mock_warn.call_args)
-
 
 # ---------------------------------------------------------------------------
 # create_student_anonymization_map


### PR DESCRIPTION
## Summary

Completes the remaining scope of #179 (the gap-closure half shipped in #184). The ten tool-layer `anonymize_response_data()` call sites are deleted, making `core/client.py` the single anonymization layer and `ENABLE_DATA_ANONYMIZATION` honored in exactly one place.

## Verification of the core premise

The refactor is only safe if every deleted call site's endpoint is covered by the client-layer gate. Verified by running each real endpoint shape through `_should_anonymize_endpoint()` (not assumed from the issue text):

| Endpoint | Gated at client |
|---|---|
| `/groups/{id}/users` | ✅ |
| `/courses/{id}/users` | ✅ |
| `/courses/{id}/assignments/{aid}/submissions` | ✅ |
| `/courses/{id}/assignments/{aid}/submissions/{uid}` | ✅ |
| `/courses/{id}/discussion_topics/{tid}/entries` | ✅ |

Also confirmed the only `skip_anonymization=True` in tool code is `create_student_anonymization_map` (intentional — fixed in #184) and is not one of the ten sites.

## Enforcement

- **ruff TID251 banned-api**: importing `anonymize_response_data` outside `core/` and `tests/` now fails lint (a required CI check). The gate was probe-tested against a real violation before committing.
- **env.template** documents the single-layer contract.

## Behavior change

With `ENABLE_DATA_ANONYMIZATION=false`, these ten read paths now correctly return real names (previously the tool layer over-anonymized regardless of the flag). With the flag on (the default), output is unchanged — the client layer produced the same result before the redundant second pass.

Three tests asserting the deleted failure-fallback path were removed with the behavior; 968 tests pass, ruff clean.

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)