### PR TITLE
Add direct assignment lookup to get_my_peer_reviews_todo

### DIFF
--- a/src/canvas_mcp/tools/student_tools.py
+++ b/src/canvas_mcp/tools/student_tools.py
@@ -306,11 +306,21 @@ def register_student_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     @validate_params
-    async def get_my_peer_reviews_todo(course_identifier: str | int | None = None) -> str:
+    async def get_my_peer_reviews_todo(
+        course_identifier: str | int | None = None,
+        assignment_identifier: str | int | None = None,
+    ) -> str:
         """Get peer reviews YOU need to complete.
 
         Args:
-            course_identifier: Course code or Canvas ID (omit for all courses)
+            course_identifier: Course code or Canvas ID (omit for all courses).
+                Required if assignment_identifier is given.
+            assignment_identifier: Canvas assignment ID to check directly, bypassing
+                the per-course discovery scan. Use this when you already know which
+                assignment has your peer review — the discovery scan only queries
+                assignments whose "peer_reviews" flag came back true on the course's
+                assignment listing, so an assignment where that flag is missing or
+                stale for any reason would otherwise be silently skipped.
         """
         # The peer-review listing is only meaningful relative to the caller:
         # reviews are filtered to assessor_id == the current user.
@@ -319,6 +329,53 @@ def register_student_tools(mcp: FastMCP) -> None:
             detail = me.get("error") if isinstance(me, dict) else me
             return f"Error identifying current user: {detail}"
         my_id = me["id"]
+
+        if assignment_identifier is not None:
+            if not course_identifier:
+                return (
+                    "Error: assignment_identifier requires course_identifier "
+                    "(peer reviews are looked up within a specific course)."
+                )
+            course_id = await get_course_id(course_identifier)
+
+            assignment = await make_canvas_request(
+                "get", f"/courses/{course_id}/assignments/{assignment_identifier}"
+            )
+            if not isinstance(assignment, dict) or "error" in assignment:
+                detail = assignment.get("error") if isinstance(assignment, dict) else assignment
+                return f"Error fetching assignment {assignment_identifier}: {detail}"
+
+            peer_reviews = await fetch_all_paginated_results(
+                f"/courses/{course_id}/assignments/{assignment_identifier}/peer_reviews",
+                params={"include[]": ["user"], "per_page": 100}
+            )
+            if isinstance(peer_reviews, dict) and "error" in peer_reviews:
+                return f"Error fetching peer reviews: {peer_reviews['error']}"
+
+            assignment_name = assignment.get("name", f"assignment {assignment_identifier}")
+            course_display = await get_course_code(course_id)
+            my_reviews = [
+                review for review in (peer_reviews if isinstance(peer_reviews, list) else [])
+                if review.get("assessor_id") == my_id
+                and review.get("workflow_state") != "completed"
+            ]
+
+            if not my_reviews:
+                return (
+                    f"No pending peer review found for you on "
+                    f"{fence_untrusted_inline(assignment_name, 'assignment name')} "
+                    f"({course_display})."
+                )
+
+            output_lines = ["Peer Reviews You Need to Complete:\n"]
+            for review in my_reviews:
+                output_lines.append(
+                    f"• {fence_untrusted_inline(assignment_name, 'assignment name')}\n"
+                    f"  Course: {course_display}\n"
+                    f"  Reviewing: Student {review.get('user_id')}\n"
+                    f"  Status: Incomplete\n"
+                )
+            return "\n".join(output_lines)
 
         if course_identifier:
             course_ids = [await get_course_id(course_identifier)]

--- a/tests/tools/test_student_tools.py
+++ b/tests/tools/test_student_tools.py
@@ -460,5 +460,96 @@ class TestGetMyPeerReviewsTodo:
         assert "no pending peer reviews" not in result.lower()
 
 
