### PR TITLE
refactor: zero mypy errors + mypy in CI (#106)

### DIFF
--- a/.github/workflows/canvas-mcp-testing.yml
+++ b/.github/workflows/canvas-mcp-testing.yml
@@ -27,6 +27,14 @@ jobs:
     - name: Run Ruff
       run: ruff check src/ tests/
 
+    - name: Install mypy
+      run: |
+        python -m pip install -e .
+        python -m pip install "mypy>=1.15.0,<2"
+
+    - name: Run mypy
+      run: mypy src/
+
   test-enhancements:
     runs-on: ubuntu-latest
     

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,12 @@ strict_equality = true
 module = "tests.*"
 disallow_untyped_defs = false
 
+[[tool.mypy.overrides]]
+# Azure SDK packages are optional hosted-deployment deps, not installed in the
+# default dev environment, and ship without type stubs.
+module = "azure.*"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/src/canvas_mcp/core/access/factory.py
+++ b/src/canvas_mcp/core/access/factory.py
@@ -7,17 +7,20 @@ requires the optional ``[hosted]`` dependencies. Callers must guard with
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable, Sequence
+from typing import Any
+
 from ..logging import log_error
 from .store import AccessStore, ConcurrencyConflict
 
 
-def feature_ready(config) -> bool:
+def feature_ready(config: Any) -> bool:
     return bool(getattr(config, "access_request_enabled", False)
                 and getattr(config, "access_token_secret", "")
                 and getattr(config, "access_table_account", ""))
 
 
-def _entity_to_row(entity) -> dict:
+def _entity_to_row(entity: Any) -> dict:
     """Convert an azure-data-tables entity to a plain row, surfacing the ETag.
 
     azure-data-tables exposes the ETag via ``entity.metadata['etag']`` rather
@@ -35,20 +38,20 @@ def _entity_to_row(entity) -> dict:
 
 
 class _AzureTableBackend:
-    def __init__(self, table_client) -> None:
+    def __init__(self, table_client: Any) -> None:
         self._t = table_client
 
-    def get(self, pk, rk):
+    def get(self, pk: str, rk: str) -> dict | None:
         from azure.core.exceptions import ResourceNotFoundError
         try:
             return _entity_to_row(self._t.get_entity(pk, rk))
         except ResourceNotFoundError:
             return None
 
-    def upsert(self, entity):
+    def upsert(self, entity: dict) -> None:
         self._t.upsert_entity(entity)
 
-    def replace_if_unmodified(self, entity, etag):
+    def replace_if_unmodified(self, entity: dict, etag: str) -> None:
         from azure.core import MatchConditions
         from azure.core.exceptions import HttpResponseError
         # The ETag rides the match_condition param, not the row body; drop the
@@ -61,15 +64,15 @@ class _AzureTableBackend:
         except HttpResponseError as exc:
             raise ConcurrencyConflict(str(exc)) from exc
 
-    def query(self, pk):
+    def query(self, pk: str) -> list[dict]:
         flt = "PartitionKey eq '{}'".format(pk.replace("'", "''"))
         return [_entity_to_row(e) for e in self._t.query_entities(flt)]
 
-    def delete(self, pk, rk):
+    def delete(self, pk: str, rk: str) -> None:
         self._t.delete_entity(pk, rk)
 
 
-def build_store(config) -> AccessStore | None:
+def build_store(config: Any) -> AccessStore | None:
     if not feature_ready(config):
         return None
     try:
@@ -85,7 +88,9 @@ def build_store(config) -> AccessStore | None:
         return None
 
 
-def build_email_sender(config):
+def build_email_sender(
+    config: Any,
+) -> Callable[[Sequence[str], str, str, str], Awaitable[None]] | None:
     if not (config.acs_endpoint and config.acs_sender):
         return None
     # Build the credential + client ONCE here (not per send). Azure imports stay
@@ -101,8 +106,10 @@ def build_email_sender(config):
         log_error(f"access email sender unavailable: {exc}")
         return None
 
-    async def send(recipients, subject, html, plain):
-        def _send():
+    async def send(
+        recipients: Sequence[str], subject: str, html: str, plain: str
+    ) -> None:
+        def _send() -> None:
             message = {
                 "senderAddress": config.acs_sender,
                 "content": {"subject": subject, "html": html, "plainText": plain},

--- a/src/canvas_mcp/core/access/notify.py
+++ b/src/canvas_mcp/core/access/notify.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from html import escape
+from typing import Any
 
 from ..logging import log_error, log_info
 from .store import AccessStore, Requester
@@ -33,7 +34,7 @@ def build_request_email(req: Requester, approve_url: str) -> dict:
 async def notify_access_request(
     *, store: AccessStore, requester: Requester, secret: str,
     approve_base_url: str, admin_emails: list[str], cooldown_hours: int,
-    ttl_seconds: int, send_email, jti: str, now: int, now_iso: str,
+    ttl_seconds: int, send_email: Any, jti: str, now: int, now_iso: str,
 ) -> bool:
     """Dedup, mint a token, build the email, and send it. Never raises."""
     try:

--- a/src/canvas_mcp/core/access/routes.py
+++ b/src/canvas_mcp/core/access/routes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from html import escape
+from typing import Any
 from urllib.parse import parse_qs
 
 from ..audit import log_access_change
@@ -44,7 +45,7 @@ def render_retry_page() -> str:
             "fresh approval link.</p>")
 
 
-async def _send_html(send, html: str, status: int = 200) -> None:
+async def _send_html(send: Any, html: str, status: int = 200) -> None:
     await send({"type": "http.response.start", "status": status,
                 "headers": [(b"content-type", b"text/html; charset=utf-8")]})
     await send({"type": "http.response.body", "body": html.encode()})
@@ -55,7 +56,7 @@ def _requester_from_pending(row: dict | None, oid: str) -> Requester:
     return Requester(oid=oid, upn=row.get("upn", ""), display_name=row.get("displayName", ""))
 
 
-async def handle_approve(query_string: bytes, send, *, store: AccessStore,
+async def handle_approve(query_string: bytes, send: Any, *, store: AccessStore,
                          secret: str, now: int) -> None:
     token = (parse_qs(query_string.decode()).get("token") or [""])[0]
     claims = verify_token(token, secret=secret, now=now)
@@ -69,7 +70,7 @@ async def handle_approve(query_string: bytes, send, *, store: AccessStore,
     await _send_html(send, render_confirm_page(_requester_from_pending(pending, claims.oid), token))
 
 
-async def handle_confirm(body: bytes, send, *, store: AccessStore,
+async def handle_confirm(body: bytes, send: Any, *, store: AccessStore,
                          secret: str, now: int) -> None:
     token = (parse_qs(body.decode()).get("token") or [""])[0]
     claims = verify_token(token, secret=secret, now=now)

--- a/src/canvas_mcp/core/access/store.py
+++ b/src/canvas_mcp/core/access/store.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import calendar
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Any
 
 GRANT_PK = "grant"
 PENDING_PK = "pending"
@@ -71,7 +73,13 @@ class InMemoryBackend:
 
 
 class AccessStore:
-    def __init__(self, backend, *, cache_ttl_seconds: int = 30, clock=time.time) -> None:
+    def __init__(
+        self,
+        backend: Any,
+        *,
+        cache_ttl_seconds: int = 30,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
         self._backend = backend
         self._ttl = cache_ttl_seconds
         self._clock = clock
@@ -131,7 +139,8 @@ class AccessStore:
         return True
 
     def get_pending(self, oid: str) -> dict | None:
-        return self._backend.get(PENDING_PK, oid)
+        row: dict | None = self._backend.get(PENDING_PK, oid)
+        return row
 
     def consume_pending(self, oid: str, jti: str) -> bool:
         row = self._backend.get(PENDING_PK, oid)
@@ -148,7 +157,7 @@ class AccessStore:
         return True
 
 
-def _utcnow_iso(clock) -> str:
+def _utcnow_iso(clock: Callable[[], float]) -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(clock()))
 
 

--- a/src/canvas_mcp/core/cache.py
+++ b/src/canvas_mcp/core/cache.py
@@ -104,7 +104,7 @@ async def get_course_code(course_id: str | int) -> str | None:
     # If we can't find a code, try to fetch the course directly
     response = await make_canvas_request("get", f"/courses/{course_id}")
     if "error" not in response and "course_code" in response:
-        code = response.get("course_code", "")
+        code: str | None = response.get("course_code", "")
         # Update our cache
         if code:
             id_to_course_code_cache[course_id] = code

--- a/src/canvas_mcp/core/cache.py
+++ b/src/canvas_mcp/core/cache.py
@@ -37,7 +37,7 @@ async def refresh_course_cache() -> bool:
 
 
 @validate_params
-async def get_course_id(course_identifier: str | int) -> str | None:
+async def get_course_id(course_identifier: str | int) -> str:
     """Get course ID from either course code or ID, with caching.
 
     Args:

--- a/src/canvas_mcp/core/client.py
+++ b/src/canvas_mcp/core/client.py
@@ -5,7 +5,7 @@ import re
 import weakref
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from typing import Any, Literal
+from typing import Any, Final, Literal, cast
 from urllib.parse import urlencode
 
 import httpx
@@ -20,8 +20,8 @@ INITIAL_BACKOFF_SECONDS = 2
 
 # Default number of results per page for paginated requests
 DEFAULT_PAGE_SIZE = 100
-API_ROOT_REST = "rest"
-API_ROOT_QUIZ = "quiz"
+API_ROOT_REST: Final = "rest"
+API_ROOT_QUIZ: Final = "quiz"
 
 
 def _canvas_auth_headers(api_token: str) -> dict[str, str]:
@@ -390,7 +390,7 @@ async def make_canvas_request(
     method: str,
     endpoint: str,
     params: dict[str, Any] | None = None,
-    data: dict[str, Any] | None = None,
+    data: dict[str, Any] | list[tuple[str, Any]] | None = None,
     use_form_data: bool = False,
     skip_anonymization: bool = False,
     files: dict[str, tuple[str, bytes, str]] | None = None,
@@ -473,7 +473,13 @@ async def make_canvas_request(
                         response = await client.get(url, params=params)
                     elif method.lower() == "post":
                         if files:
-                            response = await client.post(url, data=data, files=files)
+                            # File uploads always pass dict form fields, never
+                            # the list-of-tuples encoding.
+                            response = await client.post(
+                                url,
+                                data=cast("dict[str, Any] | None", data),
+                                files=files,
+                            )
                         elif use_form_data:
                             # Handle list of tuples separately to work around httpx async bug
                             # with duplicate keys (e.g., module[prerequisite_module_ids][])
@@ -635,7 +641,8 @@ async def upload_file_to_storage(
             if response.status_code in (200, 201):
                 # Direct success response
                 try:
-                    return response.json()
+                    body: dict[str, Any] = response.json()
+                    return body
                 except ValueError:
                     # Some storage backends return empty success
                     return {"success": True, "status_code": response.status_code}
@@ -652,7 +659,8 @@ async def upload_file_to_storage(
                         async with canvas_authenticated_client() as canvas_client:
                             confirm_response = await canvas_client.get(redirect_url)
                             confirm_response.raise_for_status()
-                            return confirm_response.json()
+                            confirmed: dict[str, Any] = confirm_response.json()
+                            return confirmed
                     except PermissionError as e:
                         return {"error": str(e)}
                 else:

--- a/src/canvas_mcp/core/course_policy.py
+++ b/src/canvas_mcp/core/course_policy.py
@@ -104,7 +104,7 @@ def _is_not_found(error_message: str) -> bool:
     artifact and, under a permissive default, turn a server error into a grant.
     """
     match = _HTTP_STATUS_RE.match(error_message.strip())
-    return bool(match) and match.group(1) == "404"
+    return match is not None and match.group(1) == "404"
 
 
 def _strip_html(body: str) -> str:

--- a/src/canvas_mcp/core/enrollment.py
+++ b/src/canvas_mcp/core/enrollment.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from typing import cast
 
 from .audit import log_data_access
 from .cache import get_course_id
@@ -220,18 +221,18 @@ def _match_enrollment(
     unverifiable_domain = False
     for enrollment, user in candidates:
         try:
-            field = _local_part_field(user, needle, needle_local)
+            local_field = _local_part_field(user, needle, needle_local)
         except _UnverifiableDomain:
             unverifiable_domain = True
             continue
-        if field is not None:
+        if local_field is not None:
             user_id = user.get("id")
             # Fall back to identity of the row itself when Canvas gives no id,
             # so a missing id cannot silently collapse two people into one.
             key = ("id", user_id) if user_id is not None else ("row", id(enrollment))
             if key not in seen_users:
                 seen_users.add(key)
-                hits.append((enrollment, field))
+                hits.append((enrollment, local_field))
 
     if len(hits) > 1:
         raise AmbiguousIdentifier(
@@ -380,11 +381,13 @@ async def check_enrollment(
     if active_only:
         params["state[]"] = ["active"]
 
-    enrollments = await _fetch_enrollments_raw(course_id, params)
-    if isinstance(enrollments, dict) and "error" in enrollments:
+    raw = await _fetch_enrollments_raw(course_id, params)
+    if isinstance(raw, dict) and "error" in raw:
         log_data_access("GET", f"/courses/{course_id}/enrollments", "error",
-                        error=str(enrollments.get("error")))
-        raise RuntimeError(str(enrollments.get("error")))
+                        error=str(raw.get("error")))
+        raise RuntimeError(str(raw.get("error")))
+    # _fetch_enrollments_raw returns a list in every non-error case.
+    enrollments = cast("list[dict]", raw)
 
     match = _match_enrollment(enrollments, net_id, active_only)
 
@@ -451,8 +454,9 @@ async def check_enrollment(
         matched_enrollment
     ]
     # dict.fromkeys preserves roster order while de-duplicating.
+    role_values = (e.get("type") for e in subject)
     roles_held = tuple(
-        dict.fromkeys(e.get("type") for e in subject if e.get("type"))
+        dict.fromkeys(r for r in role_values if isinstance(r, str) and r)
     )
 
     # Role is now evaluated here rather than by Canvas, so pick the enrollment

--- a/src/canvas_mcp/core/peer_review_comments.py
+++ b/src/canvas_mcp/core/peer_review_comments.py
@@ -503,7 +503,7 @@ class PeerReviewCommentAnalyzer:
         """
         try:
             # Default criteria
-            default_criteria = {
+            default_criteria: dict[str, Any] = {
                 "min_word_count": 10,
                 "generic_phrases": ["good job", "nice work", "looks good"],
                 "max_quality_score": 2.0
@@ -565,7 +565,7 @@ class PeerReviewCommentAnalyzer:
                     })
 
             # Categorize flags
-            flag_summary = Counter()
+            flag_summary: Counter[str] = Counter()
             for review in flagged_reviews:
                 for flag in review["flags"]:
                     flag_summary[flag] += 1

--- a/src/canvas_mcp/core/peer_review_comments.py
+++ b/src/canvas_mcp/core/peer_review_comments.py
@@ -39,7 +39,7 @@ class PeerReviewCommentAnalyzer:
 
     async def get_peer_review_comments(
         self,
-        course_id: int,
+        course_id: int | str,
         assignment_id: int,
         include_reviewer_info: bool = True,
         include_reviewee_info: bool = True,
@@ -243,7 +243,7 @@ class PeerReviewCommentAnalyzer:
 
     async def analyze_peer_review_quality(
         self,
-        course_id: int,
+        course_id: int | str,
         assignment_id: int,
         analysis_criteria: dict[str, Any] | None = None,
         generate_report: bool = True
@@ -486,7 +486,7 @@ class PeerReviewCommentAnalyzer:
 
     async def identify_problematic_peer_reviews(
         self,
-        course_id: int,
+        course_id: int | str,
         assignment_id: int,
         criteria: dict[str, Any] | None = None
     ) -> dict[str, Any]:

--- a/src/canvas_mcp/core/peer_reviews.py
+++ b/src/canvas_mcp/core/peer_reviews.py
@@ -494,7 +494,7 @@ class PeerReviewAnalyzer:
             days_since_assigned = days_threshold  # Default value
 
             # Process followup categories
-            followup_categories = {
+            followup_categories: dict[str, dict[str, Any]] = {
                 "urgent": {
                     "description": "Students with 0 peer reviews completed",
                     "count": len(completion_groups.get("none_complete", [])),

--- a/src/canvas_mcp/core/peer_reviews.py
+++ b/src/canvas_mcp/core/peer_reviews.py
@@ -20,7 +20,7 @@ class PeerReviewAnalyzer:
 
     async def get_assignments(
         self,
-        course_id: int,
+        course_id: int | str,
         assignment_id: int,
         include_names: bool = True,
         include_submission_details: bool = False
@@ -108,7 +108,7 @@ class PeerReviewAnalyzer:
 
     async def get_completion_analytics(
         self,
-        course_id: int,
+        course_id: int | str,
         assignment_id: int,
         include_student_details: bool = True,
         group_by_status: bool = True
@@ -230,7 +230,7 @@ class PeerReviewAnalyzer:
 
     async def generate_report(
         self,
-        course_id: int,
+        course_id: int | str,
         assignment_id: int,
         report_format: str = "markdown",
         include_executive_summary: bool = True,
@@ -465,7 +465,7 @@ class PeerReviewAnalyzer:
 
     async def get_followup_list(
         self,
-        course_id: int,
+        course_id: int | str,
         assignment_id: int,
         priority_filter: str = "all",
         include_contact_info: bool = False,

--- a/src/canvas_mcp/resources/resources.py
+++ b/src/canvas_mcp/resources/resources.py
@@ -26,7 +26,7 @@ def register_resources_and_prompts(mcp: FastMCP) -> None:
         if "error" in response:
             return f"Error fetching syllabus: {response['error']}"
 
-        syllabus_body = response.get("syllabus_body", "")
+        syllabus_body: str = response.get("syllabus_body", "")
 
         if not syllabus_body:
             return "No syllabus available for this course."
@@ -53,7 +53,7 @@ def register_resources_and_prompts(mcp: FastMCP) -> None:
         if "error" in response:
             return f"Error fetching assignment description: {response['error']}"
 
-        description = response.get("description", "")
+        description: str = response.get("description", "")
 
         if not description:
             return "No description available for this assignment."

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -77,8 +77,8 @@ async def _send_json_error(send: Any, status: int, message: str) -> None:
     await send({"type": "http.response.body", "body": body})
 
 
-async def _read_body(receive) -> bytes:
-    body = b""
+async def _read_body(receive: Any) -> bytes:
+    body: bytes = b""
     while True:
         msg = await receive()
         body += msg.get("body", b"")
@@ -134,7 +134,7 @@ _ADMIN_CONFIRM_PATH = "/admin/access/confirm"
 _overlay_store = None
 
 
-def _access_store(config):
+def _access_store(config: Any) -> Any:
     """Build the overlay store once and reuse it across requests.
 
     The store's ``is_granted`` TTL cache is per-instance, so it only works if
@@ -156,7 +156,7 @@ def reset_overlay_store() -> None:
     _overlay_store = None
 
 
-def _schedule_notify(config, store, requester) -> None:
+def _schedule_notify(config: Any, store: Any, requester: Any) -> None:
     """Fire-and-forget admin email; never blocks or breaks the request path."""
     from .core.access.factory import build_email_sender
     from .core.access.notify import notify_access_request
@@ -412,7 +412,7 @@ def test_connection() -> bool:
         return False
 
 
-def _cmd_list_grants(args) -> int:
+def _cmd_list_grants(args: argparse.Namespace) -> int:
     """List self-service access grants from the overlay store. Returns an exit code."""
     store = _access_store(get_config())
     if store is None:
@@ -427,7 +427,7 @@ def _cmd_list_grants(args) -> int:
     return 0
 
 
-def _cmd_revoke(args) -> int:
+def _cmd_revoke(args: argparse.Namespace) -> int:
     """Revoke one self-service access grant by Entra OID. Returns an exit code."""
     store = _access_store(get_config())
     if store is None:

--- a/src/canvas_mcp/tools/admin_tools.py
+++ b/src/canvas_mcp/tools/admin_tools.py
@@ -9,7 +9,7 @@ from ..core.client import fetch_all_paginated_results, make_canvas_request
 from ..core.validation import validate_params
 
 
-def register_admin_tools(mcp: FastMCP):
+def register_admin_tools(mcp: FastMCP) -> None:
     """Register admin/developer MCP tools."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))

--- a/src/canvas_mcp/tools/assignments.py
+++ b/src/canvas_mcp/tools/assignments.py
@@ -15,7 +15,7 @@ from ..core.validation import validate_params
 from .rubrics import build_rubric_assessment_form_data
 
 
-def register_shared_assignment_tools(mcp: FastMCP):
+def register_shared_assignment_tools(mcp: FastMCP) -> None:
     """Register assignment tools accessible to both students and educators."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -92,7 +92,7 @@ def register_shared_assignment_tools(mcp: FastMCP):
         return f"Assignment Details for ID {assignment_id} in course {course_display}:\n\n" + "\n".join(details)
 
 
-def register_educator_assignment_tools(mcp: FastMCP):
+def register_educator_assignment_tools(mcp: FastMCP) -> None:
     """Register educator-only assignment tools (grading, analytics, management)."""
 
     @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
@@ -394,7 +394,7 @@ def register_educator_assignment_tools(mcp: FastMCP):
             is_past_due = False
 
         # Process submissions
-        submission_stats = {
+        submission_stats: dict[str, Any] = {
             "total_students": len(students),
             "submitted_count": 0,
             "missing_count": 0,
@@ -775,7 +775,7 @@ def register_educator_assignment_tools(mcp: FastMCP):
         course_id = await get_course_id(course_identifier)
 
         # Build assignment data - only include fields that are provided
-        assignment_data = {}
+        assignment_data: dict[str, Any] = {}
 
         if name is not None:
             assignment_data["name"] = name
@@ -956,7 +956,9 @@ def register_educator_assignment_tools(mcp: FastMCP):
         }
         failed_results = []
 
-        async def grade_single_submission(user_id: str, grade_info: dict[str, Any]):
+        async def grade_single_submission(
+            user_id: str, grade_info: dict[str, Any]
+        ) -> dict[str, Any]:
             """Grade a single submission."""
             try:
                 if dry_run:
@@ -1061,7 +1063,7 @@ def register_educator_assignment_tools(mcp: FastMCP):
 
             # Update statistics
             for result in results:
-                if isinstance(result, Exception):
+                if isinstance(result, BaseException):
                     stats["failed"] += 1
                     failed_results.append({
                         "user_id": "unknown",

--- a/src/canvas_mcp/tools/code_execution.py
+++ b/src/canvas_mcp/tools/code_execution.py
@@ -270,7 +270,9 @@ def _build_local_tsx_command(temp_file_path: str) -> list[str]:
     if sys.platform != 'win32':
         return ['npx', 'tsx', temp_file_path]
 
-    node_path = shutil.which('node') or 'node'
+    # mypy evaluates sys.platform for the host OS and flags this Windows-only
+    # branch as unreachable; it is live when running on Windows.
+    node_path = shutil.which('node') or 'node'  # type: ignore[unreachable]
     tsx_cli = _find_tsx_cli_windows()
     if tsx_cli:
         return [node_path, tsx_cli, temp_file_path]

--- a/src/canvas_mcp/tools/courses.py
+++ b/src/canvas_mcp/tools/courses.py
@@ -2,6 +2,7 @@
 
 import html
 import re
+from typing import Any
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
@@ -313,7 +314,7 @@ def register_course_tools(mcp: FastMCP) -> None:
                 ]
 
                 # Count module items by type across all modules
-                item_type_counts = {}
+                item_type_counts: dict[str, int] = {}
                 total_items = 0
 
                 for module in modules[:10]:  # Limit to first 10 modules to avoid too many API calls
@@ -404,7 +405,7 @@ def register_shared_content_tools(mcp: FastMCP) -> None:
         """
         course_id = await get_course_id(course_identifier)
 
-        params = {"per_page": 100}
+        params: dict[str, Any] = {"per_page": 100}
 
         if sort:
             params["sort"] = sort
@@ -575,7 +576,7 @@ def register_shared_content_tools(mcp: FastMCP) -> None:
         """
         course_id = await get_course_id(course_identifier)
 
-        params = {"per_page": 100}
+        params: dict[str, Any] = {"per_page": 100}
         if include_content_details:
             params["include[]"] = ["content_details"]
 

--- a/src/canvas_mcp/tools/courses.py
+++ b/src/canvas_mcp/tools/courses.py
@@ -67,7 +67,7 @@ def strip_html_tags(html_content: str) -> str:
     return text.strip()
 
 
-def register_course_tools(mcp: FastMCP):
+def register_course_tools(mcp: FastMCP) -> None:
     """Register all course-related MCP tools."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -383,7 +383,7 @@ def register_course_tools(mcp: FastMCP):
         return result
 
 
-def register_shared_content_tools(mcp: FastMCP):
+def register_shared_content_tools(mcp: FastMCP) -> None:
     """Register shared content tools (pages, module items) for both students and educators."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))

--- a/src/canvas_mcp/tools/discovery.py
+++ b/src/canvas_mcp/tools/discovery.py
@@ -7,7 +7,7 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
@@ -44,7 +44,7 @@ def register_discovery_tools(mcp: FastMCP) -> None:
                 }, indent=2)
 
             # Search through TypeScript files
-            matches = []
+            matches: list[str | dict[str, Any]] = []
             query_lower = query.lower()
 
             for ts_file in code_api_path.rglob("*.ts"):

--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -13,7 +13,7 @@ from ..core.logging import log_warning
 from ..core.validation import validate_params
 
 
-def register_shared_discussion_tools(mcp: FastMCP):
+def register_shared_discussion_tools(mcp: FastMCP) -> None:
     """Register discussion tools accessible to both students and educators."""
 
     # ===== DISCUSSION TOOLS =====
@@ -732,7 +732,7 @@ def register_shared_discussion_tools(mcp: FastMCP):
                f"Message: {truncate_text(message, 200)}"
 
 
-def register_educator_discussion_tools(mcp: FastMCP):
+def register_educator_discussion_tools(mcp: FastMCP) -> None:
     """Register educator-only discussion and announcement tools."""
 
     @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))

--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from typing import Any
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
@@ -30,7 +31,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
         """
         course_id = await get_course_id(course_identifier)
 
-        params = {"per_page": 100}
+        params: dict[str, Any] = {"per_page": 100}
 
         if include_announcements:
             params["include[]"] = ["announcement"]
@@ -257,7 +258,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
             # Handle replies
             replies_info = ""
             if include_replies:
-                replies = []
+                replies: list[Any] | Any = []
 
                 # Try to get replies from enhanced fetch first
                 if entry_id_str in full_entries_map:
@@ -359,7 +360,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
 
         # Method 1: Try to get entry details from the discussion view endpoint
         entry_response = None
-        replies = []
+        replies: list[Any] | Any = []
 
         try:
             # First try the discussion view endpoint which includes all entries
@@ -567,7 +568,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
 
             # Handle replies
             if include_replies:
-                replies = []
+                replies: list[Any] | Any = []
 
                 # Method 1: Check recent_replies from the entry
                 recent_replies = entry.get("recent_replies", [])

--- a/src/canvas_mcp/tools/enrollment.py
+++ b/src/canvas_mcp/tools/enrollment.py
@@ -23,7 +23,7 @@ from ..core.enrollment import check_enrollment as _check_enrollment
 from ..core.validation import validate_params
 
 
-def register_enrollment_tools(mcp: FastMCP):
+def register_enrollment_tools(mcp: FastMCP) -> None:
     """Register the enrollment-check MCP tool."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))

--- a/src/canvas_mcp/tools/files.py
+++ b/src/canvas_mcp/tools/files.py
@@ -35,7 +35,7 @@ from ..core.file_validation import (
 from ..core.validation import validate_params
 
 
-def register_shared_file_tools(mcp: FastMCP):
+def register_shared_file_tools(mcp: FastMCP) -> None:
     """Register file tools accessible to both students and educators."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -261,7 +261,7 @@ def register_shared_file_tools(mcp: FastMCP):
         return result
 
 
-def register_educator_file_tools(mcp: FastMCP):
+def register_educator_file_tools(mcp: FastMCP) -> None:
     """Register educator-only file tools (upload)."""
 
     @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))

--- a/src/canvas_mcp/tools/messaging.py
+++ b/src/canvas_mcp/tools/messaging.py
@@ -51,7 +51,8 @@ def register_shared_messaging_tools(mcp: FastMCP) -> None:
             response = await make_canvas_request("get", "/conversations", params=params)
 
             if "error" in response:
-                return response
+                error_response: dict[str, Any] = response
+                return error_response
 
             return {
                 "success": True,
@@ -92,7 +93,8 @@ def register_shared_messaging_tools(mcp: FastMCP) -> None:
             )
 
             if "error" in response:
-                return response
+                error_response: dict[str, Any] = response
+                return error_response
 
             return {
                 "success": True,
@@ -111,7 +113,8 @@ def register_shared_messaging_tools(mcp: FastMCP) -> None:
             response = await make_canvas_request("get", "/conversations/unread_count")
 
             if "error" in response:
-                return response
+                error_response: dict[str, Any] = response
+                return error_response
 
             return {
                 "success": True,
@@ -146,7 +149,8 @@ def register_shared_messaging_tools(mcp: FastMCP) -> None:
             response = await make_canvas_request("put", "/conversations", data=data, use_form_data=True)
 
             if "error" in response:
-                return response
+                error_response: dict[str, Any] = response
+                return error_response
 
             return {
                 "success": True,
@@ -238,7 +242,8 @@ def register_educator_messaging_tools(mcp: FastMCP) -> None:
             response = await make_canvas_request("post", "/conversations", data=data, use_form_data=True)
 
             if "error" in response:
-                return response
+                error_response: dict[str, Any] = response
+                return error_response
 
             return {
                 "success": True,
@@ -353,7 +358,7 @@ Please complete your peer reviews as soon as possible to receive full participat
             return {"error": "subject_template and body_template are required"}
 
         try:
-            results = {
+            results: dict[str, Any] = {
                 "success": True,
                 "sent": [],
                 "failed": [],
@@ -442,7 +447,7 @@ Please complete your peer reviews as soon as possible to receive full participat
             )
 
             # Convert the result to the expected format
-            analytics_response = {
+            analytics_response: dict[str, Any] = {
                 "success": "error" not in analytics_result,
                 "analytics": analytics_result if "error" not in analytics_result else {}
             }
@@ -456,7 +461,7 @@ Please complete your peer reviews as soon as possible to receive full participat
             analytics = analytics_response["analytics"]
             completion_groups = analytics.get("completion_groups", {})
 
-            results = {
+            results: dict[str, Any] = {
                 "success": True,
                 "analytics": analytics,
                 "messaging_results": {}

--- a/src/canvas_mcp/tools/modules.py
+++ b/src/canvas_mcp/tools/modules.py
@@ -5,6 +5,8 @@ and module items. Modules are the primary content organization system in Canvas.
 """
 
 
+from typing import Any
+
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
@@ -33,7 +35,7 @@ def register_shared_module_tools(mcp: FastMCP) -> None:
         """
         course_id = await get_course_id(course_identifier)
 
-        params = {"per_page": 100}
+        params: dict[str, Any] = {"per_page": 100}
         if include_items:
             params["include[]"] = ["items"]
         if search_term:
@@ -224,7 +226,7 @@ def register_educator_module_tools(mcp: FastMCP) -> None:
         course_id = await get_course_id(course_identifier)
 
         # Build module parameters
-        module_params = {
+        module_params: dict[str, Any] = {
             "module[name]": name,
             "module[published]": str(published).lower()
         }
@@ -308,7 +310,7 @@ def register_educator_module_tools(mcp: FastMCP) -> None:
         course_id = await get_course_id(course_identifier)
 
         # Build update parameters (only include changed fields)
-        module_params = {}
+        module_params: dict[str, Any] = {}
 
         if name is not None:
             module_params["module[name]"] = name
@@ -464,7 +466,7 @@ def register_educator_module_tools(mcp: FastMCP) -> None:
             return f"Invalid item_type '{item_type}'. Must be one of: {', '.join(valid_types)}"
 
         # Build item parameters
-        item_params = {
+        item_params: dict[str, Any] = {
             "module_item[type]": item_type
         }
 
@@ -601,7 +603,7 @@ def register_educator_module_tools(mcp: FastMCP) -> None:
         course_id = await get_course_id(course_identifier)
 
         # Build update parameters
-        item_params = {}
+        item_params: dict[str, Any] = {}
 
         if title is not None:
             item_params["module_item[title]"] = title

--- a/src/canvas_mcp/tools/modules.py
+++ b/src/canvas_mcp/tools/modules.py
@@ -14,7 +14,7 @@ from ..core.dates import format_date, parse_date
 from ..core.validation import validate_params
 
 
-def register_shared_module_tools(mcp: FastMCP):
+def register_shared_module_tools(mcp: FastMCP) -> None:
     """Register module tools accessible to both students and educators."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
@@ -196,7 +196,7 @@ def register_shared_module_tools(mcp: FastMCP):
         return json.dumps(result)
 
 
-def register_educator_module_tools(mcp: FastMCP):
+def register_educator_module_tools(mcp: FastMCP) -> None:
     """Register educator-only module management tools."""
 
     @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))

--- a/src/canvas_mcp/tools/pages.py
+++ b/src/canvas_mcp/tools/pages.py
@@ -14,7 +14,7 @@ from ..core.dates import format_date
 from ..core.validation import validate_params
 
 
-def register_page_tools(mcp: FastMCP):
+def register_page_tools(mcp: FastMCP) -> None:
     """Register page settings MCP tools."""
 
     @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
@@ -191,7 +191,7 @@ def register_page_tools(mcp: FastMCP):
         return result
 
 
-def register_educator_page_crud_tools(mcp: FastMCP):
+def register_educator_page_crud_tools(mcp: FastMCP) -> None:
     """Register educator-only page CRUD tools."""
 
     # front_page=True displaces the course's CURRENT front page -- Canvas

--- a/src/canvas_mcp/tools/pages.py
+++ b/src/canvas_mcp/tools/pages.py
@@ -5,6 +5,8 @@ editing roles) separate from content editing.
 """
 
 
+from typing import Any
+
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
@@ -42,7 +44,7 @@ def register_page_tools(mcp: FastMCP) -> None:
         course_id = await get_course_id(course_identifier)
 
         # Build update parameters (only include specified settings)
-        wiki_page_params = {}
+        wiki_page_params: dict[str, Any] = {}
 
         if published is not None:
             wiki_page_params["published"] = published
@@ -126,7 +128,7 @@ def register_page_tools(mcp: FastMCP) -> None:
             return "No pages specified. Please provide a comma-separated list of page URLs."
 
         # Build update parameters
-        wiki_page_params = {}
+        wiki_page_params: dict[str, Any] = {}
 
         if published is not None:
             wiki_page_params["published"] = published

--- a/src/canvas_mcp/tools/peer_review_comments.py
+++ b/src/canvas_mcp/tools/peer_review_comments.py
@@ -17,7 +17,7 @@ from ..core.peer_review_comments import PeerReviewCommentAnalyzer
 from ..core.validation import validate_params
 
 
-def register_peer_review_comment_tools(mcp: FastMCP):
+def register_peer_review_comment_tools(mcp: FastMCP) -> None:
     """Register all peer review comment analysis MCP tools."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))

--- a/src/canvas_mcp/tools/peer_reviews.py
+++ b/src/canvas_mcp/tools/peer_reviews.py
@@ -97,7 +97,7 @@ def register_peer_review_tools(mcp: FastMCP) -> None:
         include_action_items: bool = True,
         include_timeline_analysis: bool = True,
         save_to_file: bool = False,
-        filename: str = None
+        filename: str | None = None
     ) -> str:
         """Generate peer review completion report with summary, analytics, and follow-up recommendations.
 
@@ -153,7 +153,8 @@ def register_peer_review_tools(mcp: FastMCP) -> None:
                         result["save_error"] = f"Failed to save file: {str(save_error)}"
 
             if report_format in ["csv", "markdown"]:
-                return result.get("report", json.dumps(result, indent=2))
+                report: str = result.get("report", json.dumps(result, indent=2))
+                return report
             else:
                 return json.dumps(result, indent=2)
 

--- a/src/canvas_mcp/tools/peer_reviews.py
+++ b/src/canvas_mcp/tools/peer_reviews.py
@@ -13,7 +13,7 @@ from ..core.peer_reviews import PeerReviewAnalyzer
 from ..core.validation import validate_params
 
 
-def register_peer_review_tools(mcp: FastMCP):
+def register_peer_review_tools(mcp: FastMCP) -> None:
     """Register all peer review analytics MCP tools."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))

--- a/src/canvas_mcp/tools/rubrics.py
+++ b/src/canvas_mcp/tools/rubrics.py
@@ -463,7 +463,10 @@ def count_csv_rubrics(csv_content: str) -> int | None:
     names: set[str] = set()
     for row in reader:
         if not isinstance(row, dict):
-            continue
+            # Defensive guard kept deliberately: typeshed says DictReader always
+            # yields dicts, so mypy sees this as dead, but a malformed csv module
+            # substitute would otherwise crash the loop.
+            continue  # type: ignore[unreachable]
         raw_name = row.get(rubric_name_field)
         if isinstance(raw_name, str) and raw_name.strip():
             names.add(raw_name.strip())

--- a/src/canvas_mcp/tools/self_identity.py
+++ b/src/canvas_mcp/tools/self_identity.py
@@ -40,7 +40,7 @@ def _own_roles(course: dict) -> list[str]:
     return roles
 
 
-def register_self_identity_tools(mcp: FastMCP):
+def register_self_identity_tools(mcp: FastMCP) -> None:
     """Register the caller-scoped identity tools (all role profiles)."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))

--- a/src/canvas_mcp/tools/student_tools.py
+++ b/src/canvas_mcp/tools/student_tools.py
@@ -15,7 +15,7 @@ from ..core.dates import format_date, parse_date
 from ..core.validation import validate_params
 
 
-def register_student_tools(mcp: FastMCP):
+def register_student_tools(mcp: FastMCP) -> None:
     """Register student-specific MCP tools."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -311,7 +311,7 @@ def _describe_attempts(assignment: dict, submission: dict) -> str:
     allowed = assignment.get("allowed_attempts")
     used = submission.get("attempt") or 0
 
-    if allowed in (None, -1):
+    if allowed is None or allowed == -1:
         return f"Attempts: {used} used, unlimited allowed"
 
     remaining = allowed - used


### PR DESCRIPTION
## Summary

Closes #106. The backlog had drifted from 186 to a measured **229 errors in 29 files**; this brings `uv run mypy src/` to **0 errors in 46 files** and adds mypy to the CI lint job (after the #186 ruff step), so it can't regress.

All changes are annotations/narrowing — no runtime behavior changes except one deliberate safety fix (below). Tests stayed green after every module group (969 passed, 21 skipped on the final rebase).

## Real findings surfaced by the type errors

- **`core/cache.py` — `get_course_id()` was annotated `-> str | None` but no code path returns None** (verified line by line during review, not just claimed). The wrong annotation generated ~60 false Optional errors downstream and means every `if not course_id` guard in tools is dead code (guards left untouched; separate cleanup if desired).
- **`core/client.py` — `make_canvas_request`'s `data` claimed `dict | None` while the form-data branch explicitly handles `list[tuple]`** (the httpx duplicate-key workaround) and real callers pass lists. Per the old annotation, live production code was "unreachable". Widened to match reality.
- **`tools/assignments.py` — `asyncio.gather(return_exceptions=True)` results narrowed with `isinstance(result, Exception)`, but gather's contract is `T | BaseException`.** The one behavior change: a BaseException result now counts as "failed" instead of crashing the batch loop with a TypeError on `result["status"]`.
- `tools/peer_reviews.py` — `filename: str = None` (invalid default) → `str | None`.
- `core/enrollment.py` — `roles_held` now filters with `isinstance(r, str) and r` (strictly tighter than truthiness; Canvas `type` is always a string). Reviewed carefully since this is the #199/#203 identity code.

## Suppressions

Two `# type: ignore[unreachable]`, both commented: a Windows-only branch in `code_execution.py` (mypy evaluates `sys.platform` for the host) and a defensive `DictReader` guard in `rubrics.py`. Plus a `[[tool.mypy.overrides]]` for `azure.*` (optional `[hosted]` extra, no stubs in dev).

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)