### PR TITLE
feat: block accidental issue closures from prose closing keywords

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Reject commit messages containing a GitHub closing keyword next to an issue
+# reference. This is the *prevention* half of the guard: a commit pushed
+# directly to `main` never passes through a PR, so CI can only notice it after
+# the issue has already closed. See scripts/check_closing_keywords.py.
+#
+# Install:  ./scripts/install-hooks.sh
+# Bypass:   ALLOW_CLOSING_KEYWORD=1 git commit ...
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+checker="$repo_root/scripts/check_closing_keywords.py"
+
+# Never block a commit because the guard itself is missing (e.g. checking out
+# an older revision). Fail open here; CI is the backstop.
+[ -f "$checker" ] || exit 0
+
+python3 "$checker" "$1" \
+  --label "commit message" \
+  --bypass-hint "ALLOW_CLOSING_KEYWORD=1 git commit ..."

--- a/.github/workflows/closing-keyword-guard.yml
+++ b/.github/workflows/closing-keyword-guard.yml
@@ -1,0 +1,94 @@
+name: Closing Keyword Guard
+
+# Stops a GitHub closing keyword from silently closing an issue that no work
+# actually completed. Issue #172 was closed twice this way: once via a merged
+# PR body, once via a commit message pushed straight to `main`.
+#
+# Two triggers, two different jobs, because they catch different vectors:
+#   pull_request -> preventive. Blocks before the merge that would close.
+#   push to main -> detective only. A direct commit has already closed the
+#                   issue by the time this runs; the job exists so the failure
+#                   is loud instead of silent, the way it was on 2026-07-31.
+# The commit-msg hook (scripts/install-hooks.sh) is the actual prevention for
+# the direct-push vector.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  scan-pull-request:
+    name: PR body and commits
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan PR body
+        env:
+          # Passed via env, never interpolated into the shell: a PR body is
+          # attacker-controlled text and ${{ }} inlining is a script-injection
+          # vector.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s' "$PR_BODY" \
+            | python3 scripts/check_closing_keywords.py - \
+                --label "PR #${{ github.event.pull_request.number }} body" \
+                --bypass-hint "intentional? add the 'allow-closing-keyword' label to this PR"
+
+      - name: Scan commit messages in this PR
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          status=0
+          while read -r sha; do
+            [ -z "$sha" ] && continue
+            git log -1 --format=%B "$sha" \
+              | python3 scripts/check_closing_keywords.py - \
+                  --label "commit ${sha:0:7}" \
+                  --bypass-hint "intentional? add the 'allow-closing-keyword' label to this PR" \
+              || status=1
+          done < <(git rev-list "$base..$head")
+          exit $status
+
+  scan-push:
+    name: Commits pushed to main
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan pushed commit messages
+        run: |
+          before="${{ github.event.before }}"
+          # A new branch or force-push reports an all-zero "before" SHA; fall
+          # back to just the tip rather than walking all of history.
+          if [ -z "$before" ] || [ "$before" = "0000000000000000000000000000000000000000" ] \
+             || ! git cat-file -e "$before^{commit}" 2>/dev/null; then
+            range="${{ github.sha }} -1"
+          else
+            range="$before..${{ github.sha }}"
+          fi
+          status=0
+          while read -r sha; do
+            [ -z "$sha" ] && continue
+            git log -1 --format=%B "$sha" \
+              | python3 scripts/check_closing_keywords.py - \
+                  --label "commit ${sha:0:7} (already on main)" \
+                  --bypass-hint "if the closure was intended, no action needed" \
+              || status=1
+          done < <(git rev-list $range)
+          if [ "$status" -ne 0 ]; then
+            echo "::error::A commit on main carries a closing keyword. If an issue closed that should not have, reopen it now."
+          fi
+          exit $status

--- a/.github/workflows/closing-keyword-guard.yml
+++ b/.github/workflows/closing-keyword-guard.yml
@@ -6,6 +6,12 @@ name: Closing Keyword Guard
 #
 # Two triggers, two different jobs, because they catch different vectors:
 #   pull_request -> preventive. Blocks before the merge that would close.
+#                   Runs on `edited` too, and that is not incidental: review
+#                   bots append summaries to the body after opening, and one
+#                   did exactly that on PR #231 -- a Cursor summary quoting
+#                   "Closes #173" as an example would have closed #173 on
+#                   merge. A body that was clean at creation does not stay
+#                   clean.
 #   push to main -> detective only. A direct commit has already closed the
 #                   issue by the time this runs; the job exists so the failure
 #                   is loud instead of silent, the way it was on 2026-07-31.
