### PR TITLE
fix: make include_announcements on list_discussion_topics actually work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ Course management, grading, and analytics. Requires instructor/TA role.
 | `send_conversation` | Message students |
 | `send_peer_review_reminders` | Automated reminder workflow |
 | `create_announcement` | Post course announcements |
+| `list_announcements` | Course announcements (educator-only — students should use `list_discussion_topics` with `include_announcements`) |
 | `update_discussion_topic` | Edit discussion or announcement title/body and settings |
 
 ### Shared Tools (Students & Educators)
@@ -125,8 +126,7 @@ Content access tools available to all authenticated users.
 | `add_module_item` | Add content to a module |
 | `update_module_item` | Update module item settings |
 | `delete_module_item` | Remove item from module |
-| `list_announcements` | Course announcements |
-| `list_discussion_topics` | Discussion forums |
+| `list_discussion_topics` | Discussion forums (discussions only; set `include_announcements` to also list announcements) |
 | `list_discussion_entries` | Posts in a discussion |
 | `post_discussion_entry` | Add a discussion post |
 | `reply_to_discussion_entry` | Reply to a post |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,6 @@ Course management, grading, and analytics. Requires instructor/TA role.
 | `send_conversation` | Message students |
 | `send_peer_review_reminders` | Automated reminder workflow |
 | `create_announcement` | Post course announcements |
-| `list_announcements` | Course announcements (educator-only — students should use `list_discussion_topics` with `include_announcements`) |
 | `update_discussion_topic` | Edit discussion or announcement title/body and settings |
 
 ### Shared Tools (Students & Educators)
@@ -126,6 +125,7 @@ Content access tools available to all authenticated users.
 | `add_module_item` | Add content to a module |
 | `update_module_item` | Update module item settings |
 | `delete_module_item` | Remove item from module |
+| `list_announcements` | Course announcements, and nothing else |
 | `list_discussion_topics` | Discussion forums (discussions only; set `include_announcements` to also list announcements) |
 | `list_discussion_entries` | Posts in a discussion |
 | `post_discussion_entry` | Add a discussion post |

--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -26,21 +26,49 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
                                    include_announcements: bool = False) -> str:
         """List discussion topics for a specific course.
 
+        Returns discussion topics only. Announcements are a separate Canvas
+        collection and are NOT included unless include_announcements=True.
+        To list announcements on their own, use list_announcements instead.
+
         Args:
             course_identifier: Course code or Canvas ID
-            include_announcements: Include announcements in the list (default: False)
+            include_announcements: Also list the course's announcements
+                alongside its discussion topics (default: False). Each entry is
+                labelled "Type: Announcement" or "Type: Discussion".
         """
         course_id = await get_course_id(course_identifier)
 
-        params: dict[str, Any] = {"per_page": 100}
-
-        if include_announcements:
-            params["include[]"] = ["announcement"]
-
-        topics = await fetch_all_paginated_results(f"/courses/{course_id}/discussion_topics", params)
+        # Canvas serves discussions and announcements from the same endpoint but
+        # as disjoint sets: the index excludes announcements unless
+        # only_announcements=true, which then excludes ordinary discussions.
+        # There is no single query returning both, so combining requires two
+        # calls. (include[]=announcement is NOT a supported include value --
+        # Canvas silently ignores it. Issue #238.)
+        topics = await fetch_all_paginated_results(
+            f"/courses/{course_id}/discussion_topics", {"per_page": 100}
+        )
 
         if isinstance(topics, dict) and "error" in topics:
             return f"Error fetching discussion topics: {topics['error']}"
+
+        if include_announcements:
+            announcements = await fetch_all_paginated_results(
+                f"/courses/{course_id}/discussion_topics",
+                {"only_announcements": True, "per_page": 100},
+            )
+            if isinstance(announcements, dict) and "error" in announcements:
+                # Announcements are commonly restricted separately; degrade to
+                # the discussions we did get rather than failing the whole call.
+                log_warning(
+                    "list_discussion_topics: announcements unavailable",
+                    course_id=course_id,
+                    error=announcements["error"],
+                )
+            elif announcements:
+                seen = {topic.get("id") for topic in topics}
+                topics = list(topics) + [
+                    a for a in announcements if a.get("id") not in seen
+                ]
 
         if not topics:
             return f"No discussion topics found for course {course_identifier}."
