### PR TITLE
triage: GitHub activity brief 2026-08-06

### DIFF
--- a/internal/issue-triage/2026-08-06.md
+++ b/internal/issue-triage/2026-08-06.md
@@ -1,0 +1,38 @@
+# Triage brief — 2026-08-06
+
+**Read path:** GitHub MCP tools (`mcp__github__*`).
+**Cutoff:** 2026-07-31, the date of the newest file in `internal/issue-triage/` on `main`. Note the caveat below — this cutoff has not moved in six days because none of the intervening daily briefs have been merged.
+
+## Needs your reply
+
+None. No open issue has a comment newer than the cutoff whose most recent commenter isn't you.
+
+## PRs
+
+### #191 — `feat: Add dual-engine read tools for Canvas Quizzes (Classic and New)` (Copilot agent, draft)
+- **mergeable_state: dirty** — conflicts with `main`. The branch's base is from 2026-07-30; `main` has had roughly 15 merges since.
+- **CI: 0 checks reported.** For a same-repo Copilot-authored branch this usually means Actions never triggered for it at all, not that anything failed. Known unblock: `gh pr update-branch` (rebases onto `main`, which would likely also clear the conflict).
+- Design status is unchanged from your own notes: BLOCKED on correctness. New Quizzes detection (`is_quiz_assignment AND external_tool`) was measured live to match *Classic* quizzes, so the `AND` may match nothing and silently report zero New Quizzes — see `quizzes.py`. Unblocking needs zqian's New-Quizzes-enabled sandbox (scoping question 4 on #170's thread family).
+- Housekeeping, independent of the correctness blocker: the PR's own description still carries the original auto-close phrasing pointed at issue #172 — the same phrasing that accidentally re-triggered a closure once already (2026-07-31 incident, see below). If this PR is ever merged as currently written, #172 closes again. Worth editing that line out of the description before any merge.
+- Next action: none until the sandbox question is answered. If you do pick the branch back up, run `update-branch` first.
+
+### Triage-brief PRs — 5 open, unmerged, going back to 2026-08-01
+`#209` (08-01), `#216` (08-02), `#218` (08-03), `#223` (08-04), `#227` (08-05) are this routine's own prior daily briefs. All are still open and in draft. Spot-checked `#209` and `#227` directly: both report 0 CI checks. None have been merged.
+
+**Practical effect:** because none of these merged, `internal/issue-triage/2026-07-31.md` is still the newest file on `main`, so Step 2's cutoff rule keeps re-deriving 2026-07-31 every day. Today's sweep is re-scanning six days of activity that already went into those unmerged briefs — including four bug reports that were filed *and* fixed entirely within that window (see below). Recommend merging or explicitly closing the backlog so the cutoff starts advancing; otherwise today's PR becomes a sixth entry in the same pile.
+
+## New since 2026-07-31
+
+- **#219, #220, #221** (khagyard) and **#222** (zqian) — all four filed 2026-08-03, and all four were already fixed and closed the next day, 2026-08-04, via PR #224 (#219/#220/#221) and PR #225 (#222). No reply needed; resolved before any triage brief covering them could have reached you, since the intervening PRs never merged.
+
+No new issues or PRs from anyone other than you since the cutoff otherwise. (PRs #210–#214, #217, #224–#226 were also opened in this window but all are yours.)
+
+## Going stale
+
+- **#170** (zqian, high-priority — student write tools, FERPA-adjacent) — zqian's last word was 2026-07-29: "will update you soon" on the two design questions you asked (default posture for `COURSE_AGENT_POLICY_DEFAULT`; comfort with the syllabus as the policy carrier). 8 days with no follow-up.
+- **#142** (`mcp<2` pin, `blocked-upstream`) — last non-you comment is @ashcastelinocs124 from 2026-07-01. You converted this to an unassigned watch item on 2026-07-30; nothing to chase.
+- **#157** (execute_typescript sandbox hardening) — last non-you comment is the auto-label bot from 2026-07-04. Self-hosted-only backlog per your own 2026-07-10 note; not waiting on anyone.
+
+## Checked, nothing needed
+
+#142, #157, #170 (stale, no new action needed), #191 (blocked/conflicted, no new activity since cutoff), #219, #220, #221, #222 (already resolved — see "New since 2026-07-31" above), and PRs #224, #225, #226 (already merged).


### PR DESCRIPTION
## Summary

Daily triage sweep for 2026-08-06. Cutoff: 2026-07-31 (newest brief on `main`).

- **Needs your reply:** none. No open issue has a comment newer than the cutoff from anyone but you.
- **New since cutoff:** #219, #220, #221, #222 — filed 2026-08-03. All four are already resolved as of 2026-08-04 via PRs #224 and #225. No action needed.
- **Flagged:** PR #191 is draft, conflicted with `main`, and shows 0 reported CI checks. Its description also still contains the original GitHub issue-linking directive pointed at issue number 172 (same mechanism behind the 2026-07-31 incident) — worth editing that line out of the description before any future merge.
- **Operational note:** five prior daily triage PRs (#209, #216, #218, #223, #227) are still open and unmerged, which is why this cutoff hasn't moved past 2026-07-31 in six days. Recommend merging or explicitly closing that backlog.

Full detail in `internal/issue-triage/2026-08-06.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PC5u3eavX3gpX7u7zS9F4j)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only internal triage note with no runtime or product code changes.
> 
> **Overview**
> Adds **`internal/issue-triage/2026-08-06.md`**, the daily GitHub triage brief for 2026-08-06 (cutoff still **2026-07-31** because prior brief PRs haven’t merged).
> 
> **No issues need your reply.** Since the cutoff: four issues (#219–#222) were filed and already fixed via #224/#225. **#191** stays draft, conflicted, blocked on New Quizzes detection, and its description still has issue-link text that could re-close **#172**. **#170** is stale (8 days). The brief also flags five unmerged triage PRs (#209–#227) and recommends merging or closing that backlog so the cutoff can advance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20299c9828b7f246911917c0afc118d9e968ba71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->