### PR TITLE
fix: gate /front_page identity data like every other page route

### DIFF
--- a/src/canvas_mcp/core/client.py
+++ b/src/canvas_mcp/core/client.py
@@ -229,8 +229,11 @@ def _endpoint_anonymization_mode(endpoint: str) -> str:
       the participants are their own correspondents, not third parties whose
       records they are browsing — pseudonymising `participants[].name` would
       make "who emailed me?" unanswerable while protecting nobody.
-    - /pages, /courses/{id}/pages/{slug} -> ANONYMIZE_IDENTITY. Previously
-      ungated: `last_edited_by` leaked a display name and avatar URL. Page
+    - /pages, /courses/{id}/pages/{slug}, /courses/{id}/front_page ->
+      ANONYMIZE_IDENTITY. Previously ungated: `last_edited_by` leaked a display
+      name and avatar URL. front_page returns the same block but carries no
+      'pages' segment, so it stayed ungated after #179 until a live check found
+      it still returning display_name, pronouns and avatar_image_url. Page
       *bodies* are deliberately exempt — instructors publish office hours,
       contact addresses and phone numbers on course pages, and redacting those
       would break the page's purpose.
@@ -275,7 +278,12 @@ def _endpoint_anonymization_mode(endpoint: str) -> str:
     if _has_route_segment(segments, {'conversations'}):
         return ANONYMIZE_FREE_TEXT
 
-    if _has_route_segment(segments, {'pages'}):
+    # 'front_page' is a page too and returns the same last_edited_by block, but
+    # its path carries no 'pages' segment, so it slipped the slug rule and stayed
+    # ungated after #179. Unlike a page slug, 'front_page' is a fixed Canvas
+    # route word and cannot be user-controlled, so matching it needs no
+    # escalation guard.
+    if _has_route_segment(segments, {'pages'}) or 'front_page' in segments:
         return ANONYMIZE_IDENTITY
 
     return ANONYMIZE_NONE

--- a/tests/security/test_anonymization_endpoints.py
+++ b/tests/security/test_anonymization_endpoints.py
@@ -58,7 +58,6 @@ class TestShouldAnonymizeEndpoint:
         "/courses/123/modules/5/items",
         "/courses/123/assignments",       # assignment definitions, no student data
         "/courses/123/assignments/456",
-        "/courses/123/front_page",
         "/courses/123/rubrics/12",
         "/accounts/1/terms",
         # Group *listings* carry group names, not student names; membership is
@@ -129,6 +128,12 @@ class TestAnonymizationTierMapping:
         "/courses/123/pages/users",
         "/courses/123/pages/submissions",
         "/courses/123/pages/analytics",
+        # The front page is a page and returns the same last_edited_by block,
+        # but its path carries no 'pages' segment so the slug rule missed it.
+        # Measured live: last_edited_by came back with display_name, pronouns
+        # and avatar_image_url while /pages/{slug} was gated.
+        "/courses/123/front_page",
+        "/groups/55/front_page",
     ])
     def test_pages_are_identity_tier(self, endpoint):
         assert _endpoint_anonymization_mode(endpoint) == ANONYMIZE_IDENTITY
@@ -147,7 +152,6 @@ class TestAnonymizationTierMapping:
         "/courses",
         "/courses/123/modules",
         "/courses/123/assignments",
-        "/courses/123/front_page",
         "/accounts/1/terms",
         "/users/self/profile",
     ])


### PR DESCRIPTION
`/courses/{id}/front_page` returns the same `last_edited_by` block as any other
page (`display_name`, `pronouns`, `avatar_image_url`) but was not gated by the
anonymization tier rule, because the rule matches the `pages` path segment and
`front_page` has none.

```
before   none      /courses/1/front_page
         identity  /courses/1/pages/x
after    identity  /courses/1/front_page
         identity  /courses/1/pages/x
```

This is the same class as #164 and #179 — a route that carries identity data
slipping a segment-based gate — and it survived #179 for exactly that reason.

## Why the suite did not catch it

Two tests asserted the ungated behaviour as **correct**:

- `test_unmatched_endpoints_are_none_tier` listed `/courses/123/front_page`
- `test_non_student_endpoints_not_anonymized` listed it too

So a green suite was defending the gap rather than closing it. Both entries
moved to the identity-tier case, and `/groups/55/front_page` added alongside.

## Why no escalation guard is needed

The `pages` rule carries careful slug handling because a page named `users` is
user-controlled and must not escalate the tier to `full`. `front_page` is a
fixed Canvas route word with no slug after it, so a plain segment match is
safe. Page *bodies* remain exempt, unchanged — instructors publish office hours
and contact details on pages and redacting those would break their purpose.

## Verification

- Full suite: 1047 passed, 21 skipped. ruff and mypy clean.
- The two new tier assertions fail against the previous rule and pass after it.
- End-to-end against a real course front page with anonymization enabled:
  `last_edited_by.display_name` now returns pseudonymised rather than the real
  staff name.

One honest limitation: the pre-fix leak in a **default** install follows from
the gate returning `none` (which applies no scrubbing at all) plus
anonymization defaulting to on in `config.py`. That combination is established
from the code, not from a direct measurement in a default configuration.

Found during an audit of untrusted-content surfaces for #239, but independent
of it — this is a plain privacy-gating bug, worth landing on its own.
