### PR TITLE
fix: make CI actually run the test suite

### DIFF
--- a/.github/workflows/canvas-mcp-testing.yml
+++ b/.github/workflows/canvas-mcp-testing.yml
@@ -45,6 +45,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        # Full history: test_acceptance_replay_real_history replays the
+        # closing-keyword checker over every real commit message. The default
+        # shallow checkout has no `main` and no old commits, so the replay would
+        # skip -- and a validator that only ever sees its own fixtures has not
+        # earned its place.
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6

--- a/.github/workflows/canvas-mcp-testing.yml
+++ b/.github/workflows/canvas-mcp-testing.yml
@@ -3,9 +3,6 @@ name: Canvas MCP Enhancement Testing
 on:
   push:
     branches: [ main, development ]
-    paths: 
-      - 'src/canvas_mcp/tools/discussions.py'
-      - 'tests/**'
   pull_request:
     branches: [ main ]
 
@@ -35,74 +32,52 @@ jobs:
     - name: Run mypy
       run: mypy src/
 
-  test-enhancements:
+  # Runs the WHOLE suite on every supported interpreter. pyproject declares
+  # requires-python = ">=3.10", so 3.10 is a supported target and must be
+  # tested: a 3.10-only break (datetime.UTC is 3.11+, for one) is invisible on
+  # a 3.11-only runner.
+  test:
     runs-on: ubuntu-latest
-    
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Python
+
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
-    
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -e .
         pip install pytest pytest-asyncio
-    
-    - name: Run Enhancement Tests
+
+    - name: Run the test suite
+      run: pytest tests/ -q
+
+  # Aggregator. Branch protection requires a check literally named
+  # "test-enhancements", and a matrix job publishes per-version names
+  # ("test (3.10)"), which would leave the required check permanently pending
+  # and block every PR. This gate keeps the required name while making it mean
+  # "the full suite passed on every supported Python".
+  test-enhancements:
+    runs-on: ubuntu-latest
+    needs: test
+    if: always()
+
+    steps:
+    - name: Require every matrix job to have succeeded
       run: |
-        if [ -f "tests/test_discussion_enhancements.py" ]; then
-          python tests/test_discussion_enhancements.py
-        else
-          echo "No test file found, creating basic test report"
-          echo "# Test Results" > test_report.md
-          echo "" >> test_report.md
-          echo "✅ **Basic Validation Completed**" >> test_report.md
-          echo "- Code syntax validation: PASSED" >> test_report.md
-          echo "- Module imports: PASSED" >> test_report.md
-          echo "- No test file present for detailed testing" >> test_report.md
+        echo "matrix result: ${{ needs.test.result }}"
+        if [ "${{ needs.test.result }}" != "success" ]; then
+          echo "::error::Test suite failed on at least one supported Python version."
+          exit 1
         fi
-    
-    - name: Generate Test Report
-      run: |
-        echo "## 🧪 Canvas MCP Test Results" >> $GITHUB_STEP_SUMMARY
+        echo "## Canvas MCP test results" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        if [ -f "test_report.md" ]; then
-          cat test_report.md >> $GITHUB_STEP_SUMMARY
-        else
-          echo "No test report generated" >> $GITHUB_STEP_SUMMARY
-        fi
-    
-    - name: Upload Test Results
-      if: hashFiles('test_report.md') != ''
-      uses: actions/upload-artifact@v4
-      with:
-        name: test-results
-        path: test_report.md
-    
-    - name: Performance Regression Check
-      run: |
-        if [ -f "scripts/performance_check.py" ]; then
-          python scripts/performance_check.py
-        else
-          echo "No performance check script found, skipping"
-        fi
-    
-    - name: Comment on PR (if applicable)
-      if: github.event_name == 'pull_request' && hashFiles('test_report.md') != ''
-      continue-on-error: true
-      uses: actions/github-script@v6
-      with:
-        script: |
-          const fs = require('fs');
-          const testReport = fs.readFileSync('test_report.md', 'utf8');
-          
-          github.rest.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: `## 🧪 Automated Test Results\n\n${testReport}`
-          });
+        echo "Full suite passed on 3.10, 3.11, 3.12 and 3.13." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -52,9 +52,12 @@ jobs:
           uv pip install --system -e .
 
       - name: Run tests
+        # No `|| echo ... skipping`: that swallowed real failures, so a broken
+        # suite could not stop a release. pytest exit code 5 is the genuine
+        # "no tests collected" case and is the only one tolerated here.
         run: |
           uv pip install --system pytest pytest-asyncio
-          pytest tests/ || echo "No tests found - skipping"
+          pytest tests/ -q || { code=$?; [ "$code" -eq 5 ] && echo "No tests collected" || exit "$code"; }
 
       - name: Build package
         run: |

--- a/tests/test_closing_keyword_guard.py
+++ b/tests/test_closing_keyword_guard.py
@@ -319,6 +319,26 @@ def test_report_tells_the_user_how_to_rephrase():
 # --------------------------------------------------------------------------
 
 
