### PR TITLE
triage: GitHub activity brief 2026-08-04

### DIFF
--- a/internal/issue-triage/2026-08-04.md
+++ b/internal/issue-triage/2026-08-04.md
@@ -1,0 +1,149 @@
+# GitHub Activity Triage — 2026-08-04
+
+**Read path used:** GitHub MCP tools (`gh` CLI not installed in this sandbox).
+**Cutoff:** 2026-07-31 (newest file in `internal/issue-triage/`). Note: this is the *fourth* cycle re-deriving this same cutoff — see "Operational issue" at the bottom before anything else.
+
+---
+
+## Needs your reply
+
+None. No open issue has a comment newer than the cutoff from anyone other than you — #142, #170, and #157 (the only three open issues with any comment history) all have you as the last commenter, on or before 2026-07-30.
+
+The four new bug reports below (category: "New since cutoff") have zero comments yet, so they don't technically qualify for this section, but they're real, well-reproduced bugs from a returning tester and probably want replies regardless — draft replies included there.
+
+---
+
+## PRs
+
+Four open PRs. All CI green on the ones that have run checks.
+
+### ⚠️ #191 — feat: Add dual-engine read tools for Canvas Quizzes (Classic and New)
+- Draft, Copilot coding agent, `mergeable_state: dirty`, **0 CI checks reported**, unchanged since 2026-07-30 (same head SHA `8a7e393`).
+- You left a detailed blocking review on 2026-07-30 (10:25): New Quizzes detection (`is_quiz_assignment AND submission_types contains external_tool`) is unverified and, per your own live measurement, `is_quiz_assignment=True` actually marks **Classic** quizzes — so the `AND` may always evaluate false, making `list_quizzes` silently report zero New Quizzes. You also flagged `engine` as an unvalidated free string routed inconsistently across three tools, and asked for a rebase.
+- **5 days with no response from Copilot.** `dirty` (real conflicts, not just behind) plus 0 checks suggests the branch may need `gh pr update-branch` to even re-trigger CI — same fix noted in the last two briefs.
+- Also still blocked on the substance: **#191 remains gated on #172's scoping question 4** (a New-Quizzes-enabled sandbox from zqian) per your own review — it cannot be correctly fixed without that, regardless of how Copilot responds.
+- **Next action:** your call whether to nudge, close as stalled pending the sandbox, or leave open. Not auto-actionable by this routine.
+
+### #209, #216, #218 — this routine's own prior triage-brief PRs
+- All three: draft, authored by you (bot-run sessions), all CI green (9/9 checks passing on each), all still open/unmerged, all touching only `internal/issue-triage/*.md`.
+- **This is why the cutoff hasn't moved past 2026-07-31 in four consecutive runs** — see the operational note at the bottom.
+- **Next action:** merge whichever ones you want kept (or just the latest) and close the rest — they're pure additive markdown, no code risk, CI is clean on all of them.
+
+---
+
+## New since 2026-07-31
+
+Four new issues, all filed 2026-08-03 in a ~40-minute window, all from testers running the server under a **student-role Canvas token** — three from `khagyard` (a returning tester — filed #171 on 2026-07-28, which you resolved 2026-07-30), one from `zqian` (UMich, high-priority collaborator).
+
+### #222 — [Bug]: get_my_upcoming_assignments limited to 7 days ⚠️ zqian
+zqian asked for assignments due in the next 30 days and only got 7 days back. They diagnosed it themselves, correctly: Canvas's `/users/self/upcoming_events` endpoint (which powers the dashboard "Coming Up" sidebar) is **hardcoded server-side to 7 days** and ignores any date range.
+
+**Confirmed by reading the code** (not just their diagnosis) — `student_tools.py:33-36`: the `days` parameter is never sent to Canvas at all; it's only used client-side at `student_tools.py:54` to filter the (already 7-day-capped) result set. Passing `days=30` can only ever narrow or match the 7-day window Canvas already returned, never expand it. zqian's read of the code and the Canvas API is correct.
+
+```
+You called it — I checked the code and Canvas's own /users/self/upcoming_events
+endpoint is hardcoded server-side to 7 days (it's the same feed as the
+dashboard "Coming Up" sidebar), so our `days` parameter was only ever
+filtering an already 7-day-capped result, never actually expanding the
+window with Canvas.
+
+I think the right fix is switching to the Calendar Events API for date
+ranges beyond 7 days, and either keeping this tool as the 7-day "what's
+coming up" view or renaming it so the limit is obvious rather than
+implied. Leaning toward the rename + a note in the docstring as the
+immediate fix, with the Calendar Events API version as a possible
+follow-up if there's appetite for a broader date-range tool. Which would
+be more useful for your pilot?
+```
+
+### #221 — [Bug]: mark_module_item_done reports success but Canvas isn't updated
+khagyard called the tool on an HTML page module item; it returned a success message, but the item was not marked done in Canvas's UI.
+
+**Unverified hypothesis** — `student_write.py:993-1000` calls `PUT /courses/:id/modules/:module_id/items/:item_id/done` and reports success purely from getting a non-error HTTP response, with no check of whether the target module item actually has a `must_mark_done` completion requirement. Canvas's "mark done" endpoint only has an effect on items configured with that specific completion requirement type — if the item khagyard used has a different requirement (e.g. `must_view`) or none at all, Canvas may accept the request without it doing anything, which would produce exactly this symptom. Not confirmed against a live instance.
+
+```
+Thanks for the repro. My working theory (not yet verified against a live
+course) is that Canvas's "mark done" endpoint only does anything for
+module items that are specifically configured with a "students must mark
+as done" completion requirement — if the item you used has a different
+requirement type (or none), Canvas may be accepting the request without
+it changing anything, and our code isn't checking that before reporting
+success.
+
+Can you tell me what completion requirement that module item shows in
+Canvas (Edit module settings, or it's visible in the module view)? If
+that's it, the fix is checking the item's completion_requirement before
+attempting the mark-done call, and returning a clear "this item isn't
+configured for mark-done" error instead of a false success either way.
+```
+
+### #220 — [Bug]: create_announcement silently downgrades to a discussion post for a student token
+khagyard, testing as a student, expected a 403 when trying to create an announcement (since students normally can't post announcements) and instead got a "success" response — but the post landed in Canvas as a regular discussion topic, not an announcement.
+
+**Two separate things going on, one of them a real bug in our code regardless of the Canvas permission question:**
+1. Canvas's behavior here (a student-permitted discussion-topic write silently ignoring `is_announcement: true` rather than rejecting it) may just be how Canvas's own permission model works — unverified, would need a live student-token test to confirm this isn't our error handling swallowing a 403.
+2. **Independent of #1, this is a real gap** — `discussions.py:963-978`: the tool builds its success message straight from `response.get("id")` / `response.get("title")` and never checks `response.get("is_announcement")` in what Canvas actually returned. So even when Canvas silently downgrades the post, our tool reports "Announcement created successfully" regardless. This is the same failure shape as the #180/#181 rubric bugs already fixed this cycle — reporting success on a write that didn't do what it claimed.
+
+```
+Good catch, and there are two things tangled together here that I want to
+pull apart.
+
+Whether Canvas *should* be rejecting an announcement attempt from a
+student token with a 403, versus silently accepting it as a plain
+discussion post, is a Canvas permissions question I need to verify against
+a live student token before I can say anything confident about it.
+
+But independent of that: our code has a real bug here regardless of what
+Canvas's permission model turns out to be. The tool builds its "success"
+message from the response without ever checking whether Canvas actually
+set is_announcement on what it created — so even in the scenario you hit,
+where Canvas silently created a plain discussion topic instead, we still
+reported "Announcement created successfully." That's on us to fix either
+way, and I'll get a patch out that checks the field and surfaces a warning
+instead of a false success.
+```
+
+### #219 — [Bug]:get_my_peer_reviews_todo — reports zero reviews when 2 are assigned
+khagyard has 2 peer reviews assigned in course 505; the tool reported none.
+
+**Confirmed by reading the code, higher confidence than the others here** — `student_tools.py:323-324` and `:337` both silently swallow any non-list response from Canvas: assignment-listing errors just `continue` to the next course, and `if isinstance(peer_reviews, list):` at line 337 means a dict response (e.g. a Canvas error body) is dropped with no message at all. `GET /courses/:id/assignments/:id/peer_reviews` is documented as commonly permission-gated for non-privileged callers — if Canvas is returning a 401/403 for a student token on that endpoint, the current code makes that look identical to "you have zero peer reviews," which matches khagyard's exact symptom. Also worth noting even if that endpoint does work for students: line 340-341 has a standing `# Note: We'd need to filter by current user ID / For now, show all incomplete reviews` comment — meaning it doesn't scope to the caller at all, which is a separate, real gap from the one that likely explains this specific report.
+
+```
+I think I found it, though I want to verify against a live student token
+before calling it confirmed. The code currently treats any error response
+from Canvas's peer-reviews endpoint the same as "no peer reviews" — it
+doesn't check for or surface an error, it just silently moves on. If
+Canvas is returning a permission error for that endpoint on a student
+token (which would line up with your report of 2 reviews existing but 0
+showing), our tool would report exactly what you saw with no error
+message, which is itself a bug on top of whatever Canvas's permission
+model turns out to require.
+
+Separately — and this would matter even once the above is fixed — I found
+a code comment noting the tool doesn't actually filter reviews down to the
+ones assigned to you specifically; it shows all incomplete reviews it can
+see. I'll fix both: surface the real error if there is one, and scope
+results to the caller.
+```
+
+---
+
+## Going stale
+
+None meeting the 5-day rule with genuinely fresh non-vishalsachdev activity — #142 and #157 were both last touched by you (2026-07-30 and 2026-07-10 respectively) and match their tracked backlog status in CLAUDE.md.
+
+---
+
+## Checked, nothing needed
+
+#142, #170, #157 — all open issues with comment history; last commenter on each is you, nothing waiting on a reply. #191 — PR reviewed above, ball is with Copilot / blocked on external scoping input, not actionable from this sweep beyond flagging.
+
+---
+
+## Operational issue — cutoff has not advanced in 4 consecutive runs
+
+`internal/issue-triage/` contains exactly one merged file, `2026-07-31.md`. Three subsequent triage runs (2026-08-01, 08-02, 08-03) each produced a brief and opened a PR (#209, #216, #218 respectively) — all still open, all draft, all CI-green, none merged. Each one recomputed the same 2026-07-31 cutoff because this routine's Step 2 reads the cutoff from files that exist in `main`, and none of those three PRs ever landed there.
+
+Net effect: for four days running, this routine has been re-scanning the same window and re-flagging the same #191 status, while the actual new activity (this run's four bug reports) very nearly got missed underneath a growing pile of unmerged self-referential PRs. Category 3 (new issues since cutoff) is what saved this cycle from also being a false "quiet day" — but that's luck, not design, since a stuck cutoff means anything that was fully handled *and* commented on entirely within the stuck window would silently stop showing up as "new" once it aged past a 5-day staleness check without ever having been counted once.
+
+Recommend: merge one of #209/#216/#218 (they're identical in kind, just different report dates — content in the newest, #218, supersedes the other two) and close the other two, so the next run's cutoff actually advances to something recent. This routine has no permission to do that itself.


### PR DESCRIPTION
Automated daily triage sweep of repo activity since cutoff 2026-07-31 (unchanged from the last three cycles — see "operational issue" note below). Adds `internal/issue-triage/2026-08-04.md` only. No comments/labels/merges posted anywhere.

## Items needing your reply
None from existing threads — but see "New since cutoff" below, which has draft replies for 4 fresh bug reports that likely want a response even though they're technically new rather than "needs reply."

## New since 2026-07-31
- #222 (zqian) — `get_my_upcoming_assignments` ignores the `days` param; confirmed in code, Canvas's endpoint is hardcoded to 7 days server-side.
- #221 (khagyard) — `mark_module_item_done` reports success without Canvas actually updating; unverified hypothesis re: `must_mark_done` completion-requirement gating.
- #220 (khagyard) — `create_announcement` under a student token silently becomes a plain discussion post; independent of the Canvas-permissions question, our code never checks `is_announcement` in the response before reporting success — same failure shape as the #180/#181 rubric bugs.
- #219 (khagyard) — `get_my_peer_reviews_todo` reports zero reviews when 2 are assigned; code silently swallows non-list/error responses from Canvas's peer-reviews endpoint instead of surfacing them.

## PRs flagged
- **#191** (Copilot, targets #172) — still draft, `mergeable_state: dirty`, 0 CI checks, no response in 5 days to your 2026-07-30 blocking review. Also still gated on #172's scoping question 4 regardless of Copilot's response. Unchanged since last two briefs.
- **#209 / #216 / #218** (this routine's own prior triage-brief PRs) — all draft, all CI-green, all still open/unmerged. **This is why the cutoff has been stuck at 2026-07-31 for four consecutive runs** — merging one and closing the rest would let the next cycle's cutoff actually advance.

## Going stale
None with genuinely fresh non-owner activity — #142 and #157 match their tracked backlog status in CLAUDE.md.

Full detail, draft replies, and code citations are in the brief itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_0159GPjQqxCbDQWfZxModGtP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition under `internal/issue-triage/`; no runtime or application code changes.
> 
> **Overview**
> Adds **`internal/issue-triage/2026-08-04.md`**, the automated daily sweep since cutoff **2026-07-31** (unchanged because prior brief PRs #209/#216/#218 are still unmerged on `main`).
> 
> The brief records **no open threads waiting on your reply**, flags **#191** (still draft/dirty, no Copilot response, blocked on #172 sandbox), and recommends merging one of the stacked triage PRs so future runs can advance the cutoff.
> 
> **New since cutoff:** four student-token bug reports from 2026-08-03 (#219–#222) with code-backed notes and draft replies—upcoming assignments `days` vs Canvas’s 7-day cap (#222), false success on mark-module-done (#221), announcement vs discussion success messaging (#220), and peer reviews errors swallowed as zero (#219).
> 
> It also documents an **operational issue**: four consecutive triage cycles reused the same cutoff and nearly masked new issues until the “new since cutoff” section caught them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cb83105377c1b18176915d2f5e1c29d29257222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->