### PR TITLE
fix: close three bypasses in the closing-keyword guard

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -15,6 +15,17 @@ checker="$repo_root/scripts/check_closing_keywords.py"
 # an older revision). Fail open here; CI is the backstop.
 [ -f "$checker" ] || exit 0
 
-python3 "$checker" "$1" \
+# Only ask the checker to apply git's comment/scissors cleanup when git will
+# actually perform it. Under `whitespace` or `verbatim`, `#` lines survive into
+# the stored message and GitHub parses them, so they must be scanned.
+cleanup="$(git config --get commit.cleanup || echo default)"
+case "$cleanup" in
+  default | strip) git_comments="--git-comments" ;;
+  scissors)        git_comments="--git-comments" ;;
+  *)               git_comments="" ;;
+esac
+
+# shellcheck disable=SC2086
+python3 "$checker" "$1" $git_comments \
   --label "commit message" \
   --bypass-hint "ALLOW_CLOSING_KEYWORD=1 git commit ..."

--- a/.github/workflows/closing-keyword-guard.yml
+++ b/.github/workflows/closing-keyword-guard.yml
@@ -31,7 +31,12 @@ permissions:
 jobs:
   scan-pull-request:
     name: PR body and commits
-    if: github.event_name == 'pull_request'
+    # GitHub only honors closing keywords when the PR targets the DEFAULT
+    # branch. Enforcing on a PR into any other base is pure friction: nothing
+    # would close on merge.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     env:
       # The escape hatch for a PR that genuinely means to close an issue from
@@ -64,7 +69,7 @@ jobs:
           while read -r sha; do
             [ -z "$sha" ] && continue
             git log -1 --format=%B "$sha" \
-              | python3 scripts/check_closing_keywords.py - \
+              | python3 scripts/check_closing_keywords.py - --git-comments \
                   --label "commit ${sha:0:7}" \
                   --bypass-hint "intentional? add the 'allow-closing-keyword' label to this PR" \
               || status=1
@@ -95,7 +100,7 @@ jobs:
           while read -r sha; do
             [ -z "$sha" ] && continue
             git log -1 --format=%B "$sha" \
-              | python3 scripts/check_closing_keywords.py - \
+              | python3 scripts/check_closing_keywords.py - --git-comments \
                   --label "commit ${sha:0:7} (already on main)" \
                   --bypass-hint "if the closure was intended, no action needed" \
               || status=1

--- a/scripts/check_closing_keywords.py
+++ b/scripts/check_closing_keywords.py
@@ -82,7 +82,35 @@ BYPASS_ENV = "ALLOW_CLOSING_KEYWORD"
 # hatch on nearly every fix PR, and a bypass used routinely stops being read.
 #
 # Leading list markers count as "start": "- Closes #12" is still a trailer.
-_LINE_PREFIX = re.compile(r"^[\s>*\-+]*")
+#
+# This must match *real* markdown markers only. An earlier version consumed any
+# run of [\s>*\-+], which handed the trailer exemption to "--- fixes #172 was
+# emitted by the bot" -- three hyphens are neither a list marker nor, followed
+# by prose, a thematic break. A bullet requires whitespace after it.
+_LINE_PREFIX = re.compile(
+    r"""^
+    [ \t]*                    # indent
+    (?:>[ \t]*)*              # blockquote markers, possibly nested
+    (?:
+        [-*+][ \t]+           # bullet: marker MUST be followed by whitespace
+      | \d+[.)][ \t]+         # ordered list item
+    )?
+    [ \t]*
+    """,
+    re.VERBOSE,
+)
+
+# Only separators may sit between two references for both to count as part of
+# the same deliberate trailer ("Closes #199, closes #198"). Prose in between
+# means the later reference is narration -- see _classify_line.
+_ONLY_SEPARATORS = re.compile(r"^(?:[\s,;&/]|and\b)*$", re.IGNORECASE)
+
+# `git commit` strips `#` comment lines and everything after a scissors line,
+# but ONLY under some cleanup modes -- and never in a PR body, where `#` opens
+# a markdown heading that GitHub parses like any other text. Applying git's
+# rules to a PR body is how "## Incident report: the bot fixes #172" slipped
+# through as a "comment".
+_SCISSORS = re.compile(r"^#[ \t]*-+[ \t]*>8[ \t]*-+")
 
 
 @dataclass(frozen=True)
@@ -103,25 +131,61 @@ def _content_start(line: str) -> int:
     return _LINE_PREFIX.match(line).end()
 
 
