### PR TITLE
fix: stop reporting an update notification we cannot confirm

### DIFF
--- a/src/canvas_mcp/tools/pages.py
+++ b/src/canvas_mcp/tools/pages.py
@@ -5,6 +5,7 @@ editing roles) separate from content editing.
 """
 
 
+import datetime
 from typing import Any
 
 from fastmcp import FastMCP
@@ -12,8 +13,57 @@ from mcp.types import ToolAnnotations
 
 from ..core.cache import get_course_code, get_course_id
 from ..core.client import make_canvas_request
-from ..core.dates import format_date
+from ..core.dates import format_date, parse_date
 from ..core.validation import validate_params
+from ..core.write_confirmation import unconfirmed_write_warning
+
+# Canvas suppresses update notifications for pages younger than this (issue #234).
+_NOTIFY_MIN_PAGE_AGE = datetime.timedelta(minutes=1)
+
+_NOTIFY_IS_NOT_A_SETTING = (
+    "notify_of_update is a save-time action, not a stored setting: Canvas never "
+    "returns it, so the checkbox in the Canvas UI stays unchecked afterward "
+    "regardless. Confirm delivery through the recipients' Canvas notifications, "
+    "not through this page."
+)
+
+
+def _notify_of_update_warning(response: dict[str, Any]) -> str:
+    """Warn that a requested update notification could not be confirmed.
+
+    Canvas's page representation has no ``notify_of_update`` field -- measured
+    against a live instance, a PUT setting it returns 16 keys and none is this
+    one -- so the tool must never report it as done (issue #234).
+
+    Two of Canvas's suppression conditions ARE visible in the response, so those
+    get a confident "no notification was sent" instead of a vague maybe.
+    """
+    if not response.get("published", False):
+        return unconfirmed_write_warning(
+            "the update notification",
+            {"Requested": "notify_of_update=True", "Page state": "unpublished"},
+            "Canvas does not notify participants about changes to an unpublished "
+            "page, so no notification was sent. Publish the page first.",
+        )
+
+    created_at = parse_date(response.get("created_at"))
+    if created_at is not None:
+        # datetime.UTC is 3.11+; this project supports 3.10.
+        now = datetime.datetime.now(created_at.tzinfo or datetime.timezone.utc)
+        if now - created_at < _NOTIFY_MIN_PAGE_AGE:
+            return unconfirmed_write_warning(
+                "the update notification",
+                {"Requested": "notify_of_update=True", "Page age": "under a minute"},
+                "Canvas suppresses update notifications for pages this new, so no "
+                "notification was sent.",
+            )
+
+    return unconfirmed_write_warning(
+        "the update notification",
+        {"Requested": "notify_of_update=True",
+         "Canvas response": "does not include this field"},
+        _NOTIFY_IS_NOT_A_SETTING,
+    )
 
 
 def register_page_tools(mcp: FastMCP) -> None:
@@ -37,7 +87,12 @@ def register_page_tools(mcp: FastMCP) -> None:
             published: True to publish, False to unpublish
             front_page: True to make this the course front page
             editing_roles: One of: teachers, students, members, public
-            notify_of_update: True to notify users of the update
+            notify_of_update: Save-time action, NOT a persisted setting. Asks
+                Canvas to notify course participants about THIS edit. Canvas
+                never returns the flag, so this tool cannot confirm a
+                notification was sent and the Canvas UI checkbox will always
+                look unchecked afterward. Has no effect on an unpublished page
+                or a page under a minute old.
 
         IMPORTANT: The front page cannot be unpublished. First set another page as front page.
         """
@@ -94,6 +149,9 @@ def register_page_tools(mcp: FastMCP) -> None:
         if updated_at:
             result += f"  Updated: {format_date(updated_at)}\n"
 
+        if notify_of_update:
+            result += "\n" + _notify_of_update_warning(response)
+
         return result
 
     @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
@@ -115,7 +173,10 @@ def register_page_tools(mcp: FastMCP) -> None:
             page_urls: Comma-separated list of page URL slugs
             published: True to publish all, False to unpublish all
             editing_roles: One of: teachers, students, members, public
-            notify_of_update: True to notify users of updates
+            notify_of_update: Save-time action, NOT a persisted setting. Asks
+                Canvas to notify course participants about these edits. Canvas
+                never returns the flag, so this tool cannot confirm any
+                notification was sent. Has no effect on unpublished pages.
 
         IMPORTANT: front_page is not supported in bulk updates.
         """
@@ -147,6 +208,7 @@ def register_page_tools(mcp: FastMCP) -> None:
         # Process each page
         success_count = 0
         failed_count = 0
+        unpublished_count = 0
         failed_pages = []
         updated_pages = []
 
@@ -165,6 +227,8 @@ def register_page_tools(mcp: FastMCP) -> None:
             else:
                 success_count += 1
                 updated_pages.append(response.get("title", page_url))
+                if not response.get("published", False):
+                    unpublished_count += 1
 
         # Format result
         course_display = await get_course_code(course_id) or course_identifier
@@ -189,6 +253,20 @@ def register_page_tools(mcp: FastMCP) -> None:
                 result += f"- ❌ {error}\n"
             if len(failed_pages) > 5:
                 result += f"- ... and {len(failed_pages) - 5} more errors\n"
+
+        if notify_of_update and success_count:
+            facts: dict[str, Any] = {
+                "Requested": "notify_of_update=True",
+                "Canvas response": "does not include this field",
+            }
+            if unpublished_count:
+                facts["Definitely not notified"] = (
+                    f"{unpublished_count} of {success_count} updated page(s) are "
+                    "unpublished"
+                )
+            result += "\n" + unconfirmed_write_warning(
+                "the update notifications", facts, _NOTIFY_IS_NOT_A_SETTING
+            )
 
         return result
 

--- a/tests/tools/test_pages.py
+++ b/tests/tools/test_pages.py
@@ -217,6 +217,9 @@ class TestUpdatePageSettings:
         )
 
         assert "success" in result.lower() or "updated" in result.lower()
+        # notify_of_update was requested, so the result must NOT read as a
+        # confirmed notification (issue #234).
+        assert "Could not confirm" in result
         # Verify all params were sent
         call_args = mock_canvas_request.call_args
         assert call_args is not None
@@ -377,3 +380,189 @@ class TestInputValidation:
         )
 
         assert "success" in result.lower() or "updated" in result.lower()
+
+
+class TestNotifyOfUpdateConfirmation:
+    """Issue #234: never report an update notification we cannot confirm.
+
+    Canvas's page representation has no ``notify_of_update`` field. Measured
+    against a live instance on 2026-08-08: a PUT setting it returned 200 with
+    16 keys (body, created_at, editing_roles, front_page, hide_from_students,
+    html_url, last_edited_by, locked_for_user, page_id, publish_at, published,
+    title, todo_date, updated_at, url) and none of them was notify_of_update.
+    So the tool must warn rather than claim success.
+    """
+
+    @pytest.mark.asyncio
+    async def test_warns_when_unconfirmable(
+        self, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """Published, old enough: we simply cannot know -- say so."""
+        mock_canvas_request.return_value = {
+            "url": "notify-me", "title": "Notify Me", "published": True,
+            "front_page": False, "editing_roles": "teachers",
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+
+        update_page_settings = get_tool_function("update_page_settings")
+        result = await update_page_settings(
+            course_identifier="67619", page_url_or_id="notify-me",
+            notify_of_update=True,
+        )
+
+        assert "Could not confirm" in result
+        assert "does not include this field" in result
+
+    @pytest.mark.asyncio
+    async def test_unpublished_page_is_a_confident_no(
+        self, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """Canvas suppresses notifications on unpublished pages -- state it."""
+        mock_canvas_request.return_value = {
+            "url": "draft", "title": "Draft", "published": False,
+            "front_page": False, "editing_roles": "teachers",
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+
+        update_page_settings = get_tool_function("update_page_settings")
+        result = await update_page_settings(
+            course_identifier="67619", page_url_or_id="draft",
+            notify_of_update=True,
+        )
+
+        assert "no notification was sent" in result
+        assert "unpublished" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_brand_new_page_is_a_confident_no(
+        self, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """Canvas suppresses notifications for pages under a minute old."""
+        from datetime import datetime, timezone
+        mock_canvas_request.return_value = {
+            "url": "fresh", "title": "Fresh", "published": True,
+            "front_page": False, "editing_roles": "teachers",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+
+        update_page_settings = get_tool_function("update_page_settings")
+        result = await update_page_settings(
+            course_identifier="67619", page_url_or_id="fresh",
+            notify_of_update=True,
+        )
+
+        assert "no notification was sent" in result
+        assert "under a minute" in result
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_not_requested(
+        self, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """Ordinary publish/unpublish calls must stay noise-free."""
+        mock_canvas_request.return_value = {
+            "url": "quiet", "title": "Quiet", "published": True,
+            "front_page": False, "editing_roles": "teachers",
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+
+        update_page_settings = get_tool_function("update_page_settings")
+        result = await update_page_settings(
+            course_identifier="67619", page_url_or_id="quiet", published=True,
+        )
+
+        assert "Could not confirm" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_explicitly_false(
+        self, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """notify_of_update=False requests nothing, so there is nothing to warn about."""
+        mock_canvas_request.return_value = {
+            "url": "quiet", "title": "Quiet", "published": True,
+            "front_page": False, "editing_roles": "teachers",
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+
+        update_page_settings = get_tool_function("update_page_settings")
+        result = await update_page_settings(
+            course_identifier="67619", page_url_or_id="quiet",
+            notify_of_update=False,
+        )
+
+        assert "Could not confirm" not in result
+
+    @pytest.mark.asyncio
+    async def test_error_path_has_no_warning(
+        self, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """A failed update reports the error only."""
+        mock_canvas_request.return_value = {"error": "404 Not Found"}
+
+        update_page_settings = get_tool_function("update_page_settings")
+        result = await update_page_settings(
+            course_identifier="67619", page_url_or_id="missing",
+            notify_of_update=True,
+        )
+
+        assert "Error updating page settings" in result
+        assert "Could not confirm" not in result
+
+    @pytest.mark.asyncio
+    async def test_bulk_warns_once_and_counts_unpublished(
+        self, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """Bulk emits one warning for the batch, naming the confident negatives."""
+        mock_canvas_request.side_effect = [
+            {"url": "a", "title": "A", "published": True,
+             "created_at": "2024-01-01T00:00:00Z"},
+            {"url": "b", "title": "B", "published": False,
+             "created_at": "2024-01-01T00:00:00Z"},
+        ]
+
+        bulk_update_pages = get_tool_function("bulk_update_pages")
+        result = await bulk_update_pages(
+            course_identifier="67619", page_urls="a,b", notify_of_update=True,
+        )
+
+        assert result.count("Could not confirm") == 1
+        assert "1 of 2 updated page(s) are unpublished" in result
+
+    @pytest.mark.asyncio
+    async def test_bulk_no_warning_when_not_requested(
+        self, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        mock_canvas_request.side_effect = [
+            {"url": "a", "title": "A", "published": True,
+             "created_at": "2024-01-01T00:00:00Z"},
+        ]
+
+        bulk_update_pages = get_tool_function("bulk_update_pages")
+        result = await bulk_update_pages(
+            course_identifier="67619", page_urls="a", published=True,
+        )
+
+        assert "Could not confirm" not in result
+
+    @pytest.mark.asyncio
+    async def test_naive_created_at_does_not_crash(
+        self, mock_canvas_request, mock_course_id, mock_course_code
+    ):
+        """A created_at with no timezone must not blow up the comparison.
+
+        Regression: the age check originally reached for datetime.UTC (3.11+)
+        only on the naive branch, so every tz-aware fixture short-circuited past
+        it and the suite stayed green on Python 3.10.
+        """
+        mock_canvas_request.return_value = {
+            "url": "naive", "title": "Naive", "published": True,
+            "front_page": False, "editing_roles": "teachers",
+            "created_at": "2024-01-01T00:00:00",
+        }
+
+        update_page_settings = get_tool_function("update_page_settings")
+        result = await update_page_settings(
+            course_identifier="67619", page_url_or_id="naive",
+            notify_of_update=True,
+        )
+
+        assert "Could not confirm" in result


### PR DESCRIPTION
Closes #234

`update_page_settings` opened with "✅ Page settings updated successfully!" even
when `notify_of_update` was requested — and nothing in the Canvas response
supports that claim.

## Measured, not assumed

A live PUT setting the flag returns **200 with 16 keys**, and none of them is
`notify_of_update`:

```
body, created_at, editing_roles, front_page, hide_from_students, html_url,
last_edited_by, locked_for_user, page_id, publish_at, published, title,
todo_date, updated_at, url
```

(Measured with `notify_of_update=false`, which requests no notification, so no
students were mailed to establish this.)

It is a **save-time action, not a stored setting**. That also explains the
reporter's observation directly: the Canvas UI checkbox is unchecked afterward
no matter what, so there was never a setting to "not apply".

## What changed

Both page writers now emit `unconfirmed_write_warning`, following the pattern
already used for rubric and student writes. Two of Canvas's suppression
conditions **are** visible in the response, so those get a confident negative
instead of a vague maybe:

| Response state | What we now say |
|---|---|
| `published: false` | No notification was sent. Publish the page first. |
| `created_at` under a minute ago | No notification was sent. |
| otherwise | Cannot be confirmed — check recipient notifications |

The warning fires **only when the flag was actually requested**, so ordinary
publish/unpublish calls stay noise-free. `bulk_update_pages` emits one warning
per batch and names how many updated pages were unpublished.

Docstrings on both tools now describe it as a save-time action that cannot be
confirmed and has no effect on unpublished or brand-new pages.

## Tests

`test_multiple_settings_update` passed `notify_of_update=True` while asserting
only that the output said "success" — it encoded the false confirmation as
correct and would have kept passing forever. Tightened rather than left alone.

9 new tests: unconfirmable case, both confident negatives, no-warning when not
requested, no-warning when explicitly `False`, error path, bulk batch warning
with the unpublished count, bulk no-warning, and a naive-`created_at` case.

That last one is a real regression guard: the age check first reached for
`datetime.UTC` (3.11+) on a branch only taken when `created_at` has no
timezone, so every tz-aware fixture short-circuited past it and the suite
stayed green on Python 3.10.

## Verification

1056 passed, 21 skipped. ruff and mypy clean.

## Not claimed

Whether a `notify_of_update=True` PUT with no body change actually delivers
mail to enrolled participants is **not** verified here. Canvas's own broadcast
policy suggests it does, but that is a reading of the Rails source, and the
confirming experiment mails real students. This PR only stops us asserting an
outcome we cannot observe.