@@ -27,6 +33,12 @@ jobs:
     name: PR body and commits
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      # The escape hatch for a PR that genuinely means to close an issue from
+      # prose. An empty string is falsy to the checker, so the label's absence
+      # simply leaves the guard armed.
+      ALLOW_CLOSING_KEYWORD: >-
+        ${{ contains(github.event.pull_request.labels.*.name, 'allow-closing-keyword') && '1' || '' }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,20 @@ FastMCP server; type-driven validation via `@validate_params`; dual-layer course
 
 This repo has branch protection on `main` (PR + status checks required), but admin can bypass. Always ask the user which workflow they prefer for the current task.
 
+### Closing-keyword guard — run `./scripts/install-hooks.sh` once per clone
+
+GitHub closes an issue on any `fixes|closes|resolves #N` in a merged PR body **or
+a commit message landing on `main`** — including prose that only *describes*
+other work. Issue #172 was closed twice this way (PR #202's body, then commit
+`98643ce` whose message documented the first accident).
+
+`scripts/check_closing_keywords.py` is the single detector, shared by the
+`commit-msg` hook (prevention) and `.github/workflows/closing-keyword-guard.yml`
+(backstop). It blocks keywords **mid-sentence** and allows ones that **open a
+line** — `Closes #173` is a deliberate trailer, `...bug that closed #172` is
+narration. Deliberate close on a fix PR needs no ceremony; narration must be
+rephrased (`closed [issue 172]`) or bypassed with `ALLOW_CLOSING_KEYWORD=1`.
+
 ---
 
 ## Release Checklist