+class TestGetMyPeerReviewsTodoDirectAssignment:
+    """#275: the per-course discovery scan only checks assignments whose
+    listing carried peer_reviews=True; if that flag is missing/stale for any
+    reason (still uninvestigated on real student data), the caller has no way
+    to check a specific assignment they already know has their review. This
+    param bypasses the flag gate entirely and queries the assignment's
+    peer-review listing directly.
+    """
+
+    SELF_ID = 2407
+
+    @pytest.mark.asyncio
+    async def test_finds_review_bypassing_discovery_scan_flag(self):
+        # Note: no "peer_reviews" flag anywhere in this path — the direct
+        # lookup does not gate on it at all.
+        request_side_effect = [
+            {"id": self.SELF_ID},                                    # /users/self
+            {"id": 1, "name": "Essay"},                                # assignment GET
+        ]
+        with (
+            patch('canvas_mcp.tools.student_tools.make_canvas_request',
+                  new_callable=AsyncMock, side_effect=request_side_effect),
+            patch('canvas_mcp.tools.student_tools.fetch_all_paginated_results',
+                  new_callable=AsyncMock,
+                  return_value=[
+                      {"assessor_id": self.SELF_ID, "user_id": 11, "workflow_state": "assigned"},
+                      {"assessor_id": 9999, "user_id": 12, "workflow_state": "assigned"},
+                  ]),
+            patch('canvas_mcp.tools.student_tools.get_course_id',
+                  new=AsyncMock(return_value="505")),
+            patch('canvas_mcp.tools.student_tools.get_course_code',
+                  new=AsyncMock(return_value="TEST-505")),
+        ):
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(course_identifier="505", assignment_identifier="1")
+
+        assert "Essay" in result
+        assert "Student 11" in result
+        assert "Student 12" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_match_reports_none_for_this_assignment(self):
+        request_side_effect = [
+            {"id": self.SELF_ID},
+            {"id": 1, "name": "Essay"},
+        ]
+        with (
+            patch('canvas_mcp.tools.student_tools.make_canvas_request',
+                  new_callable=AsyncMock, side_effect=request_side_effect),
+            patch('canvas_mcp.tools.student_tools.fetch_all_paginated_results',
+                  new_callable=AsyncMock,
+                  return_value=[{"assessor_id": 9999, "user_id": 12, "workflow_state": "assigned"}]),
+            patch('canvas_mcp.tools.student_tools.get_course_id',
+                  new=AsyncMock(return_value="505")),
+            patch('canvas_mcp.tools.student_tools.get_course_code',
+                  new=AsyncMock(return_value="TEST-505")),
+        ):
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(course_identifier="505", assignment_identifier="1")
+
+        assert "No pending peer review found" in result
+        assert "Essay" in result
+
+    @pytest.mark.asyncio
+    async def test_requires_course_identifier(self):
+        with patch('canvas_mcp.tools.student_tools.make_canvas_request',
+                    new_callable=AsyncMock, return_value={"id": self.SELF_ID}):
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(assignment_identifier="1")
+
+        assert "requires course_identifier" in result
+
+    @pytest.mark.asyncio
+    async def test_assignment_fetch_error_surfaces(self):
+        request_side_effect = [
+            {"id": self.SELF_ID},
+            {"error": "not found"},
+        ]
+        with (
+            patch('canvas_mcp.tools.student_tools.make_canvas_request',
+                  new_callable=AsyncMock, side_effect=request_side_effect),
+            patch('canvas_mcp.tools.student_tools.get_course_id',
+                  new=AsyncMock(return_value="505")),
+        ):
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(course_identifier="505", assignment_identifier="999")
+
+        assert "Error fetching assignment" in result
+        assert "not found" in result
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tools/README.md
+++ b/tools/README.md
@@ -257,12 +257,14 @@ View your current grades across all enrolled courses.
 List peer reviews you need to complete.
 
 **Parameters:**
