### PR TITLE
ci: publish OSSF Scorecard, pin all actions, fix Token-Permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,17 @@ updates:
       actions:
         patterns: ["*"]
 
+  # Root package-lock.json belongs to the execute_typescript sandbox.
+  # Without this entry nothing maintains it — it currently locks a
+  # vulnerable transitive `diff` (GHSA-73rr-hh4g-fpgx) via ts-node.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "sandbox"]
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies"]
+    groups:
+      dev-dependencies:
+        patterns: ["pytest*", "ruff", "black", "mypy"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "ci"]
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    labels: ["dependencies", "docker"]

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+# Least privilege by default; jobs escalate only what they need.
+permissions:
+  contents: read
+
 jobs:
   auto-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Issue Triage
         id: claude-triage
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/canvas-mcp-testing.yml
+++ b/.github/workflows/canvas-mcp-testing.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: '3.11'
 
@@ -47,7 +47,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       with:
         # Full history: test_acceptance_replay_real_history replays the
         # closing-keyword checker over every real commit message. The default
@@ -57,7 +57,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+# Least privilege by default; jobs escalate only what they need.
+permissions:
+  contents: read
+
 jobs:
   claude-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+# Least privilege by default; jobs escalate only what they need.
+permissions:
+  contents: read
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,13 +30,13 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           

--- a/.github/workflows/closing-keyword-guard.yml
+++ b/.github/workflows/closing-keyword-guard.yml
@@ -45,7 +45,7 @@ jobs:
       ALLOW_CLOSING_KEYWORD: >-
         ${{ contains(github.event.pull_request.labels.*.name, 'allow-closing-keyword') && '1' || '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,7 +12,7 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: create-release-${{ github.ref }}
@@ -21,6 +21,9 @@ concurrency:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    # Needs write to create the GitHub Release and attach the .mcpb asset.
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,7 +26,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,28 +28,28 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Compute image tag
         id: tag
         run: echo "tag=azure-gies-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to ACR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
 
       - name: Deploy to production slot
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
         with:
           app-name: ${{ env.APP_NAME }}
           slot-name: Production

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,28 +30,28 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Compute image tag
         id: tag
         run: echo "tag=azure-gies-$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Log in to ACR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.ACR_USERNAME }}
           password: ${{ secrets.ACR_PASSWORD }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
 
       - name: Deploy to staging slot
-        uses: azure/webapps-deploy@v3
+        uses: azure/webapps-deploy@02a81bead70021f5284939794bcec79c271ab383 # v3
         with:
           app-name: ${{ env.APP_NAME }}
           slot-name: staging

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -27,7 +27,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.tag_name || github.ref }}
 
@@ -41,7 +41,7 @@ jobs:
           echo "Resolved version: $VERSION"
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.10'
 
@@ -65,7 +65,7 @@ jobs:
           python -m build
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
           skip-existing: true
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.tag_name || github.ref }}
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,52 @@
+# Publishes an OSSF Scorecard result to the public OpenSSF API
+# (https://api.scorecard.dev), which is what third-party trust registries read.
+# `publish_results: true` only takes effect for runs on the default branch.
+name: OSSF Scorecard
+
+on:
+  # Re-score when branch protection / ruleset settings change.
+  branch_protection_rule:
+  schedule:
+    - cron: '27 6 * * 1'
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Upload the SARIF result to the Security tab.
+      security-events: write
+      # Publish the result to the public OpenSSF API via OIDC.
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -47,6 +47,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -22,10 +22,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
       
@@ -44,7 +44,7 @@ jobs:
           pytest tests/security/ -v --cov=src/canvas_mcp --cov-report=html --cov-report=term
       
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-report
           path: htmlcov/
@@ -64,10 +64,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
       
@@ -86,7 +86,7 @@ jobs:
         continue-on-error: true
       
       - name: Upload SAST results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sast-reports
           path: |
@@ -108,10 +108,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
       
@@ -143,7 +143,7 @@ jobs:
       
       - name: Upload dependency scan results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dependency-scan-reports
           path: |
@@ -165,12 +165,12 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0  # Full history for secret scanning
       
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
       
@@ -184,7 +184,7 @@ jobs:
         continue-on-error: true
       
       - name: TruffleHog scan
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@a7082b69f5bc6167bbe27ebab82bf6707f267bf6 # main@2026-08-10
         with:
           path: ./
           base: main
@@ -192,7 +192,7 @@ jobs:
         continue-on-error: true
       
       - name: Upload secret scan results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: secret-scan-reports
           path: secrets-baseline.json
@@ -214,18 +214,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: python
           queries: security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: "/language:python"

--- a/.github/workflows/security-testing.yml
+++ b/.github/workflows/security-testing.yml
@@ -9,6 +9,10 @@ on:
     # Run weekly security scans
     - cron: '0 0 * * 0'
 
+# Least privilege by default; jobs escalate only what they need.
+permissions:
+  contents: read
+
 jobs:
   security-tests:
     name: Security Test Suite

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * 0'  # Every Sunday at midnight UTC
   workflow_dispatch:  # Allow manual trigger
 
