### PR TITLE
fix: stop teaching the model to attach unrequested grade comments

### DIFF
--- a/skills/canvas-bulk-grading/SKILL.md
+++ b/skills/canvas-bulk-grading/SKILL.md
@@ -134,8 +134,9 @@ execute_typescript(code: `
 
       return {
         points: 100,
-        rubricAssessment: { "_8027": { points: 100 } },
-        comment: "Graded via automated review"
+        rubricAssessment: { "_8027": { points: 100 } }
+        // No `comment` here on purpose -- see Safety Rule 6. Add one only when
+        // the instructor asked for written feedback, and make it feedback.
       };
     }
   });
@@ -163,6 +164,7 @@ The key insight: as submission count grows, sending grading logic to the server 
 3. **Spot-check before bulk.** For Strategy B and C, grade 1-2 submissions manually with `grade_with_rubric` first. Verify in Canvas that the grade and rubric feedback appear correctly.
 4. **Respect rate limits.** Use `max_concurrent: 5` and `rate_limit_delay: 1.0` (1 second between batches). Canvas rate limits are approximately 700 requests per 10 minutes.
 5. **Do not grade without explicit instructor confirmation.** Always present the grading plan (rubric mapping, point values, number of students affected) and wait for approval before submitting grades.
+6. **Never attach a comment the instructor did not ask for.** A submission comment is visible to the student in SpeedGrader, it *appends* on every call rather than replacing, and it cannot be un-sent. "Assign grade 8" means the grade only. Never generate a comment that restates the grade or narrates that grading happened (e.g. "Graded via automated review") — that reads to the student as a bot mark on their work and carries no feedback. Include a comment only when the instructor asked for written feedback, and then make it feedback about the work.
 
 ## Example Prompts
 

--- a/src/canvas_mcp/tools/assignments.py
+++ b/src/canvas_mcp/tools/assignments.py
@@ -910,7 +910,13 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
         Args:
             course_identifier: Course code or Canvas ID
             assignment_id: Canvas assignment ID
-            grades: Dict mapping user_id to {rubric_assessment?, grade?, comment?}
+            grades: Dict mapping user_id to {rubric_assessment?, grade?, comment?}.
+                OMIT `comment` unless the instructor explicitly asked for written
+                feedback. "Assign grade 8" means the grade ONLY. A comment is
+                visible to the student in SpeedGrader, APPENDS a new comment on
+                every call rather than replacing the previous one, and cannot be
+                un-sent. Never generate a comment that merely restates the grade
+                or narrates that grading happened.
             dry_run: If True, validate without submitting (default: False)
             max_concurrent: Max concurrent grading operations (default: 5)
             rate_limit_delay: Delay between batches in seconds (default: 1.0)
@@ -962,7 +968,15 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
             """Grade a single submission."""
             try:
                 if dry_run:
-                    # In dry run mode, just validate the data
+                    # In dry run mode, just validate the data.
+                    # The preview MUST name any comment: it is student-visible,
+                    # permanent and appended, and an instructor who dry-runs
+                    # first (as the bulk-grading skill instructs) would
+                    # otherwise get no warning that one is about to post (#235).
+                    comment_note = (
+                        f" AND post this student-visible comment: {grade_info['comment']!r}"
+                        if grade_info.get("comment") else ""
+                    )
                     if "rubric_assessment" in grade_info:
                         total_points = sum(
                             criterion.get("points", 0)
@@ -971,13 +985,13 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
                         return {
                             "status": "success",
                             "user_id": user_id,
-                            "message": f"DRY RUN: Would grade with {total_points} rubric points"
+                            "message": f"DRY RUN: Would grade with {total_points} rubric points{comment_note}"
                         }
                     elif "grade" in grade_info:
                         return {
                             "status": "success",
                             "user_id": user_id,
-                            "message": f"DRY RUN: Would grade with {grade_info['grade']} points"
+                            "message": f"DRY RUN: Would grade with {grade_info['grade']} points{comment_note}"
                         }
                     else:
                         return {
@@ -998,7 +1012,11 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
                 elif "grade" in grade_info:
                     # Simple grading
                     form_data["submission[posted_grade]"] = str(grade_info["grade"])
-                    if "comment" in grade_info:
+                    # Truthiness, not membership: an explicit comment=None or
+                    # comment="" meant "no comment", but the membership test
+                    # posted it anyway. The rubric path (build_rubric_assessment_
+                    # form_data) has always used truthiness; these now agree.
+                    if grade_info.get("comment"):
                         form_data["comment[text_comment]"] = grade_info["comment"]
                 else:
                     return {

--- a/src/canvas_mcp/tools/rubrics.py
+++ b/src/canvas_mcp/tools/rubrics.py
@@ -789,7 +789,12 @@ def register_rubric_tools(mcp: FastMCP) -> None:
             assignment_id: Canvas assignment ID
             user_id: Canvas user ID of the student
             rubric_assessment: Dict mapping criterion_id to {points (required), rating_id?, comments?}
-            comment: Optional overall comment for the submission
+            comment: Optional overall comment. OMIT it unless the instructor
+                explicitly asked for written feedback -- "grade this with the
+                rubric" means the grade only. It is visible to the student in
+                SpeedGrader, APPENDS rather than replaces on each call, and
+                cannot be un-sent. Never generate one that merely restates the
+                grade or narrates that grading happened.
         """
         course_id = await get_course_id(course_identifier)
         assignment_id_str = str(assignment_id)

--- a/tests/tools/test_bulk_grading.py
+++ b/tests/tools/test_bulk_grading.py
@@ -88,3 +88,128 @@ class TestBulkGradeSubmissions:
 
         result_text = result.content[0].text if result.content else ""
         assert "empty" in result_text.lower() or "error" in result_text.lower()
+
+
+class TestGradeCommentsAreOptIn:
+    """Issue #235: a grade must never carry a comment the caller did not supply.
+
+    zqian reported a SpeedGrader comment appearing after asking only for a
+    grade. No code path defaults one -- but this repo's own skill shipped
+    `comment: "Graded via automated review"` and every README grading example
+    paired a comment with a grade, so the artifacts that steer the model taught
+    the behaviour. These tests pin the code half.
+    """
+
+    @pytest.fixture
+    def mocks(self):
+        with patch('canvas_mcp.tools.assignments.make_canvas_request', new_callable=AsyncMock) as req, \
+             patch('canvas_mcp.tools.assignments.get_course_id', new_callable=AsyncMock) as cid, \
+             patch('canvas_mcp.tools.assignments.get_course_code', new_callable=AsyncMock) as code:
+            cid.return_value = 12345
+            code.return_value = "TEST101"
+            req.return_value = {"name": "Essay 1", "use_rubric_for_grading": False}
+            yield req
+
+    async def _grade(self, mocks, grades, dry_run=False):
+        from fastmcp import FastMCP
+
+        from canvas_mcp.tools.assignments import register_educator_assignment_tools
+
+        mcp = FastMCP(name="test")
+        register_educator_assignment_tools(mcp)
+        result = await _call_tool(mcp, "bulk_grade_submissions", {
+            "course_identifier": "TEST101",
+            "assignment_id": "999",
+            "grades": grades,
+            "dry_run": dry_run,
+        })
+        return result.content[0].text if result.content else ""
+
+    def _submitted_comments(self, req):
+        """Every comment[text_comment] value actually sent to Canvas."""
+        sent = []
+        for call in req.call_args_list:
+            data = call.kwargs.get("data") or (call.args[2] if len(call.args) > 2 else None)
+            if isinstance(data, dict) and "comment[text_comment]" in data:
+                sent.append(data["comment[text_comment]"])
+        return sent
+
+    @pytest.mark.asyncio
+    async def test_grade_only_sends_no_comment(self, mocks):
+        """THE regression test for the report: grade alone -> no comment field."""
+        await self._grade(mocks, {"user1": {"grade": 8}})
+        assert self._submitted_comments(mocks) == []
+
+    @pytest.mark.asyncio
+    async def test_explicit_comment_is_preserved(self, mocks):
+        await self._grade(mocks, {"user1": {"grade": 8, "comment": "Nice analysis"}})
+        assert self._submitted_comments(mocks) == ["Nice analysis"]
+
+    @pytest.mark.asyncio
+    async def test_none_comment_is_not_sent(self, mocks):
+        """Membership testing used to post an explicit None as a comment."""
+        await self._grade(mocks, {"user1": {"grade": 8, "comment": None}})
+        assert self._submitted_comments(mocks) == []
+
+    @pytest.mark.asyncio
+    async def test_empty_comment_is_not_sent(self, mocks):
+        await self._grade(mocks, {"user1": {"grade": 8, "comment": ""}})
+        assert self._submitted_comments(mocks) == []
+
+    @pytest.mark.asyncio
+    async def test_dry_run_names_the_comment(self, mocks):
+        """The documented safety net must reveal the student-visible side effect."""
+        text = await self._grade(
+            mocks, {"user1": {"grade": 8, "comment": "Nice analysis"}}, dry_run=True
+        )
+        assert "student-visible comment" in text
+        assert "Nice analysis" in text
+
+    @pytest.mark.asyncio
+    async def test_dry_run_silent_when_no_comment(self, mocks):
+        text = await self._grade(mocks, {"user1": {"grade": 8}}, dry_run=True)
+        assert "student-visible comment" not in text
+
+
+class TestRubricCommentGuard:
+    """build_rubric_assessment_form_data is the shared rubric write path."""
+
+    def test_no_comment_field_without_a_comment(self):
+        from canvas_mcp.tools.rubrics import build_rubric_assessment_form_data
+        for empty in (None, ""):
+            fd = build_rubric_assessment_form_data({"_1": {"points": 5}}, empty)
+            assert "comment[text_comment]" not in fd
+
+    def test_comment_preserved_when_supplied(self):
+        from canvas_mcp.tools.rubrics import build_rubric_assessment_form_data
+        fd = build_rubric_assessment_form_data({"_1": {"points": 5}}, "Well argued")
+        assert fd["comment[text_comment]"] == "Well argued"
+
+
+class TestGradingArtifactsDoNotTeachComments:
+    """The skill and docs steer the model as much as the code does."""
+
+    def test_skill_ships_no_canned_comment(self):
+        """No copyable `comment:` VALUE in the sample code.
+
+        Matches the code form, not the bare phrase: Safety Rule 6 quotes
+        "Graded via automated review" deliberately, as the example of what not
+        to write. Banning the string outright would forbid the warning too.
+        """
+        import re
+        from pathlib import Path
+        skill = Path(__file__).resolve().parents[2] / "skills/canvas-bulk-grading/SKILL.md"
+        text = skill.read_text()
+
+        # Ban comment VALUES that narrate the grading process rather than give
+        # feedback -- those are what a model copies into a student's
+        # SpeedGrader. A placeholder like `comment: "Overall feedback"  //
+        # optional` documents the field's shape and is fine, so this matches on
+        # the narration vocabulary, not on any assignment at all.
+        narration = re.findall(
+            r'^\s*comment:\s*["\'][^"\']*\b(?:graded|grading|automated|auto-?generated)\b',
+            text,
+            re.MULTILINE | re.IGNORECASE,
+        )
+        assert narration == [], f"sample code narrates grading in a comment: {narration}"
+        assert "Never attach a comment the instructor did not ask for" in text

--- a/tools/README.md
+++ b/tools/README.md
@@ -567,17 +567,24 @@ Grade multiple submissions efficiently with concurrent processing. **Most effici
 - User 9826: 50 points for criterion _8027 with comment 'Needs improvement'"
 ```
 
-**Example Usage - Simple Grading:**
+**Example Usage - Simple Grading (no comments):**
 ```
 "Grade these submissions with simple points:
-- User 9824: 100 points, comment 'Perfect!'
-- User 9825: 85 points, comment 'Very good'"
+- User 9824: 100 points
+- User 9825: 85 points"
 ```
+
+> **Comments are opt-in.** `comment` is student-visible in SpeedGrader, it
+> **appends** on every call rather than replacing, and it cannot be un-sent.
+> Ask for one only when you want written feedback — "assign grade 8" means the
+> grade alone. A comment that only restates the grade or notes that grading
+> happened is worse than none.
 
 **Returns:** Summary of grading operation including total submissions, successfully graded, failed attempts, and any error details.
 
 **Notes:**
 - Supports both rubric-based grading and simple point-based grading
+- `dry_run: true` previews the grade **and** any comment that would be posted
 - Can mix and match grading styles for different students
 - Automatically validates rubric configuration before grading
 - Use `dry_run=true` to preview grades before applying


### PR DESCRIPTION
Closes #235

zqian reported a SpeedGrader comment appearing after asking only for a grade.

**No code path defaults one.** All five `text_comment` call sites are
conditional on caller input — verified exhaustively. But calling this purely
client-side behaviour was not sustainable, because the artifacts that steer the
model live in this repository:

- `skills/canvas-bulk-grading/SKILL.md:138` shipped
  `comment: "Graded via automated review"` in **copyable sample code**. That
  value's entire content is a statement that a bot did the grading — precisely
  what was reported.
- `tools/README.md:562-575` paired a comment with **every** grading example,
  rubric and simple alike, so the documented shape of a grade call included one.

## Two real code defects found alongside the docs

**1. The dry run never mentioned the comment.** It returned
`DRY RUN: Would grade with N points` while a student-visible comment was queued.
The skill instructs "always dry run first", so the documented safety net could
not reveal the one side effect that cannot be undone. Both dry-run branches now
name the comment text.

**2. The two grading paths disagreed on what "no comment" means.**

| path | test | `{"grade": 8, "comment": None}` |
|---|---|---|
| `assignments.py` | `"comment" in grade_info` | **posted a comment field** |
| `rubrics.py` | `if comment:` | correctly sent nothing |

Both use truthiness now.

## Docs and skill

Docstrings on `bulk_grade_submissions` and `grade_with_rubric` now state that a
comment is student-visible, **appends** rather than replaces, cannot be un-sent,
and must be omitted unless the instructor asked for written feedback. Safety
Rule 6 added to the skill. The README's simple-grading example is now
comment-free with a callout explaining the semantics.

## Tests

Six pin the code half — grade-only sends no comment field (the regression test
for the report), an explicit comment survives, `None` and `""` are not sent, the
dry run names the comment, and stays silent when there is none — plus two on the
shared rubric form builder.

One test guards the skill against regaining a narration-style canned value. It
matches on narration vocabulary rather than on any `comment:` assignment,
because `comment: "Overall feedback"  // optional` legitimately documents the
field's shape; the first version of that test banned both and had to be
narrowed.

## Verification

1079 passed, 21 skipped. ruff and mypy clean.

## Deliberately not included

An `allow_comments` flag that would reject any comment outright. That is a
product decision, and worth confirming with the reporter before building —
this PR removes the *cause* without constraining the API.