@@ -904,7 +932,9 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
         course_id = await get_course_id(course_identifier)
 
         params = {
-            "include[]": ["announcement"],
+            # only_announcements is the filter Canvas honours. include[]=announcement
+            # is NOT a supported include value and is silently ignored (issue #238);
+            # measured identical result sets with and without it.
             "only_announcements": True,
             "per_page": 100
         }
@@ -1265,7 +1295,9 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
 
         # First list all announcements
         params = {
-            "include[]": ["announcement"],
+            # only_announcements is the filter Canvas honours. include[]=announcement
+            # is NOT a supported include value and is silently ignored (issue #238);
+            # measured identical result sets with and without it.
             "only_announcements": True,
             "per_page": 100
         }

--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -93,6 +93,48 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     @validate_params
+    async def list_announcements(course_identifier: str) -> str:
+        """List a course's announcements, and nothing else.
+
+        Returns announcements only -- ordinary discussion topics are excluded.
+        Use list_discussion_topics for discussions.
+
+        Args:
+            course_identifier: Course code or Canvas ID
+        """
+        course_id = await get_course_id(course_identifier)
+
+        params = {
+            # only_announcements is the filter Canvas honours. include[]=announcement
+            # is NOT a supported include value and is silently ignored (issue #238);
+            # measured identical result sets with and without it.
+            "only_announcements": True,
+            "per_page": 100
+        }
+
+        announcements = await fetch_all_paginated_results(f"/courses/{course_id}/discussion_topics", params)
+
+        if isinstance(announcements, dict) and "error" in announcements:
+            return f"Error fetching announcements: {announcements['error']}"
+
+        if not announcements:
+            return f"No announcements found for course {course_identifier}."
+
+        announcements_info = []
+        for announcement in announcements:
+            announcement_id = announcement.get("id")
+            title = announcement.get("title", "Untitled announcement")
+            posted_at = format_date(announcement.get("posted_at"))
+
+            announcements_info.append(
+                f"ID: {announcement_id}\nTitle: {title}\nPosted: {posted_at}\n"
+            )
+
+        course_display = await get_course_code(course_id) or course_identifier
+        return f"Announcements for Course {course_display}:\n\n" + "\n".join(announcements_info)
+
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @validate_params
     async def get_discussion_topic_details(course_identifier: str | int,
                                          topic_id: str | int) -> str:
         """Get detailed information about a specific discussion topic.
@@ -920,45 +962,6 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
         return result
 
     # ===== ANNOUNCEMENT TOOLS =====
-
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-    @validate_params
-    async def list_announcements(course_identifier: str) -> str:
-        """List announcements for a specific course.
-
-        Args:
-            course_identifier: Course code or Canvas ID
-        """
-        course_id = await get_course_id(course_identifier)
-
-        params = {
-            # only_announcements is the filter Canvas honours. include[]=announcement
-            # is NOT a supported include value and is silently ignored (issue #238);
-            # measured identical result sets with and without it.
-            "only_announcements": True,
-            "per_page": 100
-        }
-
-        announcements = await fetch_all_paginated_results(f"/courses/{course_id}/discussion_topics", params)
-
-        if isinstance(announcements, dict) and "error" in announcements:
-            return f"Error fetching announcements: {announcements['error']}"
-
-        if not announcements:
-            return f"No announcements found for course {course_identifier}."
-
-        announcements_info = []
-        for announcement in announcements:
-            announcement_id = announcement.get("id")
-            title = announcement.get("title", "Untitled announcement")
-            posted_at = format_date(announcement.get("posted_at"))
-
-            announcements_info.append(
-                f"ID: {announcement_id}\nTitle: {title}\nPosted: {posted_at}\n"
-            )
-
-        course_display = await get_course_code(course_id) or course_identifier
-        return f"Announcements for Course {course_display}:\n\n" + "\n".join(announcements_info)
 
     @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
     @validate_params

--- a/tests/test_role_filtering.py
+++ b/tests/test_role_filtering.py
@@ -35,6 +35,9 @@ SHARED_TOOLS = {
     "get_assignment_details",
     # shared discussions
     "list_discussion_topics",
+    # Announcements are student-visible course content and this tool is
+    # read-only, so every role gets an announcements-only listing (issue #238).
+    "list_announcements",
     "get_discussion_topic_details",
     "list_discussion_entries",
     "get_discussion_entry_details",

--- a/tests/tools/test_discussions.py
+++ b/tests/tools/test_discussions.py
@@ -182,26 +182,162 @@ class TestUpdateDiscussionTopic:
         assert "Type: Announcement" in result
 
 
-class TestDiscussionTools:
-    """Test discussion tool functions."""
+class TestListDiscussionTopics:
+    """Tests for list_discussion_topics (issue #238).
+
+    Canvas's ``GET /courses/:id/discussion_topics`` index excludes announcements
+    unless ``only_announcements=true`` is passed. ``include[]=announcement`` is
+    NOT a supported include value and is silently ignored -- measured live on
+    2026-08-08 against course 41635: with and without it the endpoint returned
+    the same 19 topics, 0 of them announcements.
+    """
 
     @pytest.mark.asyncio
-    async def test_list_discussion_topics(self):
-        """Test listing discussion topics."""
-        mock_topics = [
-            {"id": 1, "title": "Topic 1", "posted_at": "2024-01-15"},
-            {"id": 2, "title": "Topic 2", "posted_at": "2024-01-20"}
+    async def test_list_discussion_topics(self, mock_canvas_api):
+        """Default call lists discussion topics via the tool itself."""
+        mock_canvas_api['fetch_all_paginated_results'].return_value = [
+            {"id": 1, "title": "Topic 1", "posted_at": "2024-01-15", "published": True},
+            {"id": 2, "title": "Topic 2", "posted_at": "2024-01-20", "published": True},
         ]
 
-        with patch('canvas_mcp.core.client.fetch_all_paginated_results', new_callable=AsyncMock) as mock_fetch:
-            mock_fetch.return_value = mock_topics
+        list_discussion_topics = get_tool_function('list_discussion_topics')
+        result = await list_discussion_topics("badm_350_120251")
 
-            from canvas_mcp.core.client import fetch_all_paginated_results
+        assert "Topic 1" in result
+        assert "Topic 2" in result
+        assert "Type: Discussion" in result
 
-            result = await fetch_all_paginated_results("/courses/12345/discussion_topics", {})
+    @pytest.mark.asyncio
+    async def test_default_does_not_request_announcements(self, mock_canvas_api):
+        """Default call must not ask Canvas for announcements at all."""
+        mock_canvas_api['fetch_all_paginated_results'].return_value = []
 
-            assert len(result) == 2
-            assert result[0]["title"] == "Topic 1"
+        list_discussion_topics = get_tool_function('list_discussion_topics')
+        await list_discussion_topics("badm_350_120251")
+
+        assert mock_canvas_api['fetch_all_paginated_results'].call_count == 1
+        params = mock_canvas_api['fetch_all_paginated_results'].call_args[0][1]
+        assert "only_announcements" not in params
+
+    @pytest.mark.asyncio
+    async def test_never_sends_unsupported_include_announcement(self, mock_canvas_api):
+        """``include[]=announcement`` is not a valid Canvas include -- never send it."""
+        mock_canvas_api['fetch_all_paginated_results'].return_value = []
+
+        list_discussion_topics = get_tool_function('list_discussion_topics')
+        await list_discussion_topics("badm_350_120251", include_announcements=True)
+
+        for call in mock_canvas_api['fetch_all_paginated_results'].call_args_list:
+            params = call[0][1]
+            assert "announcement" not in params.get("include[]", [])
+
+    @pytest.mark.asyncio
+    async def test_include_announcements_actually_returns_announcements(self, mock_canvas_api):
+        """include_announcements=True must really yield announcements, not just discussions.
+
+        This is the issue #238 regression: the flag used to set an ignored
+        ``include[]`` value, so the caller got discussions only while believing
+        announcements were included.
+        """
+        mock_canvas_api['fetch_all_paginated_results'].side_effect = [
+            [{"id": 1, "title": "Week 1 discussion", "posted_at": "2024-01-15",
+              "published": True, "is_announcement": False}],
+            [{"id": 9, "title": "Exam moved", "posted_at": "2024-01-20",
+              "published": True, "is_announcement": True}],
+        ]
+
+        list_discussion_topics = get_tool_function('list_discussion_topics')
+        result = await list_discussion_topics("badm_350_120251", include_announcements=True)
+
+        assert mock_canvas_api['fetch_all_paginated_results'].call_count == 2
+        announcement_params = mock_canvas_api['fetch_all_paginated_results'].call_args_list[1][0][1]
+        assert announcement_params["only_announcements"] is True
+
+        assert "Week 1 discussion" in result
+        assert "Exam moved" in result
+        assert "Type: Announcement" in result
+        assert "Type: Discussion" in result
+
+    @pytest.mark.asyncio
+    async def test_include_announcements_deduplicates(self, mock_canvas_api):
+        """A topic returned by both queries must appear once."""
+        duplicate = {"id": 9, "title": "Exam moved", "posted_at": "2024-01-20",
+                     "published": True, "is_announcement": True}
+        mock_canvas_api['fetch_all_paginated_results'].side_effect = [
+            [duplicate], [dict(duplicate)],
+        ]
+
+        list_discussion_topics = get_tool_function('list_discussion_topics')
+        result = await list_discussion_topics("badm_350_120251", include_announcements=True)
+
+        assert result.count("Exam moved") == 1
+
+    @pytest.mark.asyncio
+    async def test_include_announcements_survives_announcement_error(self, mock_canvas_api):
+        """If the announcements query errors, still return the discussions."""
+        mock_canvas_api['fetch_all_paginated_results'].side_effect = [
+            [{"id": 1, "title": "Week 1 discussion", "posted_at": "2024-01-15",
+              "published": True, "is_announcement": False}],
+            {"error": "403 Forbidden"},
+        ]
+
+        list_discussion_topics = get_tool_function('list_discussion_topics')
+        result = await list_discussion_topics("badm_350_120251", include_announcements=True)
+
+        assert "Week 1 discussion" in result
+
+    @pytest.mark.asyncio
+    async def test_error_response_surfaces(self, mock_canvas_api):
+        """A failing primary query returns a readable error."""
+        mock_canvas_api['fetch_all_paginated_results'].return_value = {"error": "404 Not Found"}
+
+        list_discussion_topics = get_tool_function('list_discussion_topics')
+        result = await list_discussion_topics("badm_350_120251")
+
+        assert "Error fetching discussion topics" in result
+
+
+class TestListAnnouncements:
+    """Tests for list_announcements (issue #238)."""
+
+    @pytest.mark.asyncio
+    async def test_sends_only_announcements_filter(self, mock_canvas_api):
+        """The announcements listing must filter server-side."""
+        mock_canvas_api['fetch_all_paginated_results'].return_value = []
+
+        list_announcements = get_tool_function('list_announcements')
+        await list_announcements("badm_350_120251")
+
+        params = mock_canvas_api['fetch_all_paginated_results'].call_args[0][1]
+        assert params["only_announcements"] is True
+
+    @pytest.mark.asyncio
+    async def test_does_not_send_unsupported_include(self, mock_canvas_api):
+        """``include[]=announcement`` is a no-op against Canvas -- drop it."""
+        mock_canvas_api['fetch_all_paginated_results'].return_value = []
+
+        list_announcements = get_tool_function('list_announcements')
+        await list_announcements("badm_350_120251")
+
+        params = mock_canvas_api['fetch_all_paginated_results'].call_args[0][1]
+        assert "include[]" not in params
+
+    @pytest.mark.asyncio
+    async def test_lists_announcements(self, mock_canvas_api):
+        """Announcements are rendered with id, title and post date."""
+        mock_canvas_api['fetch_all_paginated_results'].return_value = [
+            {"id": 9, "title": "Exam moved", "posted_at": "2024-01-20", "is_announcement": True},
+        ]
+
+        list_announcements = get_tool_function('list_announcements')
+        result = await list_announcements("badm_350_120251")
+
+        assert "Exam moved" in result
+        assert "ID: 9" in result
+
+
+class TestDiscussionTools:
+    """Test discussion tool functions."""
 
     @pytest.mark.asyncio
     async def test_list_discussion_entries(self):

--- a/tools/README.md
+++ b/tools/README.md
@@ -1727,11 +1727,15 @@ View course announcements.
 ### Discussions
 
 #### `list_discussion_topics`
-View discussion forums in a course.
+View discussion forums in a course. Returns discussion topics only — announcements
+are a separate Canvas collection and are excluded unless you opt in.
 
 **Parameters:**
 - `course_identifier`: Course code or ID
-- `only_announcements` (optional): Filter for announcements only
+- `include_announcements` (optional, default `false`): Also list the course's
+  announcements alongside its discussion topics. Each entry is labelled
+  `Type: Announcement` or `Type: Discussion`. To list announcements on their
+  own, use [`list_announcements`](#list_announcements) instead.
 
 **Example:**
 ```

--- a/tools/TOOL_MANIFEST.json
+++ b/tools/TOOL_MANIFEST.json
@@ -2209,8 +2209,8 @@
     },
     {
       "name": "list_announcements",
-      "category": "educator",
-      "description": "List announcements for a specific course.",
+      "category": "shared",
+      "description": "List a course's announcements, and nothing else. Ordinary discussion topics are excluded; use list_discussion_topics for those.",
       "parameters": [
         {
           "name": "course_identifier",

--- a/tools/TOOL_MANIFEST.json
+++ b/tools/TOOL_MANIFEST.json
@@ -561,7 +561,7 @@
     {
       "name": "list_discussion_topics",
       "category": "shared",
-      "description": "View discussion forums in a course",
+      "description": "View discussion forums in a course. Returns discussion topics only; announcements are excluded unless include_announcements is set. Use list_announcements to list announcements on their own.",
       "parameters": [
         {
           "name": "course_identifier",
@@ -570,11 +570,11 @@
           "description": "Course code or Canvas ID"
         },
         {
-          "name": "only_announcements",
+          "name": "include_announcements",
           "type": "boolean",
           "required": false,
           "default": false,
-          "description": "Filter for announcements only"
+          "description": "Also list the course's announcements alongside its discussion topics; each entry is labelled Type: Announcement or Type: Discussion"
         }
       ],
       "returns": "List of discussion topics with IDs and titles",


### PR DESCRIPTION
Closes #238

Asking for a course's announcements could return discussion topics instead.

## Root cause — measured, not inferred

Live A/B against course 41635 (44 announcements, 19 discussions):

| Query | total | announcements | discussions |
|---|---|---|---|
| no filter | 19 | 0 | 19 |
| `include[]=announcement` | 19 | 0 | 19 |
| `only_announcements=true` | 44 | 44 | 0 |

Rows 1 and 2 are identical: `include[]=announcement` is not a supported Canvas
include value and is silently ignored. So
`list_discussion_topics(include_announcements=True)` advertised announcements
and returned discussions only.

Canvas serves both kinds from `/courses/:id/discussion_topics` as **disjoint
sets** — `only_announcements` switches scope rather than widening it, so no
single query returns both. Combining now costs a deliberate second call, deduped
by id, degrading to discussions-only if announcements are restricted.

## Also corrected — all of these steer tool selection

- `tools/README.md` and `TOOL_MANIFEST.json` documented a parameter that does
  not exist: `only_announcements` on `list_discussion_topics`. Wrong name, and
  inverted semantics versus the real `include_announcements`. For an MCP tool
  the manifest *is* runtime behaviour, since it is what the model reads to pick.
- `AGENTS.md` listed `list_announcements` under shared tools; `server.py:354`
  registers it educator-only. A student-role agent could not find it and fell
  back to the broken flag.
- Dropped the dead `include[]=announcement` from `list_announcements` and
  `delete_announcements_by_criteria`. Measured identical result sets with and
  without it, so the destructive tool's target set is unchanged.

## The reporter's suggested endpoint was measured and rejected

`/announcements?context_codes[]=course_41635` returned **0** for this course —
it applies a default date window. With an explicit wide range it returned 44.
Adopting it as suggested would have shipped a silent "no announcements found".

## Tests

`test_list_discussion_topics` patched `fetch_all_paginated_results` and then
called `fetch_all_paginated_results`, never invoking the tool — it passed
regardless of the implementation. Replaced with a real invocation through the
registration path, plus coverage for: the second query being issued, the
unsupported include never being sent, dedup, graceful degradation when
announcements are restricted, and the error path.

Three of the new tests failed against the old code before the fix.

## Verification

- 1047 tests pass, 21 skipped; ruff and mypy clean.
- Post-fix live run: `include_announcements=True` returns 19 discussions + 44
  announcements (was 19 / 0).

## Second commit: every role gets an announcements-only tool

The first pass resolved the `AGENTS.md` / `server.py` mismatch in the wrong
direction — it documented the educator-only restriction instead of removing it,
which left student-role callers with no announcements-only tool and pointed them
at the mixed listing. That is the behaviour the reporter asked us to stop.

`list_announcements` is now registered as shared. Marginal data exposure is
**zero**: the first commit already surfaces every announcement to student callers
through `include_announcements`, so this adds a correctly scoped tool rather than
new access. It is read-only, announcements are student-visible course content,
and Canvas still enforces its own permissions on the request.

Measured registration across all three profiles:

```
role=student   list_announcements=True
role=educator  list_announcements=True
role=all       list_announcements=True
```

Added to `SHARED_TOOLS` in `test_role_filtering.py`; manifest category changed
from `educator` to `shared`.

Credit: this gap was caught by an independent Codex diagnosis run from the
`v1.6.0` tag, which framed the mismatch as a registration bug rather than a
documentation bug. It also independently confirmed the `include[]` finding
against Canvas's own controller source.