+# Least privilege by default; jobs escalate only what they need.
+permissions:
+  contents: read
+
 jobs:
   maintenance:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: '3.11'
 
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run Claude Maintenance Tasks
         id: claude-maintenance
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Use Python 3.12 slim image for smaller size
-FROM python:3.12-slim
+# Use Python 3.12 slim image for smaller size.
+# Pinned by digest so the build is reproducible; Dependabot's docker
+# ecosystem entry keeps the digest current.
+FROM python:3.12-slim@sha256:229a2c5bfa27522db7815ea81f9bed70af17ccb9de9fc7ad142b1877b5830d36
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
Sets up OSSF Scorecard publishing so third-party trust registries can read a real
score for this repo, and fixes the two Scorecard checks that were cheapest to fix.

Context: issue #260 (HVTracker) scores us **70.3/100, Grade B**. Their published
methodology weights OSSF Scorecard at **50% of Safety (12.5 pts) and 50% of
Transparency (8.5 pts)**. We have never published a Scorecard, so all 21 of those
points score zero regardless of the repo's actual posture. The arithmetic confirms
it rather than assuming it: Safety scores 10.0/25, which is exactly build
provenance (7.5) plus half the signed-commit points (2.5) and nothing else;
Transparency scores 8.5/17, exactly the license half.

## What this does

- **`.github/workflows/scorecard.yml`** — `ossf/scorecard-action` with
  `publish_results: true`, which is what puts a result on the public OpenSSF API.
  Runs on push to `main`, weekly, on `branch_protection_rule`, and manually.
- **`.github/dependabot.yml`** — pip, github-actions, npm, docker. Note this repo
  currently has **Dependabot security updates disabled entirely**
  (`security_and_analysis.dependabot_security_updates: disabled`), which is worth
  turning on in repo settings separately — a config file does not enable alerts.
- **Token-Permissions** — five workflows declared no *top-level* permissions
  (their job-level grants were already correct), and `create-release.yml` granted
  `contents: write` at the top level rather than in the one job that needs it.
- **Pinned-Dependencies** — all 45 action references were mutable tags or
  branches. Each is pinned at the SHA of the major version already in use, so
  nothing is upgraded, except CodeQL v2 → v4 because that action generation is
  obsolete. Docker base image pinned by digest, verified against the registry.

## Measured, not estimated

Run with `scorecard v5.5.0`. Before, against the live repo:

| Check | Before | After | How measured |
|---|---|---|---|
| Token-Permissions | 0/10 | **10/10** | `scorecard --local` A/B |
| Pinned-Dependencies | 0/10 | **4/10** | `scorecard --local` A/B |
| Dependency-Update-Tool | 0/10 | 10/10 | config file present |
| Dangerous-Workflow | 10/10 | 10/10 | unchanged |

Aggregate **5.4 → ~7.0**. Feeding 7.0 into HVTracker's weights puts the project at
roughly **85, Grade A** (threshold 80), and adds a fourth independent evidence
type, which also lifts their Evidence Coverage grade to A.

`trufflesecurity/trufflehog@main` was the sharpest single item here: a mutable
branch ref means every upstream push silently changes what CI executes.

## Reviewed

Codex security review of the first commit. It confirmed the main correctness
worry — adding a top-level `permissions:` cannot break these five workflows,
because every affected job already declares its own permission map, which
replaces the workflow default rather than intersecting with it. It also confirmed
`publish_results: true` exposes nothing private (OpenSSF already scans public
repos; this replaces their scan with an authenticated one) and receives no
secrets. Two of its findings are applied in the second commit: the missing npm
ecosystem, and CodeQL v3 → v4 in the new workflow.

## Deliberately not done

- **Code-Review (0/10)** — needs an independent human approver. Not fixable by a
  solo maintainer, and self-approval or a second account would be score-gaming.
- **Fuzzing, CII-Best-Practices** — disproportionate for this project.
- **Branch-Protection (5/10)** — the gaps are admin-bypass and a second reviewer,
  both of which need a maintainer decision rather than a code change.
- **Unpinned pip commands** — the residual 6 points of Pinned-Dependencies.
  Needs hash-pinned requirements files; larger change, separate PR.

## Follow-ups worth filing

1. **Signed-Releases (0/10)** — the `canvas-mcp.mcpb` bundle is downloaded
   independently of PyPI, so our existing PyPI provenance does not cover it.
   Build it in a contents-read job, attest it in a job with only `id-token: write`
   + `attestations: write`, attach the `.intoto.jsonl` from a third job.
2. **`diff@4.0.2`** in the root `package-lock.json` (GHSA-73rr-hh4g-fpgx, DoS,
   dev-only via `ts-node`). Bump to ≥4.0.4. Left out here to keep the sandbox
   dependency tree in its own PR.
3. `create-release.yml` and `publish-mcp.yml` execute `@latest`/dynamically
   downloaded tooling while holding release-write and OIDC publishing authority.
4. Several security scans use `continue-on-error`, so findings cannot fail a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