--- a/scripts/check_closing_keywords.py
+++ b/scripts/check_closing_keywords.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Detect GitHub closing keywords that would auto-close an issue.
+
+Background: issue #172 was closed twice by accident, neither time by work
+landing. First by merging PR #202, whose *body* described another PR in prose
+("#191 (Copilot, fixes #172)"). Second by a direct commit to `main` (98643ce)
+whose message documented the first accident and repeated the offending phrase
+verbatim -- GitHub matched it and re-closed the issue four seconds after the
+push. The post-incident guard only checked PR bodies, so the commit vector
+sailed straight past it.
+
+This module is the single source of truth for that detection, shared by the
+`commit-msg` hook (prevention) and the CI workflow (backstop). Keeping one
+regex in one place is the point: two copies would drift.
+
+GitHub matches a closing keyword only when the issue reference *directly*
+follows it, with at most a colon and whitespace between. "fixed the bug in
+#191" does not close anything; "fixes #191" does. We match the same shape, so
+this neither over- nor under-reports relative to the platform behavior.
+
+Usage:
+    check_closing_keywords.py FILE...      # scan files
+    check_closing_keywords.py -            # scan stdin
+    ... --label "PR #230 body"             # name the source in output
+
+Exit 0 when clean, 1 when a keyword reference is found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+# GitHub's documented closing keywords.
+_KEYWORDS = (
+    "close",
+    "closes",
+    "closed",
+    "fix",
+    "fixes",
+    "fixed",
+    "resolve",
+    "resolves",
+    "resolved",
+)
+
+# The forms GitHub accepts for the issue reference itself: bare (#12),
+# shorthand (GH-12), cross-repo (owner/repo#12), and full issue URLs.
+_REFERENCE = r"""
+    (?:
+        \#\d+
+      | GH-\d+
+      | [\w.-]+/[\w.-]+\#\d+
+      | https?://github\.com/[\w.-]+/[\w.-]+/issues/\d+
+    )
+"""
+
+CLOSING_PATTERN = re.compile(
+    r"\b(?P<keyword>" + "|".join(_KEYWORDS) + r")\b"
+    r"[ \t]*:?[ \t]*"
+    r"(?P<ref>" + _REFERENCE + r")",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Escape hatch for a deliberate close. Set in the environment, not in the text,
+# so it can never be smuggled in by content this tool is scanning.
+BYPASS_ENV = "ALLOW_CLOSING_KEYWORD"
+
+
+# GitHub treats "Closes #173" and "...bug that closed #173" identically, but
+# the *intent* behind them is opposite, and on this repo's real history one
+# cheap signal separates them perfectly: position. A line that *opens* with a
+# closing keyword is the conventional deliberate trailer; a keyword buried
+# mid-sentence is narration about work, not a request to close it.
+#
+# Validated by replay over all ~400 commits on main: 18 deliberate closures
+# all open their line, and every accidental one -- including both #172
+# incidents -- is mid-sentence. Flagging trailers too would mean an escape
+# hatch on nearly every fix PR, and a bypass used routinely stops being read.
+#
+# Leading list markers count as "start": "- Closes #12" is still a trailer.
+_LINE_PREFIX = re.compile(r"^[\s>*\-+]*")
+
+
+@dataclass(frozen=True)
+class Match:
+    """One closing-keyword reference, located for a human to act on."""
+
+    source: str
+    line_number: int
+    line: str
+    keyword: str
+    reference: str
+    column: int
+    is_trailer: bool
+
+
+def _content_start(line: str) -> int:
+    """Index of the line's first real character, past indent and list markers."""
+    return _LINE_PREFIX.match(line).end()
+
+
+def scan_text(text: str, source: str = "<text>") -> list[Match]:
+    """Return every closing-keyword reference in ``text``.
+
+    Comment lines are skipped: git strips them before the message is stored,
+    so a `#` -prefixed line never reaches GitHub's parser. Scanning them would
+    flag the commit template's own instructions on every single commit.
+    """
+    found: list[Match] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if line.lstrip().startswith("#"):
+            continue
+        line_matches = list(CLOSING_PATTERN.finditer(line))
+        if not line_matches:
+            continue
+        # Deliberateness is a property of the line, not of each reference: once
+        # a line opens as a trailer, everything it goes on to list is equally
+        # intended ("Closes #199, closes #198").
+        is_trailer = line_matches[0].start() == _content_start(line)
+        for m in line_matches:
+            found.append(
+                Match(
+                    source=source,
+                    line_number=lineno,
+                    line=line,
+                    keyword=m.group("keyword"),
+                    reference=m.group("ref"),
+                    column=m.start(),
+                    is_trailer=is_trailer,
+                )
+            )
+    return found
+
+
+def format_report(matches: list[Match], *, bypass_hint: str) -> str:
+    """Render matches as an actionable message, not just a rejection."""
+    issues = ", ".join(sorted({m.reference for m in matches}))
+    out = ["", "✗ GitHub closing keyword in prose", ""]
+    for m in matches:
+        out.append(f"  {m.source}:{m.line_number}: {m.line.strip()}")
+        out.append(f"  {' ' * (len(f'{m.source}:{m.line_number}: '))}"
+                   f"{'^' * len(m.keyword + ' ' + m.reference)}")
+    out += [
+        "",
+        f"  Landing this on the default branch will CLOSE {issues}.",
+        "",
+        "  If that is intended:",
+        f"    {bypass_hint}",
+        "",
+        "  If it is not (you are describing or quoting, not closing), rephrase",
+        "  so the keyword does not directly precede the reference:",
+        '    "closed #172 by accident"  ->  "closed [issue 172] by accident"',
+        "",
+    ]
+    return "\n".join(out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", help="files to scan, or - for stdin")
+    parser.add_argument("--label", default=None, help="name for the source in output")
+    parser.add_argument(
+        "--bypass-hint",
+        default=f"{BYPASS_ENV}=1 git commit ...",
+        help="how to intentionally allow, shown on failure",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="also fail on deliberate trailer lines (e.g. 'Closes #12'), "
+        "which are allowed by default",
+    )
+    args = parser.parse_args(argv)
+
+    if os.environ.get(BYPASS_ENV):
+        print(f"[closing-keyword-guard] {BYPASS_ENV} set - check skipped.", file=sys.stderr)
+        return 0
+
+    matches: list[Match] = []
+    for path in args.paths:
+        if path == "-":
+            matches += scan_text(sys.stdin.read(), args.label or "<stdin>")
+        else:
+            with open(path, encoding="utf-8") as fh:
+                matches += scan_text(fh.read(), args.label or path)
+
+    blocking = matches if args.strict else [m for m in matches if not m.is_trailer]
+
+    # Deliberate trailers still get named, so an intentional close is visible
+    # in the log rather than merely unpunished.
+    for m in matches:
+        if m.is_trailer and not args.strict:
+            print(
+                f"[closing-keyword-guard] {m.source}:{m.line_number}: "
+                f"will close {m.reference} (deliberate trailer, allowed).",
+                file=sys.stderr,
+            )
+
+    if blocking:
+        print(format_report(blocking, bypass_hint=args.bypass_hint), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Point git at the repo's tracked hooks directory.
+#
+# `core.hooksPath` is per-clone local config, so every contributor runs this
+# once. It is deliberately not automatic: silently installing executables that
+# run on someone's commits is not something a `pip install` should do.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+git -C "$repo_root" config core.hooksPath .githooks
+chmod +x "$repo_root"/.githooks/*
+
+echo "✓ core.hooksPath -> .githooks"
+echo "  Installed: $(cd "$repo_root/.githooks" && ls | tr '\n' ' ')"
+echo
+echo "  To uninstall: git config --unset core.hooksPath"

--- a/tests/test_closing_keyword_guard.py
+++ b/tests/test_closing_keyword_guard.py
@@ -1,0 +1,326 @@
+"""Tests for the closing-keyword guard.
+
+The fixtures that matter most here are the two real incidents, quoted verbatim
+from the actual artifacts (commit 98643ce and PR #202's body). A synthetic
+fixture would only prove the regex matches text written to match the regex --
+the same circularity that let PR #191's New-Quizzes test pass while the filter
+matched nothing. See `test_acceptance_replay_real_history` for the check that
+runs against this repo's genuine git log.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from check_closing_keywords import (  # noqa: E402
+    BYPASS_ENV,
+    format_report,
+    main,
+    scan_text,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHECKER = REPO_ROOT / "scripts" / "check_closing_keywords.py"
+
+
+# --------------------------------------------------------------------------
+# The real incidents
+# --------------------------------------------------------------------------
+
+# Commit 98643ce, pushed directly to main 2026-07-31T13:08:48Z, quoted
+# verbatim. Issue #172 closed 4 seconds later. This is the vector the original
+# PR-body-only guard did not cover.
+#
+# Note it carries TWO closing references, not one: "four issues closed: #203"
+# as well as "closed #172". The incident write-up only recorded the second.
+# The acceptance replay found the first -- a hand-written fixture had missed
+# it, which is the whole argument for replaying against real data.
+INCIDENT_COMMIT_MSG = """\
+docs: session log 2026-07-31 — closed all three zqian bugs + tool-annotation contract
+
+Four PRs merged, four issues closed: #203 (#199 institution-neutral enrollment
+matching, #198 upload-to-course-root), #202 (first triage brief), #201 (#200
+annotations), #205 (#204 annotation contract + CI gate). Tests 928 -> 968.
+
+Archives the 2026-07-30 (later) entry to internal/session-history.md, checks off
+the completed Current Focus items, and records the triage-routine closing-keyword
+bug that closed #172 by accident (routine prompt patched; #172 reopened).
+
+Also commits internal/issue-170-followup-draft.md, the record of the #170
+follow-up comment posted 2026-07-30.
+"""
+
+# PR #202's body: a triage brief describing another PR in prose. Merging it
+# closed #172 the first time, on 2026-07-31T05:47Z.
+INCIDENT_PR_BODY = "- **`#191`** (Copilot, fixes #172) — draft, blocked on review."
+
+
+def test_flags_the_direct_commit_incident():
+    """The commit that documented the bug must itself be caught -- twice."""
+    matches = scan_text(INCIDENT_COMMIT_MSG, "commit 98643ce")
+    assert matches, "guard missed the exact commit that re-closed #172"
+
+    by_ref = {m.reference: m.keyword.lower() for m in matches}
+    # The closure everyone noticed.
+    assert by_ref["#172"] == "closed"
+    # And the one nobody did: "four issues closed: #203". Harmless in the
+    # event (#203 was an already-merged PR) but the same live directive.
+    assert by_ref["#203"] == "closed"
+    assert sorted(by_ref) == ["#172", "#203"]
+
+
+def test_flags_the_pr_body_incident():
+    matches = scan_text(INCIDENT_PR_BODY, "PR #202 body")
+    assert [m.reference for m in matches] == ["#172"]
+    assert matches[0].keyword.lower() == "fixes"
+
+
+# --------------------------------------------------------------------------
+# Success path: text that must pass untouched
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Real commit subjects from this repo's history. Conventional-commit
+        # "fix:" is followed by prose, not a reference -- GitHub does not close
+        # on these, so neither may we.
+        "fix: restore make_canvas_request import lost in #224/#225 cross-merge",
+        "fix: never report unconfirmed writes as success (#219, #220, #221) (#224)",
+        "fix: honor the requested days range in get_my_upcoming_assignments (#222) (#225)",
+        "docs: weekly impact stats 2026-08-04 (re-collected after failed Aug 3 run)",
+        # Words between keyword and reference: GitHub does not link these.
+        "fixed the detection bug reported in #191",
+        "this resolves the problem described by #142",
+        # The recommended rephrasing from the failure message.
+        "closed [issue 172] by accident",
+        # Bare references with no keyword at all.
+        "See #172 and #191 for context.",
+    ],
+)
+def test_does_not_flag_safe_text(text):
+    assert scan_text(text) == []
+
+
+# --------------------------------------------------------------------------
+# Trailer vs prose: the distinction that keeps the escape hatch meaningful
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "Closes #173",
+        "Fixes #207",
+        "Fixes #207, #208",
+        "Closes #199, closes #198",
+        "Resolves #12 and #13",
+        "closes #12.",
+        # Deliberate trailers routinely carry trailing prose on the same line.
+        "Closes #200 (reported by @zqian).",
+        "Closes #204. Follow-up to #200 / #201, which shipped the symptom fix.",
+        "- Closes #12",
+    ],
+)
+def test_standalone_trailers_are_classified_deliberate(line):
+    matches = scan_text(line)
+    assert matches, f"expected a match in {line!r}"
+    assert all(m.is_trailer for m in matches)
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        # Both real incidents.
+        "bug that closed #172 by accident (routine prompt patched)",
+        "Four PRs merged, four issues closed: #203 (#199 enrollment matching,",
+        "- **`#191`** (Copilot, fixes #172) — draft, blocked on review.",
+        # The two the incident write-up never noticed.
+        "docs: close #215 doc gaps — full tool coverage in tools/README.md (#217)",
+        "Salvaged from the closed #111 weekly-maintenance report:",
+    ],
+)
+def test_narration_is_classified_prose(line):
+    matches = scan_text(line)
+    assert matches, f"expected a match in {line!r}"
+    assert not any(m.is_trailer for m in matches)
+
+
+def test_cli_allows_trailers_but_blocks_prose(tmp_path, monkeypatch, capsys):
+    monkeypatch.delenv(BYPASS_ENV, raising=False)
+    msg = tmp_path / "COMMIT_EDITMSG"
+
+    msg.write_text("fix: real fix\n\nCloses #173\n", encoding="utf-8")
+    assert main([str(msg)]) == 0
+    assert "deliberate trailer, allowed" in capsys.readouterr().err
+
+    msg.write_text("docs: log the bug that closed #172 by accident\n", encoding="utf-8")
+    assert main([str(msg)]) == 1
+
+
+def test_strict_mode_blocks_trailers_too(tmp_path, monkeypatch):
+    monkeypatch.delenv(BYPASS_ENV, raising=False)
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text("fix: real fix\n\nCloses #173\n", encoding="utf-8")
+    assert main([str(msg)]) == 0
+    assert main([str(msg), "--strict"]) == 1
+
+
+def test_skips_comment_lines():
+    """Git strips `#` lines before storing, so they never reach GitHub."""
+    msg = "docs: update notes\n\n# On branch main\n# fixes #172 <- template noise\n"
+    assert scan_text(msg) == []
+
+
+# --------------------------------------------------------------------------
+# Edge cases: the reference forms GitHub accepts
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected_ref",
+    [
+        ("closes #12", "#12"),
+        ("Closes: #12", "#12"),
+        ("CLOSED #12", "#12"),
+        ("resolve GH-12", "GH-12"),
+        ("fixes vishalsachdev/canvas-mcp#12", "vishalsachdev/canvas-mcp#12"),
+        (
+            "closed https://github.com/vishalsachdev/canvas-mcp/issues/12",
+            "https://github.com/vishalsachdev/canvas-mcp/issues/12",
+        ),
+        ("fix\t#12", "#12"),
+    ],
+)
+def test_flags_every_reference_form(text, expected_ref):
+    matches = scan_text(text)
+    assert len(matches) == 1
+    assert matches[0].reference == expected_ref
+
+
+def test_reports_every_occurrence_not_just_the_first():
+    matches = scan_text("closes #1 and fixes #2\nresolves #3")
+    assert [m.reference for m in matches] == ["#1", "#2", "#3"]
+    assert [m.line_number for m in matches] == [1, 1, 2]
+
+
+# --------------------------------------------------------------------------
+# CLI behavior
+# --------------------------------------------------------------------------
+
+
+def test_cli_exits_nonzero_and_names_the_issue(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv(BYPASS_ENV, raising=False)
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text(INCIDENT_COMMIT_MSG, encoding="utf-8")
+
+    assert main([str(msg), "--label", "commit message"]) == 1
+
+    err = capsys.readouterr().err
+    assert "#172" in err
+    assert BYPASS_ENV in err
+
+
+def test_cli_exits_zero_on_clean_input(tmp_path, monkeypatch):
+    monkeypatch.delenv(BYPASS_ENV, raising=False)
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text("docs: ordinary session log\n", encoding="utf-8")
+    assert main([str(msg)]) == 0
+
+
+def test_bypass_env_var_allows_a_deliberate_close(tmp_path, monkeypatch):
+    monkeypatch.setenv(BYPASS_ENV, "1")
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text("feat: ship the thing\n\nCloses #123\n", encoding="utf-8")
+    assert main([str(msg)]) == 0
+
+
+def test_report_tells_the_user_how_to_rephrase():
+    report = format_report(scan_text(INCIDENT_PR_BODY, "body"), bypass_hint="HINT=1")
+    assert "HINT=1" in report
+    assert "[issue 172]" in report  # the suggested rewrite
+
+
+# --------------------------------------------------------------------------
+# Acceptance replay against this repo's real history
+# --------------------------------------------------------------------------
+
+
+def test_acceptance_replay_real_history():
+    """Run the checker over every real commit message on main.
+
+    A validator that has only ever seen its own fixtures has not earned its
+    place. This replays it over the actual corpus it will police.
+
+    The expected set is pinned deliberately. Running this the first time is
+    what produced the trailer/prose split: the regex flagged 20 commits, of
+    which 18 were ordinary `Closes #N` trailers on fix PRs. Blocking those
+    would have meant an escape hatch on nearly every PR. It also surfaced two
+    accidental closures nobody had recorded -- 2bee9f2 and c63b23b -- plus a
+    second reference inside 98643ce itself.
+    """
+    log = subprocess.run(
+        ["git", "log", "--format=%H%x00%B%x1e", "main"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+    # Every accidental closure in this repo's history, and nothing else.
+    EXPECTED_PROSE = {
+        "98643ce": ["#172", "#203"],  # the incident; #203 previously unrecorded
+        "2bee9f2": ["#215"],  # "docs: close #215 doc gaps" -- prose in a subject
+        "e3922b3": ["#111"],  # "Salvaged from the closed #111 report:"
+    }
+
+    flagged_prose: dict[str, list[str]] = {}
+    trailer_shas: set[str] = set()
+    for record in log.split("\x1e"):
+        record = record.strip()
+        if not record:
+            continue
+        sha, _, body = record.partition("\x00")
+        matches = scan_text(body, sha[:7])
+        prose = sorted({m.reference for m in matches if not m.is_trailer})
+        if prose:
+            flagged_prose[sha[:7]] = prose
+        if any(m.is_trailer for m in matches):
+            trailer_shas.add(sha[:7])
+
+    assert flagged_prose == EXPECTED_PROSE, (
+        "replay drifted from the known corpus. New keys are either a real "
+        f"accidental closure or a regex false positive: {flagged_prose}"
+    )
+
+    # Sanity on the other half: deliberate trailers must be recognized and
+    # allowed, or the guard degenerates into a bypass-on-every-PR ritual.
+    assert len(trailer_shas) >= 15, (
+        f"expected the historical `Closes #N` trailers to be classified "
+        f"deliberate; only found {len(trailer_shas)}"
+    )
+
+
+def test_hook_is_executable_and_rejects_the_incident(tmp_path):
+    """End-to-end: the hook script itself, not just the Python behind it."""
+    hook = REPO_ROOT / ".githooks" / "commit-msg"
+    assert hook.exists(), "commit-msg hook missing"
+
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text(INCIDENT_COMMIT_MSG, encoding="utf-8")
+
+    env = {"PATH": "/usr/bin:/bin:/usr/local/bin"}
+    result = subprocess.run(
+        ["bash", str(hook), str(msg)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 1
+    assert "#172" in result.stderr


### PR DESCRIPTION
> **Note on this description:** every closing keyword below is written with its
> issue number bracketed (`fixes [#172]`) or as a `#NNN` placeholder. Written
> normally, merging this PR would close five issues — including #172 for the
> third time. That is the bug, demonstrated.

## Problem

Issue #172 was closed twice by GitHub's closing-keyword parser, neither time because work landed:

| When | Vector | Text |
|---|---|---|
| 2026-07-31 05:47Z | PR #202 body (triage brief) | ``#191 (Copilot, fixes [#172])`` |
| 2026-07-31 13:08Z | commit `98643ce`, **pushed directly to main** | `...bug that closed [#172] by accident` |

The second is the one that matters: the guard added after the first incident lived only in the triage routine's prompt, and only checked PR bodies — so a commit pushed straight to `main` went right past it. The issue closed **four seconds** after that push.

An outside user noticed the closed-but-unfinished issue on 2026-08-04, and it sat unanswered for three days, because the triage routine queries `is:open` — which structurally cannot see a comment on a wrongly-closed issue.

## Approach

One detector, two enforcement points, so they cannot drift apart:

- **`scripts/check_closing_keywords.py`** — matches GitHub's own grammar (bare `#N`, `GH-N`, `owner/repo#N`, issue URLs).
- **`.githooks/commit-msg`** — prevention for the direct-to-main vector. CI can only ever notice that one *after* the issue has closed.
- **`.github/workflows/closing-keyword-guard.yml`** — PR body + PR commits (preventive); pushes to `main` (detective, so a bypassed hook is loud instead of silent).

Install once per clone: `./scripts/install-hooks.sh`

### Prose vs trailer

Blocks keywords **mid-sentence**, allows ones that **open a line**:

```
Closes #NNN                          -> allowed  (deliberate trailer)
docs: log the bug that closed #NNN   -> blocked  (narration)
```

This split came out of the acceptance replay, not from taste. The regex alone flagged **20** commits on `main` — **18** were ordinary trailers on fix PRs. Blocking those would have meant an escape hatch on nearly every PR, and a bypass used routinely stops being read. Every accidental closure in this repo's history is mid-sentence; every deliberate one opens its line. Deliberate closes are still reported in the log, just not blocked. `--strict` blocks both.

## What the replay found that the fixtures did not

Three accidental closing directives nobody had recorded:

- `98643ce` also contained **"four issues closed: [#203]"** — a second live directive inside the very commit from the incident report
- `2bee9f2` — `docs: close [#215] doc gaps` (prose in a subject line)
- `e3922b3` — `Salvaged from the closed [#111] weekly-maintenance report:`

My hand-written fixture for `98643ce` missed its second reference entirely; only replaying against real `git log` caught it. Fixtures now quote the real artifacts verbatim.

## Testing

41 new tests. Suite 987 -> 1028, ruff and mypy clean. Includes `test_acceptance_replay_real_history`, which pins the expected set against actual history so a regex change that starts over- or under-matching fails loudly.

The hook is live in this clone, so this PR's own commit message had to pass it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to git hooks, CI, and a standalone script with tests; no runtime or Canvas MCP behavior is affected.
> 
> **Overview**
> Adds a **closing-keyword guard** so mid-sentence `fixes/closes/resolves #N` in commit messages and PR text cannot silently auto-close issues (the vector that closed issue 172 twice).
> 
> **`scripts/check_closing_keywords.py`** is the shared detector (GitHub-style keywords and issue reference forms). It **blocks prose** matches and **allows line-opening trailers** like `Closes issue 173`; optional `--strict`, `ALLOW_CLOSING_KEYWORD`, and PR label `allow-closing-keyword` provide escape hatches.
> 
> Enforcement is wired in three places: **`.githooks/commit-msg`** (blocks before commit; fail-open if the script is missing), **`scripts/install-hooks.sh`** (sets `core.hooksPath` to `.githooks`), and **`.github/workflows/closing-keyword-guard.yml`** (scans PR bodies—including on `edited`—and all PR commits before merge; scans pushes to `main` as a loud backstop). **`CLAUDE.md`** documents install and rephrase guidance.
> 
> **`tests/test_closing_keyword_guard.py`** adds incident fixtures, trailer vs prose cases, CLI/hook E2E, and `test_acceptance_replay_real_history` pinned to known accidental closures on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8533c7680b2ad10c9ad1ece9f9a250d743dc582a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