-def scan_text(text: str, source: str = "<text>") -> list[Match]:
+def _classify_line(line: str) -> list[tuple[re.Match[str], bool]]:
+    """Pair each match on ``line`` with whether it is a deliberate trailer.
+
+    Trailer status is earned per match, not granted per line. The first match
+    qualifies by opening the line; each later one qualifies only if nothing but
+    separators sits between it and the previous qualifying match. So
+    "Closes #199, closes #198" is entirely deliberate, while
+    "Closes #173. Historical note: the old bot fixes #172 by accident."
+    is deliberate for #173 and narration for #172 -- which is exactly the
+    accidental closure this guard exists to catch, and which an earlier
+    per-line rule laundered through.
+    """
+    matches = list(CLOSING_PATTERN.finditer(line))
+    if not matches:
+        return []
+
+    out: list[tuple[re.Match[str], bool]] = []
+    cursor = _content_start(line)
+    still_trailer = True
+    for m in matches:
+        if still_trailer and _ONLY_SEPARATORS.match(line[cursor:m.start()]):
+            out.append((m, True))
+            cursor = m.end()
+        else:
+            still_trailer = False
+            out.append((m, False))
+    return out
+
+
+def scan_text(
+    text: str, source: str = "<text>", *, git_comments: bool = False
+) -> list[Match]:
     """Return every closing-keyword reference in ``text``.
 
-    Comment lines are skipped: git strips them before the message is stored,
-    so a `#` -prefixed line never reaches GitHub's parser. Scanning them would
-    flag the commit template's own instructions on every single commit.
+    ``git_comments`` applies `git commit`'s own message cleanup before
+    scanning: drop `#` comment lines and truncate at a scissors marker. Pass it
+    ONLY for text git will actually clean up that way -- a commit message under
+    the default/strip cleanup mode. It must never be set for a PR body, where
+    `#` opens a markdown heading that GitHub parses like any other prose.
     """
+    if git_comments:
+        kept = []
+        for line in text.splitlines():
+            if _SCISSORS.match(line):
+                break
+            if line.lstrip().startswith("#"):
+                continue
+            kept.append(line)
+        lines = list(enumerate(kept, start=1))
+    else:
+        lines = list(enumerate(text.splitlines(), start=1))
+
     found: list[Match] = []
-    for lineno, line in enumerate(text.splitlines(), start=1):
-        if line.lstrip().startswith("#"):
-            continue
-        line_matches = list(CLOSING_PATTERN.finditer(line))
-        if not line_matches:
-            continue
-        # Deliberateness is a property of the line, not of each reference: once
-        # a line opens as a trailer, everything it goes on to list is equally
-        # intended ("Closes #199, closes #198").
-        is_trailer = line_matches[0].start() == _content_start(line)
-        for m in line_matches:
+    for lineno, line in lines:
+        for m, is_trailer in _classify_line(line):
             found.append(
                 Match(
                     source=source,
@@ -174,6 +238,14 @@ def main(argv: list[str] | None = None) -> int:
         help="also fail on deliberate trailer lines (e.g. 'Closes #12'), "
         "which are allowed by default",
     )
+    parser.add_argument(
+        "--git-comments",
+        action="store_true",
+        help="apply git's commit-message cleanup before scanning: drop '#' "
+        "comment lines and truncate at a scissors marker. ONLY for commit "
+        "messages under default/strip cleanup -- never for a PR body, where "
+        "'#' opens a markdown heading that GitHub parses as prose.",
+    )
     args = parser.parse_args(argv)
 
     if os.environ.get(BYPASS_ENV):
@@ -183,10 +255,16 @@ def main(argv: list[str] | None = None) -> int:
     matches: list[Match] = []
     for path in args.paths:
         if path == "-":
-            matches += scan_text(sys.stdin.read(), args.label or "<stdin>")
+            matches += scan_text(
+                sys.stdin.read(),
+                args.label or "<stdin>",
+                git_comments=args.git_comments,
+            )
         else:
             with open(path, encoding="utf-8") as fh:
-                matches += scan_text(fh.read(), args.label or path)
+                matches += scan_text(
+                    fh.read(), args.label or path, git_comments=args.git_comments
+                )
 
     blocking = matches if args.strict else [m for m in matches if not m.is_trailer]
 

--- a/tests/test_closing_keyword_guard.py
+++ b/tests/test_closing_keyword_guard.py
@@ -171,10 +171,78 @@ def test_strict_mode_blocks_trailers_too(tmp_path, monkeypatch):
     assert main([str(msg), "--strict"]) == 1
 
 
-def test_skips_comment_lines():
-    """Git strips `#` lines before storing, so they never reach GitHub."""
+def test_skips_comment_lines_only_under_git_cleanup():
+    """`#` lines are git comments in a commit message -- and nowhere else."""
     msg = "docs: update notes\n\n# On branch main\n# fixes #172 <- template noise\n"
-    assert scan_text(msg) == []
+    assert scan_text(msg, git_comments=True) == []
+    # Without the flag the same text is scanned, because in a PR body `#`
+    # opens a heading that GitHub parses like any other prose.
+    assert scan_text(msg) != []
+
+
+def test_git_comments_truncates_at_scissors():
+    """Git discards the scissors line and everything after it."""
+    msg = (
+        "docs: record example\n\n"
+        "# ------------------------ >8 ------------------------\n"
+        "Template reminder: never write fixes #172 in prose.\n"
+    )
+    assert scan_text(msg, git_comments=True) == []
+    assert scan_text(msg) != []
+
+
+# --------------------------------------------------------------------------
+# Red-team regressions (2026-08-08)
+#
+# Found by an independent adversarial pass over the shipped guard. Every input
+# below is quoted verbatim from that run and returned exit 0 -- a silent
+# bypass -- before these fixes. All three trace to design decisions made when
+# the guard was written, not to exotic edge cases.
+# --------------------------------------------------------------------------
+
+
+def test_markdown_heading_is_not_a_comment():
+    """FN1, critical: `## ... fixes #172` in a PR body closes #172 on merge.
+
+    The original blanket `#`-line skip was justified by git's comment
+    stripping, which does not apply to a PR body at all. The acceptance replay
+    never caught it because it replayed `git log` only -- never a PR body.
+    """
+    line = "## Incident report: the bot fixes #172 by accident."
+    matches = scan_text(line)
+    assert [m.reference for m in matches] == ["#172"]
+    assert not matches[0].is_trailer, "a heading is prose, not a trailer"
+
+
+def test_trailer_does_not_launder_later_prose_on_the_same_line():
+    """FN2: a real trailer must not grant amnesty to narration after it."""
+    line = "Closes #173. Historical note: the old bot fixes #172 by accident."
+    by_ref = {m.reference: m.is_trailer for m in scan_text(line)}
+    assert by_ref == {"#173": True, "#172": False}
+
+
+def test_punctuation_run_is_not_a_list_marker():
+    """FN3: `---` is not a bullet, so it earns no trailer exemption."""
+    line = "--- fixes #172 was emitted by the bot, not requested by us."
+    matches = scan_text(line)
+    assert matches and not matches[0].is_trailer
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "- Closes #12",
+        "* Closes #12",
+        "+ Closes #12",
+        "> Closes #12",
+        "  - Closes #12",
+        "1. Closes #12",
+    ],
+)
+def test_real_list_and_quote_markers_still_earn_the_exemption(line):
+    """The FN3 fix must not break genuine markdown markers."""
+    matches = scan_text(line)
+    assert matches and matches[0].is_trailer
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
> Closing keywords below are written with bracketed issue numbers so this PR does not close anything on merge.

