### PR TITLE
ci: derive the lint job's mypy constraint from pyproject

### DIFF
--- a/.github/workflows/canvas-mcp-testing.yml
+++ b/.github/workflows/canvas-mcp-testing.yml
@@ -28,9 +28,24 @@ jobs:
       run: ruff check src/ tests/
 
     - name: Install mypy
+      # Read the constraint from pyproject instead of repeating it. A literal
+      # here silently drifts: it said "<2" while pyproject said "<3", so CI
+      # would have kept type-checking on mypy 1.x forever while contributors
+      # running `uv sync` got 2.x — the gate asserting a version nobody uses.
       run: |
         python -m pip install -e .
-        python -m pip install "mypy>=1.15.0,<2"
+        CONSTRAINT=$(python - <<'PY'
+        import tomllib
+        with open("pyproject.toml", "rb") as fh:
+            groups = tomllib.load(fh)["dependency-groups"]["dev"]
+        specs = [d for d in groups if isinstance(d, str) and d.startswith("mypy")]
+        if len(specs) != 1:
+            raise SystemExit(f"expected exactly one mypy spec in dependency-groups.dev, found {specs}")
+        print(specs[0])
+        PY
+        )
+        echo "Installing $CONSTRAINT"
+        python -m pip install "$CONSTRAINT"
 
     - name: Run mypy
       run: mypy src/


### PR DESCRIPTION
Follow-up to #267, which widened `mypy` to `>=1.15.0,<3` in
`pyproject.toml`'s `dependency-groups.dev`.

The lint job did not read that. It hardcoded its own copy:

```yaml
python -m pip install "mypy>=1.15.0,<2"
```

So after #267 the two disagreed, and the disagreement was invisible: CI would
have kept type-checking on mypy 1.x indefinitely while anyone running `uv sync`
locally got 2.x. #267's bump would have been inert, and the required `lint`
check would have been asserting a version nobody actually uses.

That is the same shape as PR #247, where the required `test-enhancements` check
was measuring something other than what it claimed.

The job now reads the single mypy spec out of `pyproject.toml` and **fails loudly
if there is not exactly one**, so a rename or a duplicate entry cannot silently
degrade into an unconstrained install.

## Verified, not assumed

- **mypy 2.3.0 (current latest) against `src/`: `Success: no issues found in 48
  source files`.** This is the check that actually justifies #267 — and the green
  `lint` run on #267 did *not* establish it, because CI installed 1.x regardless
  of the pyproject change.
- The heredoc survives YAML block-scalar indentation stripping — extracted the
  step with a YAML parser and ran `bash -n` on the result, rather than eyeballing
  the indentation.
- The extraction returns exactly `mypy>=1.15.0,<3` against the real file, and the
  guard raises when no mypy spec is present.

Note for whoever bumps mypy next: mypy 2.x emits
`pyproject.toml: note: unused section(s): module = ['tests.*']`, because the lint
job only checks `src/`. Harmless, but it will show up in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
