### PR TITLE
Potential fix for code scanning alert no. 70: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -1,5 +1,6 @@
 """Tests for HTTP transport: credential middleware, ContextVar flow, and CLI args."""
 
+from urllib.parse import urlparse
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -359,7 +360,9 @@ class TestClientPerRequestCredentials:
             # Verify the URL uses per-request base URL
             mock_client_instance.get.assert_called_once()
             call_args = mock_client_instance.get.call_args
-            assert "per-request.instructure.com" in call_args[0][0]
+            request_url = call_args[0][0]
+            parsed_url = urlparse(request_url)
+            assert parsed_url.hostname == "per-request.instructure.com"
 
             # Client should be closed after use
             mock_client_instance.aclose.assert_called_once()


### PR DESCRIPTION
Potential fix for [https://github.com/vishalsachdev/canvas-mcp/security/code-scanning/70](https://github.com/vishalsachdev/canvas-mcp/security/code-scanning/70)

The right fix is to parse the called URL and assert on its structured hostname field instead of checking for a host substring anywhere in the URL string.

Best single change (without altering functionality):
- In `tests/test_http_transport.py`, in `test_uses_per_request_credentials`, replace:
  - `assert "per-request.instructure.com" in call_args[0][0]`
- With:
  - parse URL using `urllib.parse.urlparse`
  - assert parsed `.hostname` equals `"per-request.instructure.com"`

Also add the required standard-library import:
- `from urllib.parse import urlparse`

This keeps the test intent identical (“URL uses per-request base host”) but makes the check precise and resistant to accidental matches.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