-- `course_identifier` (optional): Filter by specific course
+- `course_identifier` (optional): Filter by specific course. Required if `assignment_identifier` is given.
+- `assignment_identifier` (optional): Check a specific assignment directly, bypassing the per-course discovery scan. Use this if you know which assignment has your peer review but the general scan doesn't find it.
 
 **Example:**
 ```
 "What peer reviews do I need to complete?"
 "Show me my pending peer reviews for ENGL 101"
+"Do I have a peer review to do for assignment 4821 in ENGL 101?"
 ```
 
 **Returns:** Incomplete peer reviews with assignment and course information.

--- a/tools/TOOL_MANIFEST.json
+++ b/tools/TOOL_MANIFEST.json
@@ -129,13 +129,20 @@
           "name": "course_identifier",
           "type": "string | integer",
           "required": false,
-          "description": "Course code or ID to filter (optional)"
+          "description": "Course code or ID to filter (optional; required if assignment_identifier is given)"
+        },
+        {
+          "name": "assignment_identifier",
+          "type": "string | integer",
+          "required": false,
+          "description": "Check a specific assignment directly, bypassing the per-course discovery scan"
         }
       ],
       "returns": "Incomplete peer reviews with assignment and course info",
       "examples": [
         "What peer reviews do I need to complete?",
-        "Show me my pending peer reviews"
+        "Show me my pending peer reviews",
+        "Do I have a peer review to do for assignment 4821 in ENGL 101?"
       ]
     },
     {


### PR DESCRIPTION
## Summary

Issue #275 reports `get_my_peer_reviews_todo` answering "no pending peer reviews" for a caller who has a real, incomplete review assigned — on v1.9.0, after #219 already fixed the error-swallowing and missing assessor-filter defects in this same tool.

**I want to be upfront about what this PR does and doesn't establish.** I read through the discovery-scan logic and confirmed (via Canvas's own API docs and the anonymization-gating code in `core/client.py`) that the field mapping (`assessor_id` = reviewer, `user_id` = reviewee) is correct, and that this endpoint isn't touched by the anonymization layer at all — so those two suspects are ruled out. I do not have a student-scoped Canvas token to reproduce the actual failure, so I can't confirm whether the root cause is:

- the assignment's `peer_reviews` flag coming back missing/false for some assignment shape that the discovery scan's pre-filter then silently skips, or
- something specific to how the `/assignments/:id/peer_reviews` listing behaves for a student-scoped token (permission truncation, filtering), or
- something else I haven't identified.

## What this PR does

Adds an optional `assignment_identifier` parameter to `get_my_peer_reviews_todo`. When given (with `course_identifier`), it queries that specific assignment's peer-review listing directly — bypassing the discovery scan's `peer_reviews` flag gate entirely — instead of relying on the per-course scan to have found it. This is exactly the workaround the reporter says they already tried ("I even tried prompting with the course and assignment id... that did not work") and had no way to actually do, since the tool only accepted `course_identifier` before.

This gives a reliable path forward regardless of whatever the discovery-scan bug turns out to be, without me guessing at a fix for a root cause I can't verify.

## Not closing #275

Leaving #275 open — this doesn't confirm/rule out the discovery-scan's underlying defect. I've asked the reporter on the issue to try the new parameter and report back with (redacted) details that would help pin down the actual cause.

## Note on PR #276

A separate Copilot-authored PR (#276) proposed adding `include[]=all_dates`/`include[]=submission` to the assignments listing as the fix. I closed it — `include[]` params on that endpoint don't affect which assignments are returned (they only add extra data to each object), so it didn't address a plausible mechanism for the bug, and its regression test only asserted the params were *passed*, not that the real API behavior changed.

## Test plan
- [x] `uv run python -m pytest tests/tools/test_student_tools.py -v` — 24 passed (4 new tests covering the direct-lookup path: match found, no match, missing `course_identifier`, assignment-fetch error)
- [x] `uv run python -m pytest tests/ -q` — full suite: 1325 passed, 21 skipped
- [x] `ruff check` + `mypy` clean on changed files
- [ ] Reporter confirmation that the new parameter surfaces their peer review (not verifiable without a student account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)