An independent adversarial pass over the guard shipped this morning (PR #231) found **three silent bypasses**. All three trace to design decisions I made when writing it — not exotic edge cases.

## Bypasses

| Sev | Input | Was | Now |
|---|---|---|---|
| **Critical** | `## Incident report: the bot fixes [#172] by accident.` | exit 0 | exit 1 |
| **High** | `Closes [#173]. Historical note: the old bot fixes [#172] by accident.` | exit 0 | exit 1 |
| **Medium** | `--- fixes [#172] was emitted by the bot, not requested by us.` | exit 0 | exit 1 |

**1. Critical — `#` lines.** Every `#`-prefixed line was skipped as a git comment. That is correct for a commit message and wrong for a PR body, where `#` opens a markdown heading GitHub parses like any other prose — and one function scanned both surfaces. A heading is close to the most likely thing anyone writes in a PR body, so the guard failed open on its most probable real input.

Cleanup is now opt-in via `--git-comments`, set by the hook (and only under cleanup modes where git actually strips) and by the CI commit scans, deliberately **not** by the PR-body scan.

**2. High — trailer laundering.** Trailer status was decided once per line from the first match, then applied to every later match. A legitimate `Closes [#173]` therefore granted amnesty to narration after it on the same line. Status is now earned per match: a later reference qualifies only if nothing but separators sits between it and the previous qualifying one. `Closes [#199], closes [#198]` still passes as one deliberate trailer.

**3. Medium — fake list markers.** The prefix pattern consumed any run of `[\s>*\-+]`, so `---` bought the trailer exemption. It now matches real markdown only — a bullet requires trailing whitespace. Genuine markers (`-`, `*`, `+`, `>`, `1.`, nested, indented) are covered by tests.

## False positives also fixed

- The PR job no longer runs when the base branch is not the default branch. GitHub ignores closing keywords there, so blocking was pure friction.
- `--git-comments` truncates at a `scissors` marker, which git discards before storing.

## The real lesson

My acceptance replay felt rigorous and was half-blind: it replayed `git log` and **never scanned a single PR body** — the exact surface where the `#` assumption is wrong. A replay validates the corpus you point it at.

So the replay is now extended to that surface. Over **100 real PR bodies**:

- **Zero false positives**
- **Two true positives** — PR #202, the original incident (`#191 (Copilot, fixes [#172])`), and PR #187, which carried a previously unnoticed second accidental closure (`PR #186 ... fixes [#175]`)
- 29 PRs with deliberate trailers, all correctly allowed — so no new friction

## Testing

51 guard tests (up from 41), every red-team input pinned verbatim as a regression. Suite **1038 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
