### PR TITLE
triage: GitHub activity brief 2026-08-07

### DIFF
--- a/internal/issue-triage/2026-08-07.md
+++ b/internal/issue-triage/2026-08-07.md
@@ -1,0 +1,33 @@
+# Triage brief — 2026-08-07
+
+**Read path used:** GitHub MCP tools (`gh` CLI not checked; MCP tools worked directly).
+**Cutoff:** 2026-07-31 (newest file on `main` in `internal/issue-triage/` — still the only one there; see operational note below).
+
+## Operational note — read this first
+
+This is the **eighth** consecutive daily run whose cutoff has been stuck at `2026-07-31`, because none of the seven prior triage-brief PRs have been merged or closed: **#209** (08-01), **#216** (08-02), **#218** (08-03), **#223** (08-04), **#227** (08-05), **#228** (08-06). Each is draft, CI-green (where checked), and none touch overlapping files, so any one (or all) can merge without conflict. Until at least the newest is merged, tomorrow's run will re-derive this same 2026-07-31 cutoff again. Recommend merging **#228** (the most recent, most complete) and closing #209/#216/#218/#223/#227 as superseded, or merging all of them — they're additive (each adds one dated file).
+
+## Needs your reply
+
+None. No open issue has a comment newer than 2026-07-31 from anyone other than `vishalsachdev` (confirmed via `search_issues … is:open updated:>2026-07-31`, 0 results).
+
+## PRs
+
+- **#191** (Copilot, targets #172) — still draft, `mergeable_state: dirty`, **0 CI checks reported** (confirmed via `get_check_runs`), unchanged since 2026-07-30 (8 days now), no response to your 2026-07-30 blocking review on the New Quizzes detection logic. Also gated on #172's scoping question 4 (zqian's New-Quizzes sandbox) regardless of any Copilot response. **Note:** the PR description still ends with a GitHub auto-close keyword directly followed by the `172` issue reference — issue #172 is closed already, so this specific line poses no fresh risk right now, but it's the same pattern that caused the 2026-07-31 incident and is worth stripping before this PR ever merges, since merging would then re-trigger the keyword against an issue in whatever state it's in at that time. Next action: nudge Copilot, or close as stalled if it stays silent past #172's outstanding blocker.
+- **#209 / #216 / #218 / #223 / #227 / #228** — this routine's own prior triage-brief PRs. All open, unmerged. See operational note above.
+
+## New since 2026-07-31
+
+- **#219, #220, #221, #222** — filed 2026-08-03 by `khagyard` (first-time reporter, testing as a student) and `zqian`. All four are bug reports and all four are **already fixed and merged** as of 2026-08-04, via PR #224 (#219/#220/#221) and PR #225 (#222). No action needed; logging only per instructions not to duplicate prior briefs' detail. (Also visible on `main`: `95fd026`, `2b12745`, and hotfix `7fabcca` for a cross-PR merge conflict between #224/#225.)
+- **#215** — automated weekly-maintenance report (`weekly-maintenance.yml`), opened and closed same day. Not summarized here per standing instruction to skip that automation's own output.
+
+No new issues or PRs from anyone other than `vishalsachdev` have appeared since #222 (2026-08-03) — the four-day gap since is the first genuinely quiet stretch in this backlog's history.
+
+## Going stale
+
+- **#170** (zqian) — last non-`vishalsachdev` touch was zqian's comment on 2026-07-29 ("we use HTTP deployment with per-user tokens; will update you soon about the five Tier 1 tools"), now 9 days old. You posted a long, detailed design writeup the next day (2026-07-30) ending in two explicit questions (default posture for `COURSE_AGENT_POLICY_DEFAULT`; whether the syllabus-as-policy-carrier design is acceptable) and confirmed Tier 1 shipped to `main` in a follow-up comment the same day. The ball is in zqian's court — flagging as stale rather than "needs your reply" since you're the most recent commenter and there's nothing new to respond to. **High-sensitivity**: this issue covers student write-tool defaults and a FERPA-adjacent access-control design (course-level agent policy). No draft reply needed; recommend a light nudge only if zqian goes quiet much longer, given they're an active evaluating institution.
+- **#142, #157** — match their tracked backlog status in CLAUDE.md (`blocked-upstream` watch item; self-hosted-only sandbox hardening). No new activity from anyone since before the cutoff. No action.
+
+## Checked, nothing needed
+
+#142, #157, #170 (see Going stale above — reviewed, no draft reply warranted), #172 (closed, target of #191, no new activity), #215 (automated report, not duplicated per standing instruction).


### PR DESCRIPTION
## Summary

Daily triage sweep for 2026-08-07. Cutoff: 2026-07-31 (newest brief on `main` — unchanged for the 8th consecutive cycle).

- **Needs your reply:** none. No open issue has a comment newer than the cutoff from anyone but you.
- **New since cutoff:** #219, #220, #221, #222 (filed 2026-08-03 by khagyard/zqian) — all already resolved via #224/#225 (merged 2026-08-04). No action needed.
- **Going stale:** #170 — zqian's last comment was 2026-07-29; you answered in detail on 2026-07-30 with two open questions. High-sensitivity (student write-tool defaults / access-control design). Awaiting their reply, no draft needed.
- **PRs flagged:** #191 (Copilot, targets #172) — draft, `mergeable_state: dirty`, 0 CI checks, unchanged 8 days, no response to your blocking review.
- **Operational:** this is the 8th straight cycle stuck at the 2026-07-31 cutoff because six prior triage PRs (#209, #216, #218, #223, #227, #228) remain unmerged. They're additive and non-conflicting — merging any (or all) would let the cutoff advance.

Full detail in `internal/issue-triage/2026-08-07.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01K9g1nts8A7PaVbtrxrBVZ9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition under `internal/issue-triage/` with no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **`internal/issue-triage/2026-08-07.md`**, the daily GitHub triage brief for 2026-08-07 (cutoff still **2026-07-31** because prior brief PRs are unmerged).
> 
> The writeup records **no issues needing maintainer reply**, notes four student-reported bugs (#219–#222) already fixed on `main`, flags **#170** as going stale on course agent policy, and calls out stalled draft **#191** plus a backlog of six unmerged triage PRs (#209–#228) with a recommendation to merge **#228** and close the rest as superseded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e5a0ac006f6bcdbacf9f2107929ac50279f594. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->