+def _git(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=REPO_ROOT, capture_output=True, text=True
+    )
+
+
+def _history_ref() -> str | None:
+    """First ref that resolves: local main, the remote branch, then HEAD.
+
+    A CI checkout (actions/checkout) lands on a detached HEAD with no local
+    `main`, so `git log main` exits 128 there while passing on any developer
+    machine. Resolving a ref instead of hard-coding one keeps this test running
+    in both places rather than being a local-only test.
+    """
+    for ref in ("main", "origin/main", "HEAD"):
+        if _git("rev-parse", "--verify", "--quiet", ref).returncode == 0:
+            return ref
+    return None
+
+
 def test_acceptance_replay_real_history():
     """Run the checker over every real commit message on main.
 
@@ -332,13 +352,17 @@ def test_acceptance_replay_real_history():
     accidental closures nobody had recorded -- 2bee9f2 and c63b23b -- plus a
     second reference inside 98643ce itself.
     """
-    log = subprocess.run(
-        ["git", "log", "--format=%H%x00%B%x1e", "main"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    ).stdout
+    ref = _history_ref()
+    if ref is None:
+        pytest.skip("no resolvable git history ref (not a git checkout?)")
+
+    if _git("rev-parse", "--is-shallow-repository").stdout.strip() == "true":
+        pytest.skip(
+            "shallow clone: the replay needs full history to be meaningful. "
+            "CI sets fetch-depth: 0 for exactly this test."
+        )
+
+    log = _git("log", "--format=%H%x00%B%x1e", ref).stdout
 
     # Every accidental closure in this repo's history, and nothing else.
     EXPECTED_PROSE = {
@@ -360,6 +384,14 @@ def test_acceptance_replay_real_history():
             flagged_prose[sha[:7]] = prose
         if any(m.is_trailer for m in matches):
             trailer_shas.add(sha[:7])
+
+    # Pinned shas absent means we are looking at a partial history (a truncated
+    # fetch, or a fork without the original commits), not a regex regression.
+    # Skipping is honest; asserting here would report a false failure.
+    seen_shas = {record.strip()[:7] for record in log.split("\x1e") if record.strip()}
+    missing = sorted(set(EXPECTED_PROSE) - seen_shas)
+    if missing:
+        pytest.skip(f"partial history: pinned commits not present ({missing})")
 
     assert flagged_prose == EXPECTED_PROSE, (
         "replay drifted from the known corpus. New keys are either a real "


### PR DESCRIPTION
The required `test-enhancements` check **never ran a test.**

It looked for `tests/test_discussion_enhancements.py`, which does not exist in
this repository, and on the else branch echoed a hand-written success report:

```
echo "✅ **Basic Validation Completed**"
echo "- Code syntax validation: PASSED"
echo "- Module imports: PASSED"
```

It installed pytest and never invoked it. `scripts/performance_check.py`, the
other file it looked for, does not exist either. So one of the two checks branch
protection requires was reporting a pass it had not established.

## Measured coverage on a PR, before this change

| | count |
|---|---|
| tests actually executed | **363** (`tests/security` only, via `security-testing.yml`) |
| tests in the suite | 1091 |
| **never run on a PR** | **728 (67%)** |

This is a plausible reason several defects landed here with a "green suite" —
the green came from a subset plus a fabricated report. Four bugs fixed this week
were ones the suite was actively asserting as correct.

## Changes

- **New `test` job** runs `pytest tests/` across a **3.10 / 3.11 / 3.12 / 3.13**
  matrix, `fail-fast: false`. `pyproject` declares `requires-python = ">=3.10"`,
  so 3.10 is a supported target that was never exercised — and a 3.10-only break
  is easy to ship (`datetime.UTC` is 3.11+; that exact bug was written and caught
  by hand earlier this week).
- **`test-enhancements` becomes an aggregator** gating on the matrix. The name is
  deliberately preserved: branch protection requires a check named exactly
  `test-enhancements`, and a matrix job publishes per-version names like
  `test (3.10)` — converting it directly would leave the required check
  permanently pending and **block every PR**.
- Dropped the dead file lookups, the fabricated report, the artifact upload of a
  file that was never produced, and the PR-comment step that depended on it.
- **Removed the `paths:` filter on push** — it limited runs to `discussions.py`
  and `tests/`, so a change anywhere else in `src/` ran no tests at all on main.
- **`publish-mcp.yml`** ran `pytest tests/ || echo "No tests found - skipping"`,
  which swallowed genuine failures and would let a broken suite publish a
  release. Now only pytest's exit code 5 (nothing collected) is tolerated;
  everything else propagates.

## Verification

Run **before** enabling the gate, so it cannot block PRs on arrival — the full
suite passes locally on every interpreter in the new matrix:

```
Python 3.10   1070 passed, 21 skipped
Python 3.11   1070 passed, 21 skipped
Python 3.12   1070 passed, 21 skipped
Python 3.13   1070 passed, 21 skipped
```

Both workflow files validated as YAML, and the `publish-mcp` exit-code branch
was tested directly (5 → tolerated, 1 → propagated).

## Reviewer note

This PR is the first one whose own `test-enhancements` check means anything.
Worth confirming in the checks tab that four `test (3.x)` jobs appear and that
`test-enhancements` gates on them.
