### PR TITLE
feat: add private bearer-authenticated remote MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,14 +23,24 @@ CANVAS_API_URL=https://your-institution.instructure.com/api/v1
 
 Students and educators use the same server but have access to different tools based on Canvas API permissions.
 
+### Private Remote (Poke)
+For a private single-user remote server, set
+`MCP_HTTP_CREDENTIAL_MODE=server`, keep the Canvas URL/token in the server's
+secret store, and configure one or more random 256-bit values in
+`MCP_ACCESS_KEYS`. Poke sends the selected key as `Authorization: Bearer <key>`
+to `/mcp`; `X-MCP-Access-Key` is retained only for compatibility. Never treat
+`X-Poke-User-Id` as authenticated identity. Keep `CANVAS_ROLE=student`,
+`EXECUTE_TYPESCRIPT_ENABLED=false`, and `QUIZ_TAKING_ENABLED=false` unless the
+operator deliberately widens access.
+
 ### Tool Profile (Optional)
 Reduce tool overhead by setting a role-based profile. Only tools relevant to the selected role are registered:
 
 ```
 # In .env:
-CANVAS_ROLE=student    # ~37 tools (student + shared)
-CANVAS_ROLE=educator   # ~88 tools (educator + shared)
-CANVAS_ROLE=all        # Default profile; 94 tools by default, 99 with all feature-gated tools enabled
+CANVAS_ROLE=student    # ~39 tools by default (student + shared)
+CANVAS_ROLE=educator   # ~90 tools (educator + shared)
+CANVAS_ROLE=all        # 96 tools by default; 104 with all feature gates enabled
 ```
 
 Or via CLI flag: `canvas-mcp-server --role student` (CLI flag takes precedence over env var).
@@ -75,8 +85,21 @@ Three things to know before using them:
    or reuse one. Submitting spends an attempt the student may not be able to
    recover.
 
-Quiz-taking is deliberately not offered. Group assignments are refused, because
-submitting would bind classmates who never agreed to it.
+Group assignments are refused, because submitting would bind classmates who
+never agreed to it.
+
+### Classic Quiz Tools
+
+Read-only quiz discovery is always available. Taking a quiz is deliberately
+off by default and requires `QUIZ_TAKING_ENABLED=true` from the server operator.
+
+| Tool | Purpose |
+|------|---------|
+| `list_quizzes` | List Classic Quizzes in a course |
+| `get_quiz_details` | Inspect settings for a Classic Quiz |
+| `start_quiz_attempt` | Preview, then begin or resume a Classic Quiz attempt |
+| `answer_quiz_questions` | Record answers for an in-progress attempt (no submit) |
+| `submit_quiz_attempt` | Preview, then irreversibly turn in an attempt |
 
 ### Educator Tools
 Course management, grading, and analytics. Requires instructor/TA role.
@@ -154,6 +177,33 @@ Content access tools available to all authenticated users.
 | `list_discussion_entries` | Posts in a discussion |
 | `post_discussion_entry` | Add a discussion post |
 | `reply_to_discussion_entry` | Reply to a post |
+| `list_quizzes` | List Classic Quizzes in a course (read-only) |
+| `get_quiz_details` | Quiz settings: attempts, time limit, question count (read-only) |
+
+### Quiz Tools (Classic Quizzes)
+Browse/inspect any Classic Quiz; take one as a student. **New Quizzes** (the
+`quiz_lti` engine) are not supported by the Canvas REST API — they appear via
+`list_assignments` and cannot be taken through these tools.
+
+| Tool | Role | Purpose |
+|------|------|---------|
+| `list_quizzes` | Shared | List Classic Quizzes (optional `search_term`) |
+| `get_quiz_details` | Shared | Settings: type, attempts, time limit, question count, lock state |
+| `start_quiz_attempt` | Student | Preview, then start/resume an attempt; confirmation is required before Canvas creates or resumes the take session |
+| `answer_quiz_questions` | Student | Record answers for the open attempt (call repeatedly; never auto-submits) |
+| `submit_quiz_attempt` | Student | Preview current saved answers, then complete the attempt — **irreversible** |
+
+Taking a quiz is available only when `QUIZ_TAKING_ENABLED=true`. Starting and
+submitting each use two calls: first omit `confirmation_token`, show the
+human-readable preview to the student, then call again with the returned token
+and otherwise unchanged arguments. Confirmation tokens are caller-bound,
+single-use, expire after five minutes, and fail if Canvas attempt state or saved
+answers change. Carry the resulting `quiz_submission_id`, `attempt`, and
+`validation_token` through answer and submit calls. The `answer` value format
+depends on the question type
+(multiple-choice → answer id; multiple-answers → array of ids; essay/short-answer
+→ string; numerical → number; fill-in-multiple-blanks → `{blank: text}`;
+multiple-dropdowns → `{blank: answer_id}`; matching → `[{answer_id, match_id}]`).
 
 ### Learning Designer Tools
 Course design, quality assurance, and accessibility compliance.
@@ -222,6 +272,27 @@ Is it a simple query?
    → get_my_peer_reviews_todo()
 ```
 
+### Student: Take a Classic Quiz
+```
+1. "What quizzes are open in BADM 350?"
+   → list_quizzes(course_id)            # find the quiz_id
+
+2. "How is the quiz set up?"
+   → get_quiz_details(course_id, quiz_id)   # attempts, time limit, etc.
+
+3. "Start it and show me the questions"
+   → start_quiz_attempt(course_id, quiz_id)
+     # keep quiz_submission_id, attempt, validation_token from the response
+
+4. "Record my answers" (does NOT submit)
+   → answer_quiz_questions(quiz_submission_id, attempt, validation_token,
+                           answers='{"<q_id>": <answer>, ...}')
+
+5. "Turn it in" (irreversible — only when ready)
+   → submit_quiz_attempt(course_id, quiz_id, quiz_submission_id,
+                         attempt, validation_token)
+```
+
 ### Educator: Check Assignment Progress
 ```
 1. "Show me Assignment 3 submissions"
@@ -284,6 +355,7 @@ Some Canvas API endpoints have bugs or limitations that prevent certain operatio
 | Tool | Issue | Workaround |
 |------|-------|------------|
 | `update_rubric` | Partial updates wipe all criteria (full replacement, not PATCH) | Edit rubrics via Canvas web UI |
+| `list_quizzes` / quiz tools | Only **Classic Quizzes** are exposed by the REST API; **New Quizzes** (`quiz_lti`) cannot be listed or taken | Open New Quizzes in the Canvas web UI; they also appear via `list_assignments` |
 
 **Working rubric tools:** `create_rubric`, `list_rubrics`, `get_rubric`, `get_rubric_assessment`, `associate_rubric`, `grade_with_rubric`, `bulk_grade_submissions`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 canvas-mcp/
 ├── src/canvas_mcp/        # Main application code
 │   ├── core/             # Core utilities (client, config, validation)
-│   ├── tools/            # MCP tool implementations (99 tools across 19 files)
+│   ├── tools/            # MCP tool implementations (104 tools across 20 files)
 │   ├── resources/        # MCP resources and prompts
 │   └── server.py         # FastMCP server entry point
 ├── skills/               # Agent skills for skills.sh (8 skills)

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,9 @@ RUN adduser --disabled-password --gecos '' mcp && \
     chown -R mcp:mcp /app
 
 # Set environment variables.
-# HTTP deployments pin CANVAS_API_URL at runtime and must NOT set CANVAS_API_TOKEN —
-# callers supply their own token per request via the X-Canvas-Token header.
+# HTTP deployments pin CANVAS_API_URL at runtime. In the default request-header
+# mode callers supply X-Canvas-Token and the container must not hold a token. In
+# server mode a private deployment supplies CANVAS_API_TOKEN and MCP_ACCESS_KEYS.
 # Code execution (execute_typescript) ships OFF by default for this network-facing
 # image; opt in with -e EXECUTE_TYPESCRIPT_ENABLED=true only behind real auth.
 # Anonymization ships ON — institutional deployments must opt OUT deliberately
@@ -36,7 +37,9 @@ RUN adduser --disabled-password --gecos '' mcp && \
 ENV MCP_SERVER_NAME="canvas-mcp" \
     ENABLE_DATA_ANONYMIZATION="true" \
     ANONYMIZATION_DEBUG="false" \
-    EXECUTE_TYPESCRIPT_ENABLED="false"
+    EXECUTE_TYPESCRIPT_ENABLED="false" \
+    QUIZ_TAKING_ENABLED="false" \
+    CANVAS_ROLE="student"
 
 # Switch to non-root user
 USER mcp
@@ -44,9 +47,9 @@ USER mcp
 # HTTP port the container listens on (App Service injects PORT/WEBSITES_PORT)
 EXPOSE 8819
 
-# Health check to verify installation
+# Health check the running HTTP service without credentials or configuration data.
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD python -c "import canvas_mcp; print('OK')" || exit 1
+  CMD python -c "import os, urllib.request; port = os.getenv('PORT', os.getenv('WEBSITES_PORT', '8819')); urllib.request.urlopen(f'http://127.0.0.1:{port}/healthz', timeout=2)" || exit 1
 
 # Run the MCP server over HTTP (required for container/ingress; stdio is unreachable).
 # Honors the platform-injected port, falling back to 8819.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![skills.sh](https://img.shields.io/badge/skills.sh-canvas--mcp-blue)](https://skills.sh)
 
-MCP server for Canvas LMS with **99 tools** and **8 agent skills**. Works with Claude Desktop, Cursor, Codex, Windsurf, and [40+ other agents](https://skills.sh).
+MCP server for Canvas LMS with **104 tools** and **8 agent skills**. Works with Claude Desktop, Cursor, Codex, Windsurf, Poke, and [40+ other agents](https://skills.sh).
 
 ```bash
 npx skills add vishalsachdev/canvas-mcp
@@ -23,7 +23,7 @@ npx skills add vishalsachdev/canvas-mcp
   See CLAUDE.md "Documentation Maintenance" for full guidelines.
 -->
 
-Canvas MCP provides **99 tools** for interacting with Canvas LMS. Tools are organized by user type:
+Canvas MCP provides **104 tools** for interacting with Canvas LMS. Tools are organized by user type:
 
 <details>
 <summary><strong>Student Tools</strong> (click to expand)</summary>
@@ -262,7 +262,7 @@ All student data is anonymized **before** it reaches AI systems. See [Educator G
 ### For Students: Your Data Stays Private
 
 - **Your data only**: Student tools access only your own Canvas data via Canvas API's "self" endpoints
-- **No credential storage**: In hosted mode, your Canvas token is sent as an HTTP header per-request and never stored on the server. In local mode, everything runs on your machine.
+- **Explicit credential mode**: Shared HTTP deployments keep Canvas tokens request-local. A private single-user deployment may instead keep one Canvas token in its secret store and require a separate bearer access key.
 - **No tracking**: Your Canvas usage and AI interactions remain private
 - **No anonymization needed**: Since you're only accessing your own data, there are no privacy concerns
 
@@ -271,6 +271,51 @@ All student data is anonymized **before** it reaches AI systems. See [Educator G
 The public hosted server (`mcp.illinihunt.org`) has been **retired**. A public MCP endpoint without an access gate isn't safe to operate — it would expose the built-in code-execution tool — so the supported path is **[local installation](#local-installation)** below.
 
 The HTTP/streamable transport itself remains fully supported for **self-hosting behind your own authentication** (`canvas-mcp-server --transport streamable-http`). Running a shared, authenticated instance for your institution? See **[deploy/azure/](deploy/azure/)** for a production-tested deployment specification (Azure App Service + Entra ID platform auth, per-user Canvas tokens) with sample workflow and config templates.
+
+### Private Remote Server for Poke
+
+Poke connects to standard remote MCP servers with an `Authorization: Bearer …`
+header. For a private, single-user Canvas MCP, store the Canvas credential on
+the server and give Poke only a separate random access key:
+
+```bash
+export MCP_HTTP_CREDENTIAL_MODE=server
+export CANVAS_API_URL=https://your-institution.instructure.com/api/v1
+export CANVAS_API_TOKEN=your_canvas_api_token
+export MCP_ACCESS_KEYS="$(openssl rand -hex 32)"
+export CANVAS_ROLE=student
+export EXECUTE_TYPESCRIPT_ENABLED=false
+export QUIZ_TAKING_ENABLED=false
+
+canvas-mcp-server --transport streamable-http --host 127.0.0.1 --port 8819
+```
+
+Keep the generated access key in a password manager or deployment secret store;
+never commit it. The MCP URL is `http://localhost:8819/mcp`. The public
+`/healthz` endpoint returns only `{"status":"ok"}`.
+
+For local development, expose that endpoint through Poke's tunnel:
+
+```bash
+npx poke@latest tunnel http://localhost:8819/mcp
+```
+
+For an always-on installation, build the existing OCI image and run it on any
+compatible container host with the same environment variables. Put `/mcp`
+behind HTTPS, keep the service private, and configure Poke with the generated
+key as its bearer API key. `X-Poke-User-Id` is accepted only as hashed audit
+metadata; it never authenticates a request. See the
+[Poke MCP documentation](https://poke.com/docs/mcp-servers) for its current
+connection UI and tunnel behavior.
+
+```bash
+docker build -t canvas-mcp .
+docker run --rm --env-file .env -p 127.0.0.1:8819:8819 canvas-mcp
+```
+
+On a persistent container host, supply the same values through its secret and
+environment settings and route HTTPS traffic to container port `8819`. Hosting
+provider selection and external deployment are intentionally outside this repo.
 
 ---
 
@@ -544,7 +589,7 @@ Quick start guides: [Student](examples/student_quickstart.md) | [Educator](examp
 
 ## Documentation
 
-- **[Tool Documentation](tools/README.md)** — Complete reference for all 99 tools
+- **[Tool Documentation](tools/README.md)** — Complete reference for all 104 tools
 - **[Student Guide](https://canvas-mcp.illinihunt.org/student-guide.html)** — Getting started as a student
 - **[Educator Guide](https://canvas-mcp.illinihunt.org/educator-guide.html)** — FERPA compliance and educator workflows
 - **[Bulk Grading Example](examples/bulk_grading_example.md)** — Token-efficient batch grading walkthrough

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,7 +108,7 @@ Canvas MCP includes built-in privacy features for educational data:
 
 1. **HTTPS Only**
    - Canvas API requires HTTPS
-   - HTTP URLs are automatically upgraded to HTTPS
+   - Non-loopback HTTP Canvas URLs are rejected rather than upgraded
 
 2. **User-Agent Header**
    - Canvas MCP includes proper User-Agent identification
@@ -136,6 +136,14 @@ Canvas MCP includes built-in privacy features for educational data:
    - Enable API request logging for debugging: `LOG_API_REQUESTS=true`
    - Monitor for unusual API activity
    - Review error logs for security issues
+
+4. **Private Remote MCP**
+   - Use `MCP_HTTP_CREDENTIAL_MODE=server` only for a private, single-user service
+   - Require a random 256-bit `MCP_ACCESS_KEYS` bearer key and terminate public traffic with HTTPS
+   - Store both the Canvas token and MCP access key in the host's secret store; never bake them into the image
+   - Keep `CANVAS_ROLE=student`, `EXECUTE_TYPESCRIPT_ENABLED=false`, and `QUIZ_TAKING_ENABLED=false` unless the operator deliberately widens access
+   - Rotate the MCP access key independently of the Canvas token; overlapping keys in `MCP_ACCESS_KEYS` support rotation
+   - Treat `X-Poke-User-Id` as optional audit metadata only, never identity proof
 
 ---
 
@@ -172,10 +180,10 @@ Canvas MCP includes several security features:
 
 ## Known Security Limitations
 
-1. **No Authentication**
-   - MCP server trusts the local environment
-   - No built-in authentication for MCP clients
-   - Relies on Canvas API token for authorization
+1. **Authentication Boundaries**
+   - Stdio mode trusts the local process environment and has no separate MCP client authentication
+   - HTTP mode supports bearer access keys (with legacy `X-MCP-Access-Key` compatibility) or the documented Entra deployment
+   - Access keys protect the MCP endpoint; the Canvas token still determines Canvas authorization
 
 2. **Code Execution Risks**
    - `execute_typescript` tool executes arbitrary code
@@ -198,7 +206,6 @@ Canvas MCP includes several security features:
 
 Future security enhancements under consideration:
 
-- [ ] Optional MCP client authentication
 - [ ] Code execution sandboxing (Docker/VM isolation)
 - [ ] Token encryption at rest
 - [ ] Audit logging for sensitive operations

--- a/env.template
+++ b/env.template
@@ -1,9 +1,11 @@
-# Canvas API Configuration (Required)
+# Canvas API Configuration
 # CANVAS_API_URL must be https://. The API token is sent in an Authorization
 # header on every request, so a cleartext origin exposes it on the network —
 # the server refuses to start on an http:// URL.
-CANVAS_API_TOKEN=your_canvas_api_token_here
 CANVAS_API_URL=https://your-institution.instructure.com/api/v1
+# Required for stdio and MCP_HTTP_CREDENTIAL_MODE=server. In request-header
+# HTTP mode, leave this unset and send X-Canvas-Token on each request instead.
+CANVAS_API_TOKEN=your_canvas_api_token_here
 
 # Development escape hatch for a Canvas running on this machine. Only permits
 # cleartext http:// when the host is a loopback address (localhost, 127.0.0.1,
@@ -47,8 +49,14 @@ TS_SANDBOX_TIMEOUT_SEC=120
 TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
 
 # Tool Profile (Optional)
-# Controls which tools are registered: student (~37), educator (~88), all (default)
+# Controls which tools are registered: student (~39), educator (~90), all (default)
 # CANVAS_ROLE=all
+
+# Classic Quiz taking (Optional; OFF by default)
+# Read-only quiz discovery is always registered. Setting this to true adds the
+# start, answer, and submit tools. Starting and submitting require short-lived,
+# single-use confirmation tokens; do not enable this casually on remote servers.
+# QUIZ_TAKING_ENABLED=false
 
 # Student write tools (Optional; OFF by default)
 # Campus-wide ceiling. Empty (the default) means NO student write tool is
@@ -57,8 +65,9 @@ TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
 # Quiz-taking is deliberately NOT available here; it is a separate decision.
 # STUDENT_WRITE_TOOLS=
 
-# NOTE for multi-worker HTTP deployments, if you enable submit_assignment:
-# a submission confirmation is redeemable ONLY on the process that issued it.
+# NOTE for multi-worker HTTP deployments, if you enable submit_assignment or
+# QUIZ_TAKING_ENABLED: a confirmation is redeemable ONLY on the process that
+# issued it.
 # This is deliberate. A confirmation is single-use, and that claim is held in
 # process memory; if a token were redeemable on any worker, two workers could
 # accept it at once and both submit, spending two of the student's attempts.
@@ -99,12 +108,30 @@ TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
 #   allow_tools: submit_assignment
 #   note: Allowed for weekly labs. Ask me before using it on the final project.
 
-# HTTP transport — multi-user access-key gate (Optional; HTTP mode only)
-# Comma/space-separated list of accepted keys. An HTTP caller must send a
-# matching X-MCP-Access-Key header. Leave empty to disable (rely on external
-# auth). Ignored entirely in stdio mode. In HTTP mode, also pin CANVAS_API_URL
-# and do NOT set CANVAS_API_TOKEN — each caller sends their own X-Canvas-Token.
+# HTTP Canvas credential mode (HTTP mode only)
+#   request-header (default): each caller supplies X-Canvas-Token. Do not set
+#     CANVAS_API_TOKEN. This preserves multi-user and Entra deployments.
+#   server: use the server-held CANVAS_API_TOKEN for every caller. This is for a
+#     private, single-user client such as Poke and requires MCP_ACCESS_KEYS.
+# MCP_HTTP_CREDENTIAL_MODE=request-header
+
+# HTTP transport — access-key gate (HTTP mode only)
+# Comma/space-separated list of accepted keys. Callers should send the standard
+# Authorization: Bearer <key> header. X-MCP-Access-Key remains supported for
+# compatibility; conflicting headers are rejected. Leave empty only when an
+# external authenticator is deliberately configured. Ignored in stdio mode.
+# Generate a 256-bit key with: openssl rand -hex 32
 # MCP_ACCESS_KEYS=
+
+# Private Poke profile (example; replace placeholders and keep secrets outside
+# source control):
+# MCP_HTTP_CREDENTIAL_MODE=server
+# CANVAS_API_URL=https://your-institution.instructure.com/api/v1
+# CANVAS_API_TOKEN=your_canvas_api_token_here
+# MCP_ACCESS_KEYS=paste_a_random_256_bit_key_here
+# CANVAS_ROLE=student
+# EXECUTE_TYPESCRIPT_ENABLED=false
+# QUIZ_TAKING_ENABLED=false
 
 # HTTP transport — fail-closed override (Optional; HTTP mode only)
 # Secure-by-default: in HTTP mode the server REFUSES to start if MCP_ACCESS_KEYS

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,42 @@
+app = "qwerzl-canvas-mcp"
+primary_region = "sjc"
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  PORT = "8819"
+  MCP_HTTP_CREDENTIAL_MODE = "server"
+  CANVAS_ROLE = "student"
+  EXECUTE_TYPESCRIPT_ENABLED = "false"
+  QUIZ_TAKING_ENABLED = "false"
+  ENABLE_DATA_ANONYMIZATION = "true"
+  LOG_LEVEL = "INFO"
+
+[http_service]
+  internal_port = 8819
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [http_service.concurrency]
+    type = "requests"
+    soft_limit = 25
+    hard_limit = 50
+
+  [http_service.http_options]
+    idle_timeout = 600
+
+  [[http_service.checks]]
+    grace_period = "10s"
+    interval = "30s"
+    method = "GET"
+    path = "/healthz"
+    protocol = "http"
+    timeout = "5s"
+
+[[vm]]
+  cpu_kind = "shared"
+  cpus = 1
+  memory = "512mb"

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -15,17 +15,20 @@ _INVALID_INT_ENV_VARS: dict[str, str] = {}
 _INVALID_FLOAT_ENV_VARS: dict[str, str] = {}
 
 VALID_SANDBOX_MODES = frozenset({"auto", "local", "container"})
+VALID_HTTP_CREDENTIAL_MODES = frozenset({"request-header", "server"})
 
 # Canonical names of the student write tools an operator may enable via
 # STUDENT_WRITE_TOOLS. Declared here rather than in the tools package so config
 # stays free of imports from it. Quiz-taking is deliberately absent: it is an
 # academic-integrity decision gated behind its own separate flag, not something
 # an operator can switch on by naming it in this allowlist.
-STUDENT_WRITE_TOOL_NAMES = frozenset({
-    "submit_assignment",
-    "comment_on_my_submission",
-    "mark_module_item_done",
-})
+STUDENT_WRITE_TOOL_NAMES = frozenset(
+    {
+        "submit_assignment",
+        "comment_on_my_submission",
+        "mark_module_item_done",
+    }
+)
 
 
 def _parse_keys(raw: str) -> frozenset[str]:
@@ -210,12 +213,16 @@ class Config:
         # Code execution sandbox configuration (secure defaults)
         self.enable_ts_sandbox = _bool_env("ENABLE_TS_SANDBOX", True)
         self.ts_sandbox_mode = os.getenv("TS_SANDBOX_MODE", "auto").lower()
-        self.ts_sandbox_block_outbound_network = _bool_env("TS_SANDBOX_BLOCK_OUTBOUND_NETWORK", True)
+        self.ts_sandbox_block_outbound_network = _bool_env(
+            "TS_SANDBOX_BLOCK_OUTBOUND_NETWORK", True
+        )
         self.ts_sandbox_allowlist_hosts = os.getenv("TS_SANDBOX_ALLOWLIST_HOSTS", "")
         self.ts_sandbox_cpu_limit = _int_env("TS_SANDBOX_CPU_LIMIT", 30)
         self.ts_sandbox_memory_limit_mb = _int_env("TS_SANDBOX_MEMORY_LIMIT_MB", 512)
         self.ts_sandbox_timeout_sec = _int_env("TS_SANDBOX_TIMEOUT_SEC", 120)
-        self.ts_sandbox_container_image = os.getenv("TS_SANDBOX_CONTAINER_IMAGE", "node:20-alpine")
+        self.ts_sandbox_container_image = os.getenv(
+            "TS_SANDBOX_CONTAINER_IMAGE", "node:20-alpine"
+        )
 
         # Code execution is opt-in — set EXECUTE_TYPESCRIPT_ENABLED=true to
         # enable the execute_typescript tool (independent of CANVAS_ROLE).
@@ -223,11 +230,20 @@ class Config:
         # operator choice, not something a default install exposes (#157).
         self.execute_typescript_enabled = _bool_env("EXECUTE_TYPESCRIPT_ENABLED", False)
 
-        # HTTP access-key gate (v1, multi-user). Comma- or whitespace-separated
-        # list of accepted keys; an HTTP caller must present a matching
-        # X-MCP-Access-Key header. Empty disables the gate (rely on external
-        # auth). stdio mode ignores this entirely.
+        # HTTP access-key gate. Comma- or whitespace-separated accepted keys;
+        # callers use Authorization: Bearer (or legacy X-MCP-Access-Key).
+        # Empty disables the app gate in request-header mode only when external
+        # auth is explicitly acknowledged. stdio ignores this entirely.
         self.mcp_access_keys = _parse_keys(os.getenv("MCP_ACCESS_KEYS", ""))
+
+        # How HTTP requests obtain their Canvas API credential:
+        # - request-header: each caller supplies X-Canvas-Token (multi-user)
+        # - server: use CANVAS_API_TOKEN from the server secret store (private,
+        #   single-user deployments such as Poke)
+        # stdio ignores this setting and continues to use CANVAS_API_TOKEN.
+        self.mcp_http_credential_mode = (
+            os.getenv("MCP_HTTP_CREDENTIAL_MODE", "request-header").strip().lower()
+        )
 
         # Secure-by-default: in HTTP mode, an unconfigured key gate makes the
         # server exit unless the operator EXPLICITLY opts into unauthenticated
@@ -244,7 +260,9 @@ class Config:
         # Entra object IDs permitted to use this server (empty = allow any
         # platform-authenticated identity).
         self.entra_auth_enabled = _bool_env("ENTRA_AUTH_ENABLED", False)
-        self.mcp_entra_allowed_oids = _parse_keys(os.getenv("MCP_ENTRA_ALLOWED_OIDS", ""))
+        self.mcp_entra_allowed_oids = _parse_keys(
+            os.getenv("MCP_ENTRA_ALLOWED_OIDS", "")
+        )
 
         # --- Self-service access-approval flow (hosted-only; off by default) ---
         # Feature flag. When false (default) the gate behaves exactly as before
@@ -263,7 +281,9 @@ class Config:
             if e.strip()
         ]
         # Public base URL used to build approval links (no trailing slash).
-        self.access_approve_base_url = os.getenv("ACCESS_APPROVE_BASE_URL", "").rstrip("/")
+        self.access_approve_base_url = os.getenv("ACCESS_APPROVE_BASE_URL", "").rstrip(
+            "/"
+        )
         # HMAC secret for approval tokens; empty disables the feature (fail-closed).
         self.access_token_secret = os.getenv("ACCESS_TOKEN_SECRET", "")
         # Suppress re-emailing the admin for the same OID within this window.
@@ -285,18 +305,28 @@ class Config:
             for name in os.getenv("STUDENT_WRITE_TOOLS", "").replace(",", " ").split()
             if name.strip()
         )
+        # Classic Quiz taking is a separate academic-integrity decision from
+        # the Tier 1 student write allowlist. Read-only quiz discovery remains
+        # registered; attempt/answer/submit tools are absent unless enabled.
+        self.quiz_taking_enabled = _bool_env("QUIZ_TAKING_ENABLED", False)
         # Per-course instructor policy. Can further restrict (never expand) the
         # operator ceiling above.
-        self.course_agent_policy_enabled = _bool_env("COURSE_AGENT_POLICY_ENABLED", True)
+        self.course_agent_policy_enabled = _bool_env(
+            "COURSE_AGENT_POLICY_ENABLED", True
+        )
         # Posture when a course has no policy artifact. Institutional decision, so
         # it is operator-configurable; "deny" is the safe default.
-        self.course_agent_policy_default = os.getenv(
-            "COURSE_AGENT_POLICY_DEFAULT", "deny"
-        ).strip().lower()
+        self.course_agent_policy_default = (
+            os.getenv("COURSE_AGENT_POLICY_DEFAULT", "deny").strip().lower()
+        )
         # Denials cache longer than grants. A stale grant is a revocation window on
         # an attempt-consuming action, so it is deliberately short.
-        self.course_agent_policy_allow_ttl = _int_env("COURSE_AGENT_POLICY_ALLOW_TTL", 30)
-        self.course_agent_policy_deny_ttl = _int_env("COURSE_AGENT_POLICY_DENY_TTL", 300)
+        self.course_agent_policy_allow_ttl = _int_env(
+            "COURSE_AGENT_POLICY_ALLOW_TTL", 30
+        )
+        self.course_agent_policy_deny_ttl = _int_env(
+            "COURSE_AGENT_POLICY_DENY_TTL", 300
+        )
 
 
 # Global configuration instance

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -9,13 +9,15 @@ academic tracking.
 
 Supports two transport modes:
 - stdio (default): Local process communication, credentials from .env
-- streamable-http: HTTP server, per-request token via X-Canvas-Token header;
-  the Canvas API URL is pinned by server config (CANVAS_API_URL), not the client.
+- streamable-http: HTTP server with either per-request X-Canvas-Token
+  credentials or one server-held Canvas token; the Canvas API URL is always
+  pinned by server config (CANVAS_API_URL), not the client.
 """
 
 import argparse
 import asyncio
 import base64
+import hashlib
 import hmac
 import json
 import sys
@@ -25,7 +27,12 @@ from typing import Any
 
 from fastmcp import FastMCP
 
-from .core.config import get_config, validate_canvas_url_scheme, validate_config
+from .core.config import (
+    VALID_HTTP_CREDENTIAL_MODES,
+    get_config,
+    validate_canvas_url_scheme,
+    validate_config,
+)
 from .core.credentials import (
     RequestCredentials,
     clear_http_request_context,
@@ -58,23 +65,47 @@ from .tools import (
     register_shared_file_tools,
     register_shared_messaging_tools,
     register_shared_module_tools,
+    register_shared_quiz_tools,
+    register_student_quiz_tools,
     register_student_tools,
     register_student_write_tools,
 )
 
 
-async def _send_json_error(send: Any, status: int, message: str) -> None:
+async def _send_json_response(
+    send: Any,
+    status: int,
+    payload: dict[str, Any],
+    *,
+    extra_headers: list[tuple[bytes, bytes]] | None = None,
+    head_only: bool = False,
+) -> None:
+    """Emit a small ASGI JSON response without exposing server state."""
+    body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(body)).encode("ascii")),
+    ]
+    if extra_headers:
+        headers.extend(extra_headers)
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": b"" if head_only else body})
+
+
+async def _send_json_error(
+    send: Any,
+    status: int,
+    message: str,
+    *,
+    bearer_challenge: bool = False,
+) -> None:
     """Emit a minimal ASGI JSON error response (used to fail closed)."""
-    body = json.dumps({"error": message}).encode("utf-8")
-    await send({
-        "type": "http.response.start",
-        "status": status,
-        "headers": [
-            (b"content-type", b"application/json"),
-            (b"content-length", str(len(body)).encode("ascii")),
-        ],
-    })
-    await send({"type": "http.response.body", "body": body})
+    extra = (
+        [(b"www-authenticate", b'Bearer realm="canvas-mcp"')]
+        if bearer_challenge
+        else None
+    )
+    await _send_json_response(send, status, {"error": message}, extra_headers=extra)
 
 
 # The only public (pre-auth) route posts a form containing one short signed
@@ -122,9 +153,45 @@ def _access_key_ok(presented: str, allowed: frozenset[str]) -> bool:
     """Constant-time check of a presented access key against the allowed set."""
     if not presented:
         return False
-    # compare_digest against each key; the any() still runs every comparison's
-    # constant-time op, avoiding early-exit timing leaks on the matched key.
-    return any(hmac.compare_digest(presented, key) for key in allowed)
+    # Compare against every configured key even after a match, so rotation does
+    # not expose which position matched through early-exit timing.
+    matched = False
+    for key in allowed:
+        matched |= hmac.compare_digest(presented, key)
+    return matched
+
+
+def _presented_access_key(headers: dict[bytes, bytes]) -> tuple[str, str | None]:
+    """Read a standard bearer key, with legacy header compatibility.
+
+    Returns ``(key, error)``. Supplying both forms is allowed only when they
+    match, so a proxy-injected header cannot silently override the credential
+    the client believes it sent.
+    """
+    legacy = (
+        headers.get(b"x-mcp-access-key", b"").decode("utf-8", errors="ignore").strip()
+    )
+    raw_authorization = (
+        headers.get(b"authorization", b"").decode("utf-8", errors="ignore").strip()
+    )
+    bearer = ""
+    if raw_authorization:
+        parts = raw_authorization.split()
+        if len(parts) != 2 or parts[0].lower() != "bearer" or not parts[1]:
+            return "", "Malformed Authorization bearer credential"
+        bearer = parts[1]
+
+    if bearer and legacy and not hmac.compare_digest(bearer, legacy):
+        return "", "Conflicting access credentials"
+    return bearer or legacy, None
+
+
+def _poke_user_audit_id(headers: dict[bytes, bytes]) -> str | None:
+    """Return a non-reversible short handle for Poke's untrusted user header."""
+    raw = headers.get(b"x-poke-user-id", b"").decode("utf-8", errors="ignore").strip()
+    if not raw:
+        return None
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
 
 
 def _client_principal_id(headers: dict[bytes, bytes]) -> str | None:
@@ -134,7 +201,11 @@ def _client_principal_id(headers: dict[bytes, bytes]) -> str | None:
     validates the token; external callers cannot spoof it (the platform strips
     inbound ``X-MS-*`` headers). Empty/absent → ``None``.
     """
-    pid = headers.get(b"x-ms-client-principal-id", b"").decode("utf-8", errors="ignore").strip()
+    pid = (
+        headers.get(b"x-ms-client-principal-id", b"")
+        .decode("utf-8", errors="ignore")
+        .strip()
+    )
     return pid or None
 
 
@@ -177,6 +248,7 @@ def _access_store(config: Any) -> Any:
     global _overlay_store
     if _overlay_store is None:
         from .core.access.factory import build_store
+
         _overlay_store = build_store(config)
     return _overlay_store
 
@@ -222,7 +294,9 @@ def _notify_admitted(oid: str, now: float) -> bool:
     # Bound the table itself: it is keyed by attacker-supplied identities, so an
     # unbounded dict is the same leak one layer up. Oldest entries go first.
     if len(_notify_last_scheduled) >= _NOTIFY_MAX_TRACKED_OIDS:
-        for stale, _ in sorted(_notify_last_scheduled.items(), key=lambda kv: kv[1])[:64]:
+        for stale, _ in sorted(_notify_last_scheduled.items(), key=lambda kv: kv[1])[
+            :64
+        ]:
             _notify_last_scheduled.pop(stale, None)
 
     _notify_last_scheduled[oid] = now
@@ -248,13 +322,21 @@ def _schedule_notify(config: Any, store: Any, requester: Any) -> None:
         return
     now = int(time.time())
     now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now))
-    task = asyncio.create_task(notify_access_request(
-        store=store, requester=requester, secret=config.access_token_secret,
-        approve_base_url=config.access_approve_base_url,
-        admin_emails=config.access_admin_emails,
-        cooldown_hours=config.access_notify_cooldown_hours,
-        ttl_seconds=24 * 3600, send_email=sender,
-        jti=uuid.uuid4().hex, now=now, now_iso=now_iso))
+    task = asyncio.create_task(
+        notify_access_request(
+            store=store,
+            requester=requester,
+            secret=config.access_token_secret,
+            approve_base_url=config.access_approve_base_url,
+            admin_emails=config.access_admin_emails,
+            cooldown_hours=config.access_notify_cooldown_hours,
+            ttl_seconds=24 * 3600,
+            send_email=sender,
+            jti=uuid.uuid4().hex,
+            now=now,
+            now_iso=now_iso,
+        )
+    )
     # Tracked so the in-flight cap above is real, and so the task is not garbage
     # collected mid-flight (asyncio only holds a weak reference).
     _notify_inflight.add(task)
@@ -262,16 +344,16 @@ def _schedule_notify(config: Any, store: Any, requester: Any) -> None:
 
 
 class CanvasCredentialMiddleware:
-    """ASGI middleware that extracts the caller's Canvas token from headers.
+    """ASGI middleware for MCP access control and Canvas credentials.
 
-    For each incoming HTTP request, reads X-Canvas-Token and combines it with
-    the server-pinned CANVAS_API_URL so make_canvas_request uses the caller's
-    own Canvas token instead of any server .env token.
+    ``request-header`` mode reads X-Canvas-Token per caller. ``server`` mode
+    uses the operator's CANVAS_API_TOKEN from the server secret store. Both use
+    the server-pinned CANVAS_API_URL.
 
     Fail-closed semantics:
-    - When MCP_ACCESS_KEYS is configured, a missing/invalid X-MCP-Access-Key
-      returns HTTP 401 before anything else (the v1 multi-user gate).
-    - A missing/blank X-Canvas-Token returns HTTP 401 before the app runs.
+    - MCP_ACCESS_KEYS accepts standard Authorization: Bearer credentials and
+      the legacy X-MCP-Access-Key header.
+    - A missing credential for the configured mode fails before the app runs.
     - X-Canvas-URL is ignored (logged); the Canvas API URL is never
       client-controlled, which removes the SSRF surface entirely.
     - The "HTTP request active" marker is set so downstream code refuses to
@@ -290,9 +372,25 @@ class CanvasCredentialMiddleware:
         config = get_config()
         path = scope.get("path", "")
 
+        # Deliberately public and information-minimal so container platforms can
+        # check liveness without receiving either secret.
+        if path == "/healthz":
+            method = scope.get("method", "GET").upper()
+            if method not in {"GET", "HEAD"}:
+                await _send_json_error(send, 405, "Method not allowed")
+                return
+            await _send_json_response(
+                send,
+                200,
+                {"status": "ok"},
+                head_only=method == "HEAD",
+            )
+            return
+
         # --- Admin access-approval routes (intercepted before any token gate) ---
         if path in (_ADMIN_APPROVE_PATH, _ADMIN_CONFIRM_PATH):
             from .core.access.factory import feature_ready
+
             if not (config.access_request_enabled and feature_ready(config)):
                 await _send_json_error(send, 404, "Not found")
                 return
@@ -301,10 +399,16 @@ class CanvasCredentialMiddleware:
                 await _send_json_error(send, 503, "Access service unavailable")
                 return
             from .core.access import routes
+
             now = int(time.time())
             if path == _ADMIN_APPROVE_PATH:
-                await routes.handle_approve(scope.get("query_string", b""), send,
-                                            store=store, secret=config.access_token_secret, now=now)
+                await routes.handle_approve(
+                    scope.get("query_string", b""),
+                    send,
+                    store=store,
+                    secret=config.access_token_secret,
+                    now=now,
+                )
             else:
                 # This route is reached before any authentication, so bound it
                 # before reading anything. It only ever carries a short signed
@@ -320,8 +424,9 @@ class CanvasCredentialMiddleware:
                 if body is None:
                     await _send_json_error(send, 413, "Request body too large")
                     return
-                await routes.handle_confirm(body, send, store=store,
-                                            secret=config.access_token_secret, now=now)
+                await routes.handle_confirm(
+                    body, send, store=store, secret=config.access_token_secret, now=now
+                )
             return
 
         set_http_request_active(True)
@@ -351,16 +456,20 @@ class CanvasCredentialMiddleware:
                     # can never delay or break the 403 (auth boundary: respond,
                     # then notify). The notify is additionally guarded so a
                     # scheduling error degrades to "no email", never a dropped 403.
-                    await _send_json_error(send, 403, "Identity not authorized for this MCP server")
+                    await _send_json_error(
+                        send, 403, "Identity not authorized for this MCP server"
+                    )
                     if config.access_request_enabled and store is not None:
                         try:
                             claims_for_req = _client_principal_claims(headers)
                             from .core.access.store import Requester
+
                             requester = Requester(
                                 oid=oid,
                                 upn=claims_for_req.get("preferred_username")
                                 or claims_for_req.get("upn", ""),
-                                display_name=claims_for_req.get("name", ""))
+                                display_name=claims_for_req.get("name", ""),
+                            )
                             _schedule_notify(config, store, requester)
                         except Exception as exc:
                             log_error(f"access-request notify scheduling failed: {exc}")
@@ -382,24 +491,67 @@ class CanvasCredentialMiddleware:
                 # v1 access-key gate (when configured): reject before touching creds.
                 allowed_keys = config.mcp_access_keys
                 if allowed_keys:
-                    presented = headers.get(b"x-mcp-access-key", b"").decode("utf-8", errors="ignore").strip()
-                    if not _access_key_ok(presented, allowed_keys):
-                        await _send_json_error(send, 401, "Invalid or missing X-MCP-Access-Key")
+                    presented, credential_error = _presented_access_key(headers)
+                    if credential_error:
+                        await _send_json_error(
+                            send,
+                            401,
+                            credential_error,
+                            bearer_challenge=True,
+                        )
                         return
+                    if not _access_key_ok(presented, allowed_keys):
+                        await _send_json_error(
+                            send,
+                            401,
+                            "Invalid or missing MCP access key",
+                            bearer_challenge=True,
+                        )
+                        return
+                    poke_user = _poke_user_audit_id(headers)
+                    if poke_user:
+                        log_info(
+                            "MCP request authorized via access key",
+                            poke_user_hash=poke_user,
+                        )
 
-            token = headers.get(b"x-canvas-token", b"").decode("utf-8", errors="ignore").strip()
+            credential_mode = config.mcp_http_credential_mode
+            if credential_mode == "server":
+                if headers.get(b"x-canvas-token", b"").strip():
+                    await _send_json_error(
+                        send,
+                        400,
+                        "X-Canvas-Token is not accepted in server credential mode",
+                    )
+                    return
+                token = config.canvas_api_token.strip()
+                missing_token_message = "Server Canvas API token is not configured"
+            else:
+                token = (
+                    headers.get(b"x-canvas-token", b"")
+                    .decode("utf-8", errors="ignore")
+                    .strip()
+                )
+                missing_token_message = "Missing X-Canvas-Token header"
 
             if b"x-canvas-url" in headers:
-                log_warning("Ignoring X-Canvas-URL header; Canvas API URL is server-pinned")
+                log_warning(
+                    "Ignoring X-Canvas-URL header; Canvas API URL is server-pinned"
+                )
 
             if not token:
-                await _send_json_error(send, 401, "Missing X-Canvas-Token header")
+                status = 500 if credential_mode == "server" else 401
+                await _send_json_error(send, status, missing_token_message)
                 return
 
             canvas_url = config.canvas_api_url.strip()
             if not canvas_url:
-                log_error("CANVAS_API_URL is required in HTTP mode but is not configured")
-                await _send_json_error(send, 500, "Server Canvas API URL is not configured")
+                log_error(
+                    "CANVAS_API_URL is required in HTTP mode but is not configured"
+                )
+                await _send_json_error(
+                    send, 500, "Server Canvas API URL is not configured"
+                )
                 return
 
             set_request_credentials(
@@ -437,6 +589,7 @@ def register_all_tools(mcp: FastMCP, role: str = "all") -> None:
     register_shared_module_tools(mcp)
     register_shared_file_tools(mcp)
     register_shared_messaging_tools(mcp)
+    register_shared_quiz_tools(mcp)
     register_discovery_tools(mcp)
     # Caller-scoped identity: needs no roster permission, so every profile gets it.
     register_self_identity_tools(mcp)
@@ -447,6 +600,8 @@ def register_all_tools(mcp: FastMCP, role: str = "all") -> None:
         # Tier 1 writes register only for tools the operator named in
         # STUDENT_WRITE_TOOLS (default: none). See tools/student_write.py.
         register_student_write_tools(mcp)
+        if get_config().quiz_taking_enabled:
+            register_student_quiz_tools(mcp)
 
     # Educator-specific tools
     if role in ("educator", "all"):
@@ -485,7 +640,9 @@ async def _validate_token() -> tuple[bool, str]:
         response = await make_canvas_request("get", "/users/self")
         if isinstance(response, dict) and "error" in response:
             return (False, f"Token validation failed: {response['error']}")
-        user_name = response.get("name", "Unknown") if isinstance(response, dict) else "Unknown"
+        user_name = (
+            response.get("name", "Unknown") if isinstance(response, dict) else "Unknown"
+        )
         return (True, f"Authenticated as: {user_name}")
     except Exception as e:
         return (False, f"Token validation error: {type(e).__name__}: {e}")
@@ -496,6 +653,7 @@ def test_connection() -> bool:
     log_info("Testing Canvas API connection...")
 
     try:
+
         async def test_api() -> bool:
             ok, message = await _validate_token()
             if ok:
@@ -546,47 +704,38 @@ def main() -> None:
         description="Canvas MCP Server - AI-powered Canvas LMS integration"
     )
     parser.add_argument(
-        "--test",
-        action="store_true",
-        help="Test Canvas API connection and exit"
+        "--test", action="store_true", help="Test Canvas API connection and exit"
     )
     parser.add_argument(
-        "--config",
-        action="store_true",
-        help="Show current configuration and exit"
+        "--config", action="store_true", help="Show current configuration and exit"
     )
     parser.add_argument(
         "--transport",
         choices=["stdio", "streamable-http"],
         default="stdio",
-        help="Transport protocol (default: stdio)"
+        help="Transport protocol (default: stdio)",
     )
     parser.add_argument(
-        "--host",
-        default="0.0.0.0",
-        help="Host to bind HTTP server (default: 0.0.0.0)"
+        "--host", default="0.0.0.0", help="Host to bind HTTP server (default: 0.0.0.0)"
     )
     parser.add_argument(
-        "--port",
-        type=int,
-        default=8819,
-        help="Port for HTTP server (default: 8819)"
+        "--port", type=int, default=8819, help="Port for HTTP server (default: 8819)"
     )
     parser.add_argument(
         "--role",
         choices=["student", "educator", "all"],
         default=None,
-        help="Tool profile: student (~37 tools), educator (~88 tools), all (default: all)"
+        help="Tool profile: student (~39 tools), educator (~90 tools), all (default: all)",
     )
     parser.add_argument(
         "--list-grants",
         action="store_true",
-        help="List self-service access grants (hosted; needs az login) and exit"
+        help="List self-service access grants (hosted; needs az login) and exit",
     )
     parser.add_argument(
         "--revoke",
         metavar="OID",
-        help="Revoke a self-service access grant by Entra OID and exit"
+        help="Revoke a self-service access grant by Entra OID and exit",
     )
 
     args = parser.parse_args()
@@ -602,12 +751,18 @@ def main() -> None:
     if args.revoke:
         raise SystemExit(_cmd_revoke(args))
 
-    # HTTP mode: the Canvas URL is server-pinned and per-user tokens arrive via
-    # X-Canvas-Token. A server token must NOT be set, or a missing request token
-    # could silently fall back to it (mis-attributing actions to the operator).
+    # HTTP mode always pins the Canvas URL. Credential sourcing is explicit:
+    # request-header keeps the existing per-user model; server is a private,
+    # single-user mode for standard bearer-only clients such as Poke.
     if is_http:
+        credential_mode = config.mcp_http_credential_mode
+        if credential_mode not in VALID_HTTP_CREDENTIAL_MODES:
+            log_error("MCP_HTTP_CREDENTIAL_MODE must be 'request-header' or 'server'")
+            sys.exit(1)
         if not config.canvas_api_url:
-            log_error("CANVAS_API_URL is required in HTTP mode (the Canvas API URL is server-pinned)")
+            log_error(
+                "CANVAS_API_URL is required in HTTP mode (the Canvas API URL is server-pinned)"
+            )
             sys.exit(1)
         # HTTP mode never calls validate_config() (that path is stdio's .env
         # check), so the cleartext-URL rejection has to be applied here too.
@@ -615,13 +770,51 @@ def main() -> None:
         # http:// typo leaks every caller's token, not just the operator's.
         if not validate_canvas_url_scheme():
             sys.exit(1)
-        if config.canvas_api_token:
-            log_error(
-                "CANVAS_API_TOKEN must NOT be set in HTTP mode — clients supply their "
-                "own token via the X-Canvas-Token header. Unset it and restart."
-            )
-            sys.exit(1)
-        if config.entra_auth_enabled and not config.mcp_allow_unauthenticated:
+
+        if credential_mode == "server":
+            if not config.canvas_api_token:
+                log_error(
+                    "CANVAS_API_TOKEN is required when "
+                    "MCP_HTTP_CREDENTIAL_MODE=server"
+                )
+                sys.exit(1)
+            if not config.mcp_access_keys:
+                log_error(
+                    "MCP_ACCESS_KEYS is required when "
+                    "MCP_HTTP_CREDENTIAL_MODE=server"
+                )
+                sys.exit(1)
+            if config.mcp_allow_unauthenticated:
+                log_error(
+                    "MCP_ALLOW_UNAUTHENTICATED cannot be enabled in server "
+                    "credential mode"
+                )
+                sys.exit(1)
+            if config.entra_auth_enabled:
+                log_error(
+                    "ENTRA_AUTH_ENABLED is incompatible with server credential mode"
+                )
+                sys.exit(1)
+            if config.access_request_enabled:
+                log_error(
+                    "ACCESS_REQUEST_ENABLED is only supported with Entra "
+                    "request-header deployments"
+                )
+                sys.exit(1)
+        else:
+            if config.canvas_api_token:
+                log_error(
+                    "CANVAS_API_TOKEN must NOT be set in request-header HTTP "
+                    "mode — clients supply their own token via X-Canvas-Token. "
+                    "Unset it and restart."
+                )
+                sys.exit(1)
+
+        if (
+            credential_mode == "request-header"
+            and config.entra_auth_enabled
+            and not config.mcp_allow_unauthenticated
+        ):
             # Entra platform-auth trusts the X-MS-CLIENT-PRINCIPAL-ID header, which
             # is ONLY safe when Azure App Service auth actually fronts the endpoint
             # (it strips client-supplied X-MS-* headers). The app can't detect that
@@ -636,7 +829,11 @@ def main() -> None:
                 "platform, the identity header is client-spoofable."
             )
             sys.exit(1)
-        if not config.entra_auth_enabled and not config.mcp_access_keys:
+        if (
+            credential_mode == "request-header"
+            and not config.entra_auth_enabled
+            and not config.mcp_access_keys
+        ):
             # Secure-by-default: refuse to start an ungated endpoint unless the
             # operator has explicitly accepted that external auth fronts it.
             # Student education records are FERPA "Sensitive" data (U of I DAT01)
@@ -674,6 +871,10 @@ def main() -> None:
         if is_http:
             print(f"  Host: {args.host}", file=sys.stderr)
             print(f"  Port: {args.port}", file=sys.stderr)
+            print(
+                f"  HTTP Credential Mode: {config.mcp_http_credential_mode}",
+                file=sys.stderr,
+            )
         else:
             print(f"  Canvas API URL: {config.canvas_api_url}", file=sys.stderr)
         print(f"  Debug Mode: {config.debug}", file=sys.stderr)
@@ -688,24 +889,21 @@ def main() -> None:
             if config.ts_sandbox_timeout_sec > 0:
                 print(
                     f"  Sandbox Timeout: {config.ts_sandbox_timeout_sec}s",
-                    file=sys.stderr
+                    file=sys.stderr,
                 )
             if config.ts_sandbox_memory_limit_mb > 0:
                 print(
                     f"  Sandbox Memory: {config.ts_sandbox_memory_limit_mb}MB",
-                    file=sys.stderr
+                    file=sys.stderr,
                 )
             if config.ts_sandbox_cpu_limit > 0:
                 print(
                     f"  Sandbox CPU Limit: {config.ts_sandbox_cpu_limit}s",
-                    file=sys.stderr
+                    file=sys.stderr,
                 )
             if config.ts_sandbox_block_outbound_network:
                 allowlist = config.ts_sandbox_allowlist_hosts or "canvas API only"
-                print(
-                    f"  Sandbox Network Allowlist: {allowlist}",
-                    file=sys.stderr
-                )
+                print(f"  Sandbox Network Allowlist: {allowlist}", file=sys.stderr)
         if config.institution_name:
             print(f"  Institution: {config.institution_name}", file=sys.stderr)
         sys.exit(0)
@@ -720,14 +918,22 @@ def main() -> None:
 
     # Initialize audit logging (before any API calls)
     from .core.audit import init_audit_logging
+
     init_audit_logging()
 
     # Normal server startup
     if is_http:
-        log_info(
-            f"Starting Canvas MCP server in HTTP mode on {args.host}:{args.port}"
-        )
-        log_info("Credentials: per-request via X-Canvas-Token header; Canvas API URL is server-pinned")
+        log_info(f"Starting Canvas MCP server in HTTP mode on {args.host}:{args.port}")
+        if config.mcp_http_credential_mode == "server":
+            log_info(
+                "Credentials: server-held Canvas token behind bearer access "
+                "key; Canvas API URL is server-pinned"
+            )
+        else:
+            log_info(
+                "Credentials: per-request via X-Canvas-Token header; Canvas "
+                "API URL is server-pinned"
+            )
     else:
         log_info(f"Starting Canvas MCP server with API URL: {config.canvas_api_url}")
 
@@ -756,6 +962,7 @@ def main() -> None:
             # validation is now bound to that closed loop.  Reset them so they
             # are recreated fresh inside the event loop that mcp.run() starts.
             from .core import client as _client_module
+
             _client_module.http_client = None
             _client_module._http_client_loop_ref = None
             _client_module._request_semaphore = None
@@ -808,9 +1015,9 @@ def _run_http_server(mcp: FastMCP, host: str, port: int) -> None:
     # CanvasCredentialMiddleware passes lifespan scopes through, so the
     # inner app's lifespan (required by fastmcp) still runs under uvicorn.
     #
-    # stateless_http=True: every request is self-contained (credentials arrive
-    # per-request via X-Canvas-Token; no tool uses server-initiated session
-    # features), so keeping an in-memory session table only creates a failure
+    # stateless_http=True: every request is self-contained (Canvas credentials
+    # are installed into request-local context; no tool uses server-initiated
+    # session features), so keeping an in-memory session table only creates a failure
     # mode — an App Service recycle drops it, and mcp-remote hangs forever on
     # the resulting stale-session 404 instead of re-initializing (issue #159).
     starlette_app = mcp.http_app(stateless_http=True)

--- a/src/canvas_mcp/tools/__init__.py
+++ b/src/canvas_mcp/tools/__init__.py
@@ -23,6 +23,7 @@ from .modules import register_educator_module_tools, register_shared_module_tool
 from .pages import register_educator_page_crud_tools, register_page_tools
 from .peer_review_comments import register_peer_review_comment_tools
 from .peer_reviews import register_peer_review_tools
+from .quizzes import register_shared_quiz_tools, register_student_quiz_tools
 from .rubrics import register_rubric_tools
 from .self_identity import register_self_identity_tools
 from .student_tools import register_student_tools
@@ -52,6 +53,8 @@ __all__ = [
     'register_shared_file_tools',
     'register_shared_messaging_tools',
     'register_shared_module_tools',
+    'register_shared_quiz_tools',
+    'register_student_quiz_tools',
     'register_student_tools',
     'register_student_write_tools',
 ]

--- a/src/canvas_mcp/tools/quizzes.py
+++ b/src/canvas_mcp/tools/quizzes.py
@@ -1,0 +1,812 @@
+"""Quiz-related MCP tools for Canvas API (Classic Quizzes).
+
+These tools cover the student-facing quiz lifecycle:
+
+    list_quizzes -> get_quiz_details -> start_quiz_attempt
+        -> answer_quiz_questions -> submit_quiz_attempt
+
+IMPORTANT — Classic Quizzes only
+--------------------------------
+The tools here target Canvas **Classic Quizzes** (the ``/api/v1/courses/:id/quizzes``
+REST API). Canvas **New Quizzes** (the ``quiz_lti`` engine) does not expose a public
+REST API for listing questions or recording answers; those quizzes surface as
+assignments (see ``list_assignments``) and cannot be taken through these tools.
+
+Taking a quiz is a multi-step workflow because Canvas requires you to *start an
+attempt* first — that call returns a ``validation_token`` plus the questions with
+their answer choices, which you then need to record answers and turn the quiz in.
+"""
+
+import json
+from typing import Any
+
+from fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+from ..core.cache import get_course_code, get_course_id
+from ..core.client import fetch_all_paginated_results, make_canvas_request
+from ..core.dates import format_date
+from ..core.untrusted_content import fence_untrusted, fence_untrusted_inline
+from ..core.validation import validate_params
+from ..core.write_confirmation import ConfirmationGuard
+from .courses import strip_html_tags
+
+_START_ATTEMPT_GUARD = ConfirmationGuard(ttl_seconds=300)
+_SUBMIT_ATTEMPT_GUARD = ConfirmationGuard(ttl_seconds=300)
+
+# Question types and the `answer` value they expect (summarised from the Canvas
+# "Question Answer Formats" appendix). Surfaced to callers in tool docstrings and
+# in the started-attempt output so an agent can build correctly-typed answers.
+ANSWER_FORMAT_HELP = (
+    "multiple_choice_question / true_false_question: answer id (int); "
+    "multiple_answers_question: array of answer ids, e.g. [3, 6]; "
+    "short_answer_question (fill-in-the-blank): string; "
+    "essay_question: string (may contain HTML); "
+    "numerical_question / calculated_question: number (or numeric string); "
+    'fill_in_multiple_blanks_question: object {blank_name: "text"}; '
+    "multiple_dropdowns_question: object {blank_name: answer_id}; "
+    'matching_question: array of {"answer_id": id, "match_id": id}.'
+)
+
+
+def _truncate(text: str, limit: int) -> str:
+    """Strip whitespace and append an ellipsis marker when over ``limit`` chars."""
+    text = (text or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[:limit].rstrip() + "… [truncated]"
+
+
+def _format_submission_question(question: dict[str, Any]) -> str:
+    """Render one in-progress quiz-submission question (with its answer choices)."""
+    qid = question.get("id")
+    qtype = question.get("question_type", "unknown")
+    qname = question.get("question_name", "")
+    qtext = _truncate(strip_html_tags(question.get("question_text", "") or ""), 600)
+
+    lines = [f"  Question ID: {qid}", f"  Type: {qtype}"]
+    if qname:
+        lines.append("  Name: " + fence_untrusted_inline(qname, "quiz question name"))
+    lines.append(
+        "  Text:\n" + fence_untrusted(qtext or "(no text)", "quiz question text")
+    )
+
+    # Answer choices — present for choice-type questions (permissions-dependent).
+    # Each may carry a blank_id for fill-in-multiple-blanks / multiple-dropdowns.
+    answers = question.get("answers")
+    if isinstance(answers, list) and answers:
+        lines.append("  Answer choices:")
+        for ans in answers:
+            aid = ans.get("id")
+            atext = _truncate(
+                strip_html_tags(str(ans.get("text") or ans.get("html") or "")), 200
+            )
+            blank = ans.get("blank_id")
+            blank_part = f" [blank: {blank}]" if blank else ""
+            lines.append(
+                f"    - id={aid}{blank_part}: "
+                + fence_untrusted_inline(atext, "quiz answer choice")
+            )
+
+    # Matching questions also expose the set of match options to pair against.
+    matches = question.get("matches")
+    if isinstance(matches, list) and matches:
+        lines.append("  Match options:")
+        for match in matches:
+            mid = match.get("match_id")
+            mtext = _truncate(strip_html_tags(str(match.get("text") or "")), 200)
+            lines.append(
+                f"    - match_id={mid}: "
+                + fence_untrusted_inline(mtext, "quiz match option")
+            )
+
+    current = question.get("answer")
+    if current not in (None, "", [], {}):
+        lines.append(f"  Current answer: {current}")
+
+    return "\n".join(lines)
+
+
+def reset_quiz_confirmations() -> None:
+    """Reset quiz confirmation state for deterministic tests."""
+    _START_ATTEMPT_GUARD.reset()
+    _SUBMIT_ATTEMPT_GUARD.reset()
+
+
+def _first_submission(response: Any) -> dict[str, Any] | None:
+    """Extract the current user's first quiz submission from Canvas output."""
+    if not isinstance(response, dict):
+        return None
+    submissions = response.get("quiz_submissions") or []
+    return submissions[0] if submissions and isinstance(submissions[0], dict) else None
+
+
+async def _fetch_quiz_state(
+    course_id: str | int,
+    quiz_id: str | int,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, str | None]:
+    """Load settings and current attempt state before issuing a confirmation."""
+    quiz = await make_canvas_request("get", f"/courses/{course_id}/quizzes/{quiz_id}")
+    if not isinstance(quiz, dict) or "error" in quiz:
+        error = (
+            quiz.get("error", "unexpected response") if isinstance(quiz, dict) else quiz
+        )
+        return None, None, f"Error fetching quiz details: {error}"
+
+    response = await make_canvas_request(
+        "get",
+        f"/courses/{course_id}/quizzes/{quiz_id}/submission",
+        skip_anonymization=True,
+    )
+    if isinstance(response, dict) and "error" in response:
+        return None, None, f"Error fetching current quiz attempt: {response['error']}"
+    return quiz, _first_submission(response), None
+
+
+def _quiz_state_payload(quiz: dict[str, Any], submission: dict[str, Any] | None) -> str:
+    """Serialize only state whose drift must invalidate a confirmation."""
+    quiz_state = {
+        key: quiz.get(key)
+        for key in (
+            "id",
+            "allowed_attempts",
+            "time_limit",
+            "due_at",
+            "unlock_at",
+            "lock_at",
+            "locked_for_user",
+            "published",
+        )
+    }
+    submission_state = (
+        {
+            key: submission.get(key)
+            for key in ("id", "attempt", "workflow_state", "end_at")
+        }
+        if submission
+        else None
+    )
+    return json.dumps(
+        {"quiz": quiz_state, "submission": submission_state},
+        sort_keys=True,
+        default=str,
+    )
+
+
+def _question_state_payload(response: Any) -> str:
+    """Serialize current answers so edits invalidate a submit confirmation."""
+    questions = (
+        response.get("quiz_submission_questions", [])
+        if isinstance(response, dict)
+        else response
+    )
+    if not isinstance(questions, list):
+        questions = []
+    state = [
+        {
+            "id": question.get("id"),
+            "answer": question.get("answer"),
+            "flagged": question.get("flagged", False),
+        }
+        for question in questions
+        if isinstance(question, dict)
+    ]
+    return json.dumps(state, sort_keys=True, default=str)
+
+
+def _burn_on_confirmation_error(
+    guard: ConfirmationGuard,
+    token: str,
+    fingerprint: str,
+) -> str | None:
+    """Validate a token and burn genuine mismatches to prevent revert replay."""
+    error = guard.check(token, fingerprint)
+    if error:
+        guard.reserve(token)
+    return error
+
+
+async def _fetch_submission_questions(quiz_submission_id: str | int) -> Any:
+    """GET the questions for an in-progress quiz submission (the current user's)."""
+    return await make_canvas_request(
+        "get",
+        f"/quiz_submissions/{quiz_submission_id}/questions",
+        skip_anonymization=True,
+    )
+
+
+async def _render_started_attempt(submission: dict[str, Any], header: str) -> str:
+    """Format a started/resumed attempt: the tokens to keep plus its questions."""
+    sub_id = submission.get("id")
+    attempt = submission.get("attempt")
+    token = submission.get("validation_token", "")
+    end_at = submission.get("end_at")
+    if not isinstance(sub_id, (str, int)):
+        return "Error loading quiz attempt: Canvas returned no quiz_submission_id."
+
+    lines = [
+        f"{header} (quiz {submission.get('quiz_id')}):",
+        "",
+        "⚠️  Save these — required by answer_quiz_questions and submit_quiz_attempt:",
+        f"  quiz_submission_id: {sub_id}",
+        f"  attempt: {attempt}",
+        f"  validation_token: {token}",
+        f"  workflow_state: {submission.get('workflow_state', 'untaken')}",
+    ]
+    if end_at:
+        lines.append(f"  attempt due (end_at): {format_date(end_at)}")
+
+    questions = await _fetch_submission_questions(sub_id)
+    lines.append("")
+    if isinstance(questions, dict) and "error" in questions:
+        lines.append(f"(Could not load questions: {questions['error']})")
+        return "\n".join(lines)
+
+    qlist = (
+        questions.get("quiz_submission_questions")
+        if isinstance(questions, dict)
+        else questions
+    )
+    if not qlist:
+        lines.append("No questions were returned for this attempt.")
+        return "\n".join(lines)
+
+    lines.append(f"Questions ({len(qlist)}):")
+    lines.append("")
+    for question in qlist:
+        lines.append(_format_submission_question(question))
+        lines.append("")
+
+    lines.append(f"Answer value formats — {ANSWER_FORMAT_HELP}")
+    lines.append(
+        "Next: call answer_quiz_questions with the IDs/tokens above, then "
+        "submit_quiz_attempt to turn the quiz in."
+    )
+    return "\n".join(lines)
+
+
+def _normalize_answers(
+    answers_json: str,
+) -> tuple[list[dict[str, Any]] | None, str | None]:
+    """Parse the flexible ``answers`` input into Canvas's ``quiz_questions`` array.
+
+    Accepts either form (as a JSON string):
+      - an object mapping question id -> answer value:
+            {"4": 5, "5": "Paris"}
+      - an array of per-question objects:
+            [{"id": 4, "answer": 5}, {"id": 5, "answer": "Paris", "flagged": true}]
+
+    Returns ``(quiz_questions, None)`` on success, or ``(None, error_message)``.
+    """
+    try:
+        parsed = json.loads(answers_json)
+    except (json.JSONDecodeError, TypeError) as exc:
+        return None, (
+            f"Invalid answers JSON: {exc}. Provide a JSON object "
+            '{"<question_id>": <answer>} or an array of {"id", "answer"}.'
+        )
+
+    quiz_questions: list[dict[str, Any]] = []
+
+    if isinstance(parsed, dict):
+        for qid, answer in parsed.items():
+            quiz_questions.append({"id": str(qid), "answer": answer})
+    elif isinstance(parsed, list):
+        for entry in parsed:
+            if not isinstance(entry, dict):
+                return (
+                    None,
+                    "Each answers array item must be an object with 'id' and 'answer'.",
+                )
+            qid = entry.get("id", entry.get("question_id"))
+            if qid is None:
+                return (
+                    None,
+                    "Each answers array item must include an 'id' (question ID).",
+                )
+            if "answer" not in entry:
+                return None, f"Answer for question {qid} is missing an 'answer' field."
+            item: dict[str, Any] = {"id": str(qid), "answer": entry["answer"]}
+            if "flagged" in entry:
+                item["flagged"] = entry["flagged"]
+            quiz_questions.append(item)
+    else:
+        return None, "answers must be a JSON object or array."
+
+    if not quiz_questions:
+        return None, "No answers provided."
+    return quiz_questions, None
+
+
+def register_shared_quiz_tools(mcp: FastMCP) -> None:
+    """Register quiz tools available to all roles (read-only browse/inspect)."""
+
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @validate_params
+    async def list_quizzes(
+        course_identifier: str | int,
+        search_term: str | None = None,
+    ) -> str:
+        """List Classic Quizzes available in a course.
+
+        Args:
+            course_identifier: Course code or Canvas ID
+            search_term: Optional partial quiz title to filter by
+
+        Note: Only Classic Quizzes appear here. "New Quizzes" show up as
+        assignments (use list_assignments) and cannot be taken via these tools.
+        """
+        course_id = await get_course_id(course_identifier)
+
+        params: dict[str, Any] = {"per_page": 100}
+        if search_term:
+            params["search_term"] = search_term
+
+        quizzes = await fetch_all_paginated_results(
+            f"/courses/{course_id}/quizzes", params
+        )
+
+        if isinstance(quizzes, dict) and "error" in quizzes:
+            return f"Error fetching quizzes: {quizzes['error']}"
+
+        if not quizzes:
+            return f"No quizzes found for course {course_identifier}."
+
+        course_display = await get_course_code(course_id) or course_identifier
+        lines = [f"Quizzes for Course {course_display}:\n"]
+
+        for quiz in quizzes:
+            qid = quiz.get("id")
+            title = fence_untrusted_inline(
+                quiz.get("title", "Untitled quiz"), "quiz title"
+            )
+            qtype = quiz.get("quiz_type", "unknown")
+            points = quiz.get("points_possible")
+            qcount = quiz.get("question_count")
+            due = format_date(quiz.get("due_at"))
+
+            status = ["published" if quiz.get("published") else "unpublished"]
+            if quiz.get("locked_for_user"):
+                status.append("🔒 locked")
+
+            lines.append(
+                f"ID: {qid}\n"
+                f"Title: {title}\n"
+                f"Type: {qtype}\n"
+                f"Questions: {qcount if qcount is not None else 'N/A'}\n"
+                f"Points: {points if points is not None else 'N/A'}\n"
+                f"Due: {due}\n"
+                f"Status: {', '.join(status)}\n"
+            )
+
+        return "\n".join(lines)
+
+    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @validate_params
+    async def get_quiz_details(
+        course_identifier: str | int,
+        quiz_id: str | int,
+    ) -> str:
+        """Get detailed settings for a single Classic Quiz.
+
+        Args:
+            course_identifier: Course code or Canvas ID
+            quiz_id: Canvas quiz ID (from list_quizzes)
+        """
+        course_id = await get_course_id(course_identifier)
+
+        quiz = await make_canvas_request(
+            "get", f"/courses/{course_id}/quizzes/{quiz_id}"
+        )
+
+        if isinstance(quiz, dict) and "error" in quiz:
+            return f"Error fetching quiz details: {quiz['error']}"
+
+        description = _truncate(strip_html_tags(quiz.get("description") or ""), 1000)
+        fenced_title = fence_untrusted_inline(quiz.get("title", "N/A"), "quiz title")
+
+        allowed = quiz.get("allowed_attempts")
+        if allowed == -1:
+            allowed_display = "Unlimited"
+        elif allowed is None:
+            allowed_display = "N/A"
+        else:
+            allowed_display = str(allowed)
+
+        time_limit = quiz.get("time_limit")
+        time_display = f"{time_limit} minutes" if time_limit else "No time limit"
+
+        qtypes = quiz.get("question_types") or []
+
+        details = [
+            f"Title: {fenced_title}",
+            f"Quiz ID: {quiz.get('id', quiz_id)}",
+            f"Type: {quiz.get('quiz_type', 'N/A')}",
+            f"Points Possible: {quiz.get('points_possible', 'N/A')}",
+            f"Question Count: {quiz.get('question_count', 'N/A')}",
+            f"Question Types: {', '.join(qtypes) if qtypes else 'N/A'}",
+            f"Allowed Attempts: {allowed_display}",
+            f"Time Limit: {time_display}",
+            f"Scoring Policy: {quiz.get('scoring_policy', 'N/A')}",
+            f"One Question at a Time: {quiz.get('one_question_at_a_time', False)}",
+            f"Can't Go Back: {quiz.get('cant_go_back', False)}",
+            f"Shuffle Answers: {quiz.get('shuffle_answers', False)}",
+            f"Due Date: {format_date(quiz.get('due_at'))}",
+            f"Unlock At: {format_date(quiz.get('unlock_at'))}",
+            f"Lock At: {format_date(quiz.get('lock_at'))}",
+            f"Published: {quiz.get('published', False)}",
+            f"Access Code Required: {bool(quiz.get('access_code') or quiz.get('has_access_code'))}",
+            f"Locked For You: {quiz.get('locked_for_user', False)}",
+        ]
+        if quiz.get("locked_for_user") and quiz.get("lock_explanation"):
+            details.append(
+                "Lock Explanation:\n"
+                + fence_untrusted(
+                    strip_html_tags(quiz["lock_explanation"]),
+                    "quiz lock explanation",
+                )
+            )
+        details.append(
+            "\nDescription:\n"
+            + fence_untrusted(description or "N/A", "quiz description")
+        )
+
+        course_display = await get_course_code(course_id) or course_identifier
+        return (
+            f"Quiz Details for {fenced_title} in course {course_display}:\n\n"
+            + "\n".join(details)
+        )
+
+
+def register_student_quiz_tools(mcp: FastMCP) -> None:
+    """Register tools for taking a Classic Quiz (start, answer, submit).
+
+    All three act on the *authenticated user's own* quiz attempts.
+    """
+
+    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @validate_params
+    async def start_quiz_attempt(
+        course_identifier: str | int,
+        quiz_id: str | int,
+        access_code: str | None = None,
+        confirmation_token: str | None = None,
+    ) -> str:
+        """Preview, then start or resume a Classic Quiz attempt.
+
+        The first call creates nothing. It returns the quiz timing, attempt
+        state, and a short-lived confirmation token. Show that preview to the
+        student, then call again with the token and identical arguments. The
+        confirmed call creates a quiz submission (a "take" session) and returns the
+        ``quiz_submission_id``, ``attempt`` number, and ``validation_token`` —
+        you MUST pass all three to ``answer_quiz_questions`` and
+        ``submit_quiz_attempt``. It also lists each question with its ID, type,
+        and (for choice questions) the available answer choices and their IDs.
+
+        Starting an attempt consumes one of the quiz's allowed attempts. It does
+        NOT turn anything in — answers are recorded separately and the attempt is
+        only submitted when you call ``submit_quiz_attempt``. If an attempt is
+        already in progress, this resumes it instead of starting a new one.
+
+        Args:
+            course_identifier: Course code or Canvas ID
+            quiz_id: Canvas quiz ID (from list_quizzes)
+            access_code: Access code, if the quiz requires one
+            confirmation_token: Token from the preview; omit to preview
+        """
+        course_id = await get_course_id(course_identifier)
+
+        quiz, existing_submission, state_error = await _fetch_quiz_state(
+            course_id, quiz_id
+        )
+        if state_error or quiz is None:
+            return state_error or "Error fetching quiz state"
+
+        fingerprint = _START_ATTEMPT_GUARD.fingerprint(
+            str(course_id),
+            str(quiz_id),
+            access_code or "",
+            _quiz_state_payload(quiz, existing_submission),
+        )
+        title = fence_untrusted_inline(quiz.get("title", "N/A"), "quiz title")
+        resumable_states = {"untaken", "pending", "in_progress"}
+        is_resumable = bool(
+            existing_submission
+            and existing_submission.get("workflow_state") in resumable_states
+        )
+        action = (
+            "Resume the existing attempt" if is_resumable else "Start a new attempt"
+        )
+        current_attempt = (
+            existing_submission.get("attempt") if existing_submission else 0
+        )
+        workflow = (
+            existing_submission.get("workflow_state")
+            if existing_submission
+            else "not started"
+        )
+        allowed_attempts = quiz.get("allowed_attempts")
+        allowed_display = "Unlimited" if allowed_attempts == -1 else allowed_attempts
+
+        if not confirmation_token:
+            token = _START_ATTEMPT_GUARD.issue(fingerprint)
+            return (
+                "Quiz attempt preview — nothing started:\n\n"
+                f"Quiz: {title}\n"
+                f"Action: {action}\n"
+                f"Current workflow state: {workflow}\n"
+                f"Current attempt number: {current_attempt}\n"
+                f"Allowed attempts: {allowed_display if allowed_display is not None else 'N/A'}\n"
+                f"Time limit: {quiz.get('time_limit') or 'No time limit'}"
+                f"{' minutes' if quiz.get('time_limit') else ''}\n"
+                f"Due: {format_date(quiz.get('due_at'))}\n"
+                f"Locks: {format_date(quiz.get('lock_at'))}\n"
+                f"Access code supplied: {access_code is not None}\n\n"
+                f"confirmation_token: {token}\n\n"
+                "Show this preview to the student. To proceed, call "
+                "start_quiz_attempt again with this confirmation_token and "
+                "identical arguments. The token is single-use and expires "
+                "in five minutes."
+            )
+
+        token_error = _burn_on_confirmation_error(
+            _START_ATTEMPT_GUARD, confirmation_token, fingerprint
+        )
+        if token_error:
+            return f"{token_error} Nothing was started."
+        if not _START_ATTEMPT_GUARD.reserve(confirmation_token):
+            return (
+                "❌ That confirmation was already used. Nothing was started. "
+                "Run the preview again."
+            )
+
+        data: dict[str, Any] = {}
+        if access_code is not None:
+            data["access_code"] = access_code
+
+        result = await make_canvas_request(
+            "post",
+            f"/courses/{course_id}/quizzes/{quiz_id}/submissions",
+            data=data,
+            skip_anonymization=True,
+        )
+
+        if isinstance(result, dict) and "error" in result:
+            error = str(result["error"])
+            # 409 Conflict: a submission already exists for this user/quiz. Resume
+            # the in-progress attempt (its validation_token is returned for the
+            # current user) instead of failing.
+            if "409" in error or "Conflict" in error:
+                existing = await make_canvas_request(
+                    "get",
+                    f"/courses/{course_id}/quizzes/{quiz_id}/submission",
+                    skip_anonymization=True,
+                )
+                if isinstance(existing, dict) and "error" not in existing:
+                    subs = existing.get("quiz_submissions") or []
+                    if subs and subs[0].get("validation_token"):
+                        return await _render_started_attempt(
+                            subs[0], header="Resumed in-progress quiz attempt"
+                        )
+            return f"Error starting quiz attempt: {error}"
+
+        submissions = (
+            result.get("quiz_submissions") if isinstance(result, dict) else None
+        )
+        if not submissions:
+            return f"Error starting quiz attempt: unexpected response: {result}"
+
+        return await _render_started_attempt(
+            submissions[0], header="Started quiz attempt"
+        )
+
+    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @validate_params
+    async def answer_quiz_questions(
+        quiz_submission_id: str | int,
+        attempt: int,
+        validation_token: str,
+        answers: str,
+        access_code: str | None = None,
+    ) -> str:
+        """Record answers for an in-progress quiz attempt (does NOT submit it).
+
+        Answers are saved against the open attempt and may be updated by calling
+        this again. Nothing is turned in until you call ``submit_quiz_attempt``.
+
+        Args:
+            quiz_submission_id: From start_quiz_attempt
+            attempt: The attempt number from start_quiz_attempt (must be the latest)
+            validation_token: The token from start_quiz_attempt
+            answers: A JSON string — either an object mapping question id to
+                answer value, e.g. ``{"4": 5, "5": "Paris"}``, or an array of
+                ``{"id": <question_id>, "answer": <value>}`` objects. The answer
+                VALUE format depends on the question type:
+                multiple_choice_question / true_false_question -> answer id (int);
+                multiple_answers_question -> array of answer ids [3, 6];
+                short_answer_question -> string; essay_question -> string;
+                numerical_question / calculated_question -> number;
+                fill_in_multiple_blanks_question -> {"blank_name": "text"};
+                multiple_dropdowns_question -> {"blank_name": answer_id};
+                matching_question -> [{"answer_id": id, "match_id": id}].
+            access_code: Access code, if the quiz requires one
+        """
+        quiz_questions, error = _normalize_answers(answers)
+        if error:
+            return f"Error: {error}"
+
+        body: dict[str, Any] = {
+            "attempt": attempt,
+            "validation_token": validation_token,
+            "quiz_questions": quiz_questions,
+        }
+        if access_code is not None:
+            body["access_code"] = access_code
+
+        result = await make_canvas_request(
+            "post",
+            f"/quiz_submissions/{quiz_submission_id}/questions",
+            data=body,
+            skip_anonymization=True,
+        )
+
+        if isinstance(result, dict) and "error" in result:
+            return f"Error recording answers: {result['error']}"
+
+        qlist = (
+            result.get("quiz_submission_questions")
+            if isinstance(result, dict)
+            else result
+        )
+        if not qlist:
+            return (
+                "Answers sent, but Canvas returned no confirmation questions. "
+                "Re-fetch the attempt to verify they were recorded."
+            )
+
+        lines = [
+            f"Recorded answers for {len(qlist)} question(s) (attempt {attempt}):",
+            "",
+        ]
+        for question in qlist:
+            qid = question.get("id")
+            flag = " [flagged]" if question.get("flagged") else ""
+            lines.append(f"  Q{qid}{flag}: answer = {question.get('answer')}")
+        lines.append("")
+        lines.append("Not yet submitted. Call submit_quiz_attempt to turn the quiz in.")
+        return "\n".join(lines)
+
+    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @validate_params
+    async def submit_quiz_attempt(
+        course_identifier: str | int,
+        quiz_id: str | int,
+        quiz_submission_id: str | int,
+        attempt: int,
+        validation_token: str,
+        access_code: str | None = None,
+        confirmation_token: str | None = None,
+    ) -> str:
+        """Preview, then irreversibly submit an in-progress quiz attempt.
+
+        The first call fetches and displays the current answers but submits
+        nothing. Show the preview to the student, then call again with the
+        returned confirmation token and identical arguments. The token is
+        invalidated if the attempt or any saved answer changes.
+
+        Args:
+            course_identifier: Course code or Canvas ID
+            quiz_id: Canvas quiz ID
+            quiz_submission_id: From start_quiz_attempt
+            attempt: The attempt number from start_quiz_attempt (must be the latest)
+            validation_token: The token from start_quiz_attempt
+            access_code: Access code, if the quiz requires one
+            confirmation_token: Token from the preview; omit to preview
+        """
+        course_id = await get_course_id(course_identifier)
+
+        quiz, existing_submission, state_error = await _fetch_quiz_state(
+            course_id, quiz_id
+        )
+        if state_error or quiz is None:
+            return state_error or "Error fetching quiz state"
+        if existing_submission is None:
+            return "Error: Canvas returned no current quiz attempt. Nothing submitted."
+        if str(existing_submission.get("id")) != str(quiz_submission_id):
+            return "Error: quiz_submission_id does not match the current attempt. Nothing submitted."
+        if str(existing_submission.get("attempt") or 0) != str(attempt):
+            return "Error: attempt does not match the current Canvas attempt. Nothing submitted."
+
+        questions = await _fetch_submission_questions(quiz_submission_id)
+        if isinstance(questions, dict) and "error" in questions:
+            return f"Error fetching current quiz answers: {questions['error']}"
+
+        fingerprint = _SUBMIT_ATTEMPT_GUARD.fingerprint(
+            str(course_id),
+            str(quiz_id),
+            str(quiz_submission_id),
+            str(attempt),
+            validation_token,
+            access_code or "",
+            _quiz_state_payload(quiz, existing_submission),
+            _question_state_payload(questions),
+        )
+
+        if not confirmation_token:
+            qlist = (
+                questions.get("quiz_submission_questions", [])
+                if isinstance(questions, dict)
+                else questions
+            )
+            rendered_questions = "\n\n".join(
+                _format_submission_question(question)
+                for question in qlist or []
+                if isinstance(question, dict)
+            )
+            title = fence_untrusted_inline(quiz.get("title", "N/A"), "quiz title")
+            token = _SUBMIT_ATTEMPT_GUARD.issue(fingerprint)
+            return (
+                "Quiz submission preview — nothing submitted:\n\n"
+                f"Quiz: {title}\n"
+                f"Attempt: {attempt}\n"
+                f"Workflow state: {existing_submission.get('workflow_state', 'unknown')}\n"
+                f"Questions and saved answers:\n{rendered_questions or '(none returned)'}\n\n"
+                f"confirmation_token: {token}\n\n"
+                "Show this preview to the student. To irreversibly turn in "
+                "the attempt, call submit_quiz_attempt again with this "
+                "confirmation_token and identical arguments. The token is "
+                "single-use and expires in five minutes."
+            )
+
+        token_error = _burn_on_confirmation_error(
+            _SUBMIT_ATTEMPT_GUARD, confirmation_token, fingerprint
+        )
+        if token_error:
+            return f"{token_error} Nothing was submitted."
+        if not _SUBMIT_ATTEMPT_GUARD.reserve(confirmation_token):
+            return (
+                "❌ That confirmation was already used. Nothing was submitted. "
+                "Run the preview again."
+            )
+
+        body: dict[str, Any] = {
+            "attempt": attempt,
+            "validation_token": validation_token,
+        }
+        if access_code is not None:
+            body["access_code"] = access_code
+
+        result = await make_canvas_request(
+            "post",
+            f"/courses/{course_id}/quizzes/{quiz_id}/submissions/{quiz_submission_id}/complete",
+            data=body,
+            skip_anonymization=True,
+        )
+
+        if isinstance(result, dict) and "error" in result:
+            return f"Error submitting quiz attempt: {result['error']}"
+
+        submissions = (
+            result.get("quiz_submissions") if isinstance(result, dict) else None
+        )
+        if not submissions:
+            return (
+                f"Quiz submitted, but Canvas returned an unexpected response: {result}"
+            )
+
+        sub = submissions[0]
+        state = sub.get("workflow_state", "complete")
+        lines = [
+            f"✅ Quiz submitted (attempt {sub.get('attempt', attempt)}).",
+            f"  Workflow state: {state}",
+        ]
+        if sub.get("score") is not None:
+            lines.append(f"  Score: {sub.get('score')}")
+        if sub.get("kept_score") is not None:
+            lines.append(f"  Kept score: {sub.get('kept_score')}")
+        if state == "pending_review":
+            lines.append(
+                "  Note: some questions need manual grading; the final score "
+                "will appear once the instructor reviews them."
+            )
+        return "\n".join(lines)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -68,7 +68,10 @@ def test_reset_config_clears_invalid_env_caches(monkeypatch):
         ("https://canvas.school.edu/api/v1#frag", "https://canvas.school.edu/api/v1"),
         # Over-specified path (copied from a browser) is truncated, not
         # double-appended into '…/courses/api/v1'.
-        ("https://canvas.school.edu/api/v1/courses", "https://canvas.school.edu/api/v1"),
+        (
+            "https://canvas.school.edu/api/v1/courses",
+            "https://canvas.school.edu/api/v1",
+        ),
         # Alternate Canvas API roots are not inferred from CANVAS_API_URL.
         ("https://canvas.school.edu/api/quiz/v1", "https://canvas.school.edu/api/v1"),
         # An explicit version segment is preserved, not downgraded to /api/v1,
@@ -77,7 +80,10 @@ def test_reset_config_clears_invalid_env_caches(monkeypatch):
         ("https://canvas.school.edu/api/v2/foo", "https://canvas.school.edu/api/v2"),
         ("https://canvas.school.edu/api/v10", "https://canvas.school.edu/api/v10"),
         # A Canvas install under a sub-path keeps that prefix.
-        ("https://canvas.school.edu/lms/api/v1", "https://canvas.school.edu/lms/api/v1"),
+        (
+            "https://canvas.school.edu/lms/api/v1",
+            "https://canvas.school.edu/lms/api/v1",
+        ),
         # Host:port is preserved.
         ("https://canvas.school.edu:8443", "https://canvas.school.edu:8443/api/v1"),
         # A scheme-less value is left untouched for validate_config() to flag.
@@ -106,7 +112,9 @@ def test_normalize_canvas_url(raw, expected):
         ("https:///canvas.school.edu", "hostname"),
     ],
 )
-def test_validate_config_warns_with_specific_diagnostic(url, expected_fragment, monkeypatch):
+def test_validate_config_warns_with_specific_diagnostic(
+    url, expected_fragment, monkeypatch
+):
     """A bad CANVAS_API_URL is accepted but warned about with a message that
     names the actual defect (scheme vs. missing host)."""
     monkeypatch.setenv("CANVAS_API_TOKEN", "test-token")
@@ -197,7 +205,9 @@ def test_config_normalizes_canvas_api_url(monkeypatch):
     monkeypatch.setenv("CANVAS_API_TOKEN", "test-token")
     monkeypatch.setenv("CANVAS_API_URL", "https://canvas.school.edu")
     config_module.reset_config()
-    assert config_module.get_config().canvas_api_url == "https://canvas.school.edu/api/v1"
+    assert (
+        config_module.get_config().canvas_api_url == "https://canvas.school.edu/api/v1"
+    )
 
 
 def test_execute_typescript_disabled_by_default(monkeypatch):
@@ -205,6 +215,30 @@ def test_execute_typescript_disabled_by_default(monkeypatch):
     monkeypatch.delenv("EXECUTE_TYPESCRIPT_ENABLED", raising=False)
     config_module.reset_config()
     assert config_module.get_config().execute_typescript_enabled is False
+
+
+def test_http_credential_mode_defaults_to_request_header(monkeypatch):
+    monkeypatch.delenv("MCP_HTTP_CREDENTIAL_MODE", raising=False)
+    config_module.reset_config()
+    assert config_module.get_config().mcp_http_credential_mode == "request-header"
+
+
+def test_http_credential_mode_reads_server_value(monkeypatch):
+    monkeypatch.setenv("MCP_HTTP_CREDENTIAL_MODE", " SERVER ")
+    config_module.reset_config()
+    assert config_module.get_config().mcp_http_credential_mode == "server"
+
+
+def test_quiz_taking_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("QUIZ_TAKING_ENABLED", raising=False)
+    config_module.reset_config()
+    assert config_module.get_config().quiz_taking_enabled is False
+
+
+def test_quiz_taking_can_be_enabled(monkeypatch):
+    monkeypatch.setenv("QUIZ_TAKING_ENABLED", "true")
+    config_module.reset_config()
+    assert config_module.get_config().quiz_taking_enabled is True
 
 
 def test_anonymization_enabled_by_default(monkeypatch):

--- a/tests/test_http_transport.py
+++ b/tests/test_http_transport.py
@@ -1,7 +1,8 @@
 """Tests for HTTP transport: credential middleware, ContextVar flow, and CLI args."""
 
-from urllib.parse import urlparse
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -26,12 +27,17 @@ class _FakeConfig:
         entra_auth_enabled=False,
         mcp_entra_allowed_oids=frozenset(),
         access_request_enabled=False,
+        mcp_http_credential_mode="request-header",
+        canvas_api_token="",
     ):
         self.canvas_api_url = canvas_api_url
         self.mcp_access_keys = mcp_access_keys
         self.entra_auth_enabled = entra_auth_enabled
         self.mcp_entra_allowed_oids = mcp_entra_allowed_oids
         self.access_request_enabled = access_request_enabled
+        self.mcp_http_credential_mode = mcp_http_credential_mode
+        self.canvas_api_token = canvas_api_token
+
 
 # ---------------------------------------------------------------------------
 # ContextVar credential tests
@@ -61,9 +67,7 @@ class TestRequestCredentials:
 
     def test_clear_resets_to_none(self):
         """clear_request_credentials resets to None."""
-        set_request_credentials(
-            RequestCredentials(api_token="t", api_url="u")
-        )
+        set_request_credentials(RequestCredentials(api_token="t", api_url="u"))
         clear_request_credentials()
         assert get_request_credentials() is None
 
@@ -191,6 +195,7 @@ class TestCanvasCredentialMiddleware:
     @pytest.mark.asyncio
     async def test_clears_context_after_error(self, middleware):
         """Credentials AND the http-active marker are cleared even if the app raises."""
+
         async def failing_app(scope, receive, send):
             raise ValueError("boom")
 
@@ -221,6 +226,47 @@ class TestCanvasCredentialMiddleware:
         scope = {"type": "lifespan"}
         await middleware(scope, AsyncMock(), AsyncMock())
         assert called["value"] is True
+
+    @pytest.mark.asyncio
+    async def test_concurrent_request_credentials_remain_isolated(self, middleware):
+        observed = {}
+
+        async def capture_app(scope, receive, send):
+            label = scope["path"]
+            before = get_request_credentials().api_token
+            await asyncio.sleep(0)
+            after = get_request_credentials().api_token
+            observed[label] = (before, after)
+
+        middleware.app = capture_app
+        cfg = _FakeConfig()
+        with patch("canvas_mcp.server.get_config", return_value=cfg):
+            await asyncio.gather(
+                middleware(
+                    {
+                        "type": "http",
+                        "path": "/a",
+                        "headers": [(b"x-canvas-token", b"token-a")],
+                    },
+                    AsyncMock(),
+                    AsyncMock(),
+                ),
+                middleware(
+                    {
+                        "type": "http",
+                        "path": "/b",
+                        "headers": [(b"x-canvas-token", b"token-b")],
+                    },
+                    AsyncMock(),
+                    AsyncMock(),
+                ),
+            )
+
+        assert observed == {
+            "/a": ("token-a", "token-a"),
+            "/b": ("token-b", "token-b"),
+        }
+        assert get_request_credentials() is None
 
 
 class TestAccessKeyGate:
@@ -267,7 +313,9 @@ class TestAccessKeyGate:
         send = AsyncMock()
         scope = {
             "type": "http",
-            "headers": [(b"x-canvas-token", b"tok")],  # valid canvas token, but no access key
+            "headers": [
+                (b"x-canvas-token", b"tok")
+            ],  # valid canvas token, but no access key
         }
         cfg = _FakeConfig(mcp_access_keys=frozenset({"key-abc"}))
         with patch("canvas_mcp.server.get_config", return_value=cfg):
@@ -311,6 +359,227 @@ class TestAccessKeyGate:
             await middleware(scope, AsyncMock(), AsyncMock())
 
         assert captured["token"] == "tok"
+
+    @pytest.mark.asyncio
+    async def test_standard_bearer_key_is_accepted(self, middleware):
+        """Poke's Authorization bearer header authenticates the MCP request."""
+        captured = {}
+
+        async def capture_app(scope, receive, send):
+            captured["token"] = get_request_credentials().api_token
+
+        middleware.app = capture_app
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer key-def"),
+                (b"x-canvas-token", b"canvas-token"),
+            ],
+        }
+        cfg = _FakeConfig(mcp_access_keys=frozenset({"key-abc", "key-def"}))
+        with patch("canvas_mcp.server.get_config", return_value=cfg):
+            await middleware(scope, AsyncMock(), AsyncMock())
+
+        assert captured["token"] == "canvas-token"
+
+    @pytest.mark.asyncio
+    async def test_rotated_bearer_keys_are_both_accepted(self, middleware):
+        accepted = []
+
+        async def capture_app(scope, receive, send):
+            accepted.append(get_request_credentials().api_token)
+
+        middleware.app = capture_app
+        cfg = _FakeConfig(mcp_access_keys=frozenset({"current-key", "next-key"}))
+        for access_key in ("current-key", "next-key"):
+            scope = {
+                "type": "http",
+                "headers": [
+                    (b"authorization", f"Bearer {access_key}".encode()),
+                    (b"x-canvas-token", b"canvas-token"),
+                ],
+            }
+            with patch("canvas_mcp.server.get_config", return_value=cfg):
+                await middleware(scope, AsyncMock(), AsyncMock())
+
+        assert accepted == ["canvas-token", "canvas-token"]
+
+    @pytest.mark.asyncio
+    async def test_malformed_bearer_returns_challenge(self, middleware):
+        send = AsyncMock()
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Basic abc"),
+                (b"x-canvas-token", b"canvas-token"),
+            ],
+        }
+        cfg = _FakeConfig(mcp_access_keys=frozenset({"key-abc"}))
+        with patch("canvas_mcp.server.get_config", return_value=cfg):
+            await middleware(scope, AsyncMock(), send)
+
+        response_start = send.call_args_list[0][0][0]
+        assert response_start["status"] == 401
+        assert (b"www-authenticate", b'Bearer realm="canvas-mcp"') in response_start[
+            "headers"
+        ]
+
+    @pytest.mark.asyncio
+    async def test_conflicting_bearer_and_legacy_keys_fail_closed(self, middleware):
+        send = AsyncMock()
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer key-abc"),
+                (b"x-mcp-access-key", b"key-def"),
+                (b"x-canvas-token", b"canvas-token"),
+            ],
+        }
+        cfg = _FakeConfig(mcp_access_keys=frozenset({"key-abc", "key-def"}))
+        with patch("canvas_mcp.server.get_config", return_value=cfg):
+            await middleware(scope, AsyncMock(), send)
+
+        assert send.call_args_list[0][0][0]["status"] == 401
+
+
+class TestServerCredentialMode:
+    @pytest.fixture
+    def middleware(self):
+        from canvas_mcp.server import CanvasCredentialMiddleware
+
+        return CanvasCredentialMiddleware(AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_bearer_key_uses_server_canvas_token(self, middleware):
+        captured = {}
+
+        async def capture_app(scope, receive, send):
+            creds = get_request_credentials()
+            captured.update(token=creds.api_token, url=creds.api_url)
+
+        middleware.app = capture_app
+        cfg = _FakeConfig(
+            mcp_access_keys=frozenset({"poke-key"}),
+            mcp_http_credential_mode="server",
+            canvas_api_token="server-canvas-token",
+        )
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer poke-key"),
+                (b"x-poke-user-id", b"00000000-0000-0000-0000-000000000000"),
+            ],
+        }
+        with (
+            patch("canvas_mcp.server.get_config", return_value=cfg),
+            patch("canvas_mcp.server.log_info") as mock_log,
+        ):
+            await middleware(scope, AsyncMock(), AsyncMock())
+
+        assert captured == {
+            "token": "server-canvas-token",
+            "url": "https://canvas.illinois.edu/api/v1",
+        }
+        logged = " ".join(str(call) for call in mock_log.call_args_list)
+        assert "poke-key" not in logged
+        assert "server-canvas-token" not in logged
+        assert "00000000-0000-0000-0000-000000000000" not in logged
+        assert get_request_credentials() is None
+
+    @pytest.mark.asyncio
+    async def test_server_mode_rejects_client_canvas_token(self, middleware):
+        send = AsyncMock()
+        cfg = _FakeConfig(
+            mcp_access_keys=frozenset({"poke-key"}),
+            mcp_http_credential_mode="server",
+            canvas_api_token="server-canvas-token",
+        )
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"authorization", b"Bearer poke-key"),
+                (b"x-canvas-token", b"client-token"),
+            ],
+        }
+        with patch("canvas_mcp.server.get_config", return_value=cfg):
+            await middleware(scope, AsyncMock(), send)
+
+        assert send.call_args_list[0][0][0]["status"] == 400
+
+
+class TestHealthEndpoint:
+    @pytest.mark.asyncio
+    async def test_health_is_public_and_information_minimal(self):
+        from canvas_mcp.server import CanvasCredentialMiddleware
+
+        inner = AsyncMock()
+        middleware = CanvasCredentialMiddleware(inner)
+        send = AsyncMock()
+        await middleware(
+            {"type": "http", "method": "GET", "path": "/healthz", "headers": []},
+            AsyncMock(),
+            send,
+        )
+
+        assert send.call_args_list[0][0][0]["status"] == 200
+        body = send.call_args_list[1][0][0]["body"]
+        assert body == b'{"status":"ok"}'
+        assert b"canvas" not in body.lower()
+        inner.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_health_head_has_no_body(self):
+        from canvas_mcp.server import CanvasCredentialMiddleware
+
+        send = AsyncMock()
+        await CanvasCredentialMiddleware(AsyncMock())(
+            {"type": "http", "method": "HEAD", "path": "/healthz", "headers": []},
+            AsyncMock(),
+            send,
+        )
+
+        response_start = send.call_args_list[0][0][0]
+        response_body = send.call_args_list[1][0][0]
+        assert response_start["status"] == 200
+        assert (b"content-length", b"15") in response_start["headers"]
+        assert response_body["body"] == b""
+
+
+def test_poke_shaped_tools_list_request_uses_only_bearer_key():
+    """End-to-end ASGI discovery works with exactly the headers Poke sends."""
+    from fastmcp import FastMCP
+    from starlette.testclient import TestClient
+
+    from canvas_mcp.server import CanvasCredentialMiddleware
+
+    mcp = FastMCP(name="poke-compat")
+
+    @mcp.tool()
+    async def sample_tool() -> str:
+        return "ok"
+
+    app = CanvasCredentialMiddleware(mcp.http_app(stateless_http=True))
+    cfg = _FakeConfig(
+        mcp_access_keys=frozenset({"poke-key"}),
+        mcp_http_credential_mode="server",
+        canvas_api_token="server-canvas-token",
+    )
+    headers = {
+        "Authorization": "Bearer poke-key",
+        "X-Poke-User-Id": "00000000-0000-0000-0000-000000000000",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    with patch("canvas_mcp.server.get_config", return_value=cfg):
+        with TestClient(app) as client:
+            response = client.post(
+                "/mcp",
+                headers=headers,
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            )
+
+    assert response.status_code == 200
+    assert "sample_tool" in response.text
 
 
 # ---------------------------------------------------------------------------
@@ -438,6 +707,7 @@ class TestEventLoopChangeDetection:
     def setup_method(self):
         """Reset client globals before each test."""
         import canvas_mcp.core.client as _cm
+
         _cm.http_client = None
         _cm._http_client_loop_ref = None
         _cm._request_semaphore = None
@@ -446,6 +716,7 @@ class TestEventLoopChangeDetection:
     def teardown_method(self):
         """Reset client globals after each test."""
         import canvas_mcp.core.client as _cm
+
         _cm.http_client = None
         _cm._http_client_loop_ref = None
         _cm._request_semaphore = None
@@ -509,7 +780,9 @@ class TestEventLoopChangeDetection:
 
         # Next call must return a fresh client (not the stale one)
         second_client = _get_http_client()
-        assert second_client is not first_client, "Stale client was not replaced when loop weakref died"
+        assert (
+            second_client is not first_client
+        ), "Stale client was not replaced when loop weakref died"
 
     @pytest.mark.asyncio
     async def test_semaphore_recreated_when_stored_loop_gone(self):
@@ -532,7 +805,9 @@ class TestEventLoopChangeDetection:
         assert _cm._semaphore_loop_ref() is None
 
         second_sem = _get_request_semaphore()
-        assert second_sem is not first_sem, "Stale semaphore was not replaced when loop weakref died"
+        assert (
+            second_sem is not first_sem
+        ), "Stale semaphore was not replaced when loop weakref died"
 
     def test_http_client_recreated_across_asyncio_run_calls(self):
         """A fresh client is created in loop B when loop A was closed by asyncio.run().
@@ -564,9 +839,9 @@ class TestEventLoopChangeDetection:
 
         # Weakref to loop A must be dead before loop B can detect the stale state
         assert _cm._http_client_loop_ref is not None
-        assert _cm._http_client_loop_ref() is None, (
-            "Weakref to loop A must be dead after asyncio.run() exits"
-        )
+        assert (
+            _cm._http_client_loop_ref() is None
+        ), "Weakref to loop A must be dead after asyncio.run() exits"
         assert state_a["loop_ref_alive"], "Loop ref should be alive INSIDE loop A"
 
         # Loop B — simulate mcp.run()
@@ -589,12 +864,12 @@ class TestEventLoopChangeDetection:
         asyncio.run(_loop_b())
 
         # The loop weakref must have been live INSIDE loop B (proves fresh client was created)
-        assert state_b["loop_ref_alive"], (
-            "Loop weakref must be alive inside loop B — proves a fresh client was created"
-        )
-        assert state_b["loop_ref_is_current"], (
-            "Loop weakref must point to loop B's running loop"
-        )
+        assert state_b[
+            "loop_ref_alive"
+        ], "Loop weakref must be alive inside loop B — proves a fresh client was created"
+        assert state_b[
+            "loop_ref_is_current"
+        ], "Loop weakref must point to loop B's running loop"
 
     def test_server_startup_resets_globals_after_asyncio_run(self):
         """server.main() resets http_client globals after asyncio.run() token validation.
@@ -632,10 +907,11 @@ class TestCLIArgs:
         """Default transport is stdio."""
         import argparse
 
-
         # We can't easily test main() directly, but we can test the argparse
         parser = argparse.ArgumentParser()
-        parser.add_argument("--transport", choices=["stdio", "streamable-http"], default="stdio")
+        parser.add_argument(
+            "--transport", choices=["stdio", "streamable-http"], default="stdio"
+        )
         parser.add_argument("--host", default="0.0.0.0")
         parser.add_argument("--port", type=int, default=8819)
         args = parser.parse_args([])
@@ -648,7 +924,9 @@ class TestCLIArgs:
         import argparse
 
         parser = argparse.ArgumentParser()
-        parser.add_argument("--transport", choices=["stdio", "streamable-http"], default="stdio")
+        parser.add_argument(
+            "--transport", choices=["stdio", "streamable-http"], default="stdio"
+        )
         parser.add_argument("--host", default="0.0.0.0")
         parser.add_argument("--port", type=int, default=8819)
         args = parser.parse_args(["--transport", "streamable-http", "--port", "9000"])
@@ -761,6 +1039,8 @@ class TestHttpAccessKeyStartupGuard:
         monkeypatch.delenv("MCP_ACCESS_KEYS", raising=False)
         monkeypatch.delenv("MCP_ALLOW_UNAUTHENTICATED", raising=False)
         monkeypatch.delenv("ENTRA_AUTH_ENABLED", raising=False)
+        monkeypatch.delenv("MCP_HTTP_CREDENTIAL_MODE", raising=False)
+        monkeypatch.delenv("ACCESS_REQUEST_ENABLED", raising=False)
         for key, value in env.items():
             monkeypatch.setenv(key, value)
 
@@ -783,9 +1063,7 @@ class TestHttpAccessKeyStartupGuard:
 
     def test_no_keys_with_explicit_optin_starts(self, monkeypatch):
         """No keys but MCP_ALLOW_UNAUTHENTICATED=true -> guard passes (exit 0)."""
-        exc = self._run_main(
-            monkeypatch, env={"MCP_ALLOW_UNAUTHENTICATED": "true"}
-        )
+        exc = self._run_main(monkeypatch, env={"MCP_ALLOW_UNAUTHENTICATED": "true"})
         assert exc.code == 0
 
     def test_entra_enabled_without_optin_exits_nonzero(self, monkeypatch):
@@ -814,10 +1092,75 @@ class TestHttpAccessKeyStartupGuard:
 
     def test_keys_configured_starts(self, monkeypatch):
         """MCP_ACCESS_KEYS configured -> guard passes regardless of opt-in (exit 0)."""
+        exc = self._run_main(monkeypatch, env={"MCP_ACCESS_KEYS": "key-abc,key-def"})
+        assert exc.code == 0
+
+    def test_request_header_mode_rejects_server_canvas_token(self, monkeypatch):
         exc = self._run_main(
-            monkeypatch, env={"MCP_ACCESS_KEYS": "key-abc,key-def"}
+            monkeypatch,
+            env={
+                "MCP_HTTP_CREDENTIAL_MODE": "request-header",
+                "CANVAS_API_TOKEN": "must-not-fallback",
+                "MCP_ACCESS_KEYS": "key-abc",
+            },
+        )
+        assert exc.code == 1
+
+    def test_server_mode_requires_canvas_token(self, monkeypatch):
+        exc = self._run_main(
+            monkeypatch,
+            env={
+                "MCP_HTTP_CREDENTIAL_MODE": "server",
+                "MCP_ACCESS_KEYS": "poke-key",
+            },
+        )
+        assert exc.code == 1
+
+    def test_server_mode_requires_access_key(self, monkeypatch):
+        exc = self._run_main(
+            monkeypatch,
+            env={
+                "MCP_HTTP_CREDENTIAL_MODE": "server",
+                "CANVAS_API_TOKEN": "canvas-token",
+            },
+        )
+        assert exc.code == 1
+
+    def test_server_mode_valid_configuration_starts(self, monkeypatch):
+        exc = self._run_main(
+            monkeypatch,
+            env={
+                "MCP_HTTP_CREDENTIAL_MODE": "server",
+                "CANVAS_API_TOKEN": "canvas-token",
+                "MCP_ACCESS_KEYS": "poke-key,next-key",
+            },
         )
         assert exc.code == 0
+
+    @pytest.mark.parametrize(
+        "conflict",
+        [
+            {"MCP_ALLOW_UNAUTHENTICATED": "true"},
+            {"ENTRA_AUTH_ENABLED": "true"},
+            {"ACCESS_REQUEST_ENABLED": "true"},
+        ],
+    )
+    def test_server_mode_rejects_conflicting_auth_modes(self, monkeypatch, conflict):
+        env = {
+            "MCP_HTTP_CREDENTIAL_MODE": "server",
+            "CANVAS_API_TOKEN": "canvas-token",
+            "MCP_ACCESS_KEYS": "poke-key",
+            **conflict,
+        }
+        exc = self._run_main(monkeypatch, env=env)
+        assert exc.code == 1
+
+    def test_invalid_credential_mode_exits_nonzero(self, monkeypatch):
+        exc = self._run_main(
+            monkeypatch,
+            env={"MCP_HTTP_CREDENTIAL_MODE": "something-else"},
+        )
+        assert exc.code == 1
 
 
 # ---------------------------------------------------------------------------
@@ -923,7 +1266,10 @@ class TestEntraPlatformAuth:
             "type": "http",
             "headers": [
                 (b"x-ms-client-principal-id", b"oid-anyone"),
-                (b"x-ms-client-principal", _principal_header({"scp": "access_as_user"})),
+                (
+                    b"x-ms-client-principal",
+                    _principal_header({"scp": "access_as_user"}),
+                ),
                 (b"x-canvas-token", b"tok"),
             ],
         }
@@ -943,16 +1289,20 @@ class TestAccessOverlayGate:
     @pytest.fixture
     def middleware(self):
         from canvas_mcp.server import CanvasCredentialMiddleware
+
         return CanvasCredentialMiddleware(AsyncMock())
 
     def _cfg(self, **kw):
         # Minimal config double with feature enabled + an in-memory store.
         from types import SimpleNamespace
+
         base = {
             "entra_auth_enabled": True,
             "mcp_entra_allowed_oids": frozenset({"oid-env"}),
             "canvas_api_url": "https://c.edu/api/v1",
             "mcp_access_keys": frozenset(),
+            "mcp_http_credential_mode": "request-header",
+            "canvas_api_token": "",
             "access_request_enabled": True,
             "access_token_secret": "s",
             "access_table_account": "acct",
@@ -968,34 +1318,60 @@ class TestAccessOverlayGate:
     @pytest.mark.asyncio
     async def test_overlay_oid_is_authorized(self, middleware):
         from canvas_mcp.core.access.store import AccessStore, InMemoryBackend, Requester
+
         store = AccessStore(InMemoryBackend(), cache_ttl_seconds=0)
         store.grant(Requester("oid-new", "j@x", "Jane"), jti="j1")
         captured = {}
+
         async def inner(scope, receive, send):
             captured["ran"] = True
+
         middleware.app = inner
-        scope = {"type": "http", "path": "/mcp", "headers": [
-            (b"x-ms-client-principal-id", b"oid-new"),
-            (b"x-ms-client-principal", _principal_header({"scp": "x"})),
-            (b"x-canvas-token", b"tok")]}
-        with patch("canvas_mcp.server.get_config", return_value=self._cfg()), \
-             patch("canvas_mcp.server._access_store", return_value=store):
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "headers": [
+                (b"x-ms-client-principal-id", b"oid-new"),
+                (b"x-ms-client-principal", _principal_header({"scp": "x"})),
+                (b"x-canvas-token", b"tok"),
+            ],
+        }
+        with (
+            patch("canvas_mcp.server.get_config", return_value=self._cfg()),
+            patch("canvas_mcp.server._access_store", return_value=store),
+        ):
             await middleware(scope, AsyncMock(), AsyncMock())
         assert captured.get("ran") is True  # overlay grant -> allowed
 
     @pytest.mark.asyncio
     async def test_unlisted_oid_403_and_schedules_notify(self, middleware):
         from canvas_mcp.core.access.store import AccessStore, InMemoryBackend
+
         store = AccessStore(InMemoryBackend(), cache_ttl_seconds=0)
         send = AsyncMock()
-        scope = {"type": "http", "path": "/mcp", "headers": [
-            (b"x-ms-client-principal-id", b"oid-unknown"),
-            (b"x-ms-client-principal", _principal_header(
-                {"scp": "x", "name": "Stranger", "preferred_username": "s@x.edu"})),
-            (b"x-canvas-token", b"tok")]}
-        with patch("canvas_mcp.server.get_config", return_value=self._cfg()), \
-             patch("canvas_mcp.server._access_store", return_value=store), \
-             patch("canvas_mcp.server._schedule_notify") as sched:
+        scope = {
+            "type": "http",
+            "path": "/mcp",
+            "headers": [
+                (b"x-ms-client-principal-id", b"oid-unknown"),
+                (
+                    b"x-ms-client-principal",
+                    _principal_header(
+                        {
+                            "scp": "x",
+                            "name": "Stranger",
+                            "preferred_username": "s@x.edu",
+                        }
+                    ),
+                ),
+                (b"x-canvas-token", b"tok"),
+            ],
+        }
+        with (
+            patch("canvas_mcp.server.get_config", return_value=self._cfg()),
+            patch("canvas_mcp.server._access_store", return_value=store),
+            patch("canvas_mcp.server._schedule_notify") as sched,
+        ):
             await middleware(scope, AsyncMock(), send)
         assert send.call_args_list[0][0][0]["status"] == 403
         sched.assert_called_once()
@@ -1003,12 +1379,19 @@ class TestAccessOverlayGate:
     @pytest.mark.asyncio
     async def test_approve_path_served_without_canvas_token(self, middleware):
         from canvas_mcp.core.access.store import AccessStore, InMemoryBackend
+
         store = AccessStore(InMemoryBackend(), cache_ttl_seconds=0)
         send = AsyncMock()
-        scope = {"type": "http", "path": "/admin/access/approve",
-                 "query_string": b"token=garbage", "headers": []}
-        with patch("canvas_mcp.server.get_config", return_value=self._cfg()), \
-             patch("canvas_mcp.server._access_store", return_value=store):
+        scope = {
+            "type": "http",
+            "path": "/admin/access/approve",
+            "query_string": b"token=garbage",
+            "headers": [],
+        }
+        with (
+            patch("canvas_mcp.server.get_config", return_value=self._cfg()),
+            patch("canvas_mcp.server._access_store", return_value=store),
+        ):
             await middleware(scope, AsyncMock(), send)
         status = send.call_args_list[0][0][0]["status"]
         assert status == 200  # served by route handler, not the 401 token gate
@@ -1016,9 +1399,15 @@ class TestAccessOverlayGate:
     @pytest.mark.asyncio
     async def test_admin_path_404_when_feature_disabled(self, middleware):
         send = AsyncMock()
-        scope = {"type": "http", "path": "/admin/access/approve",
-                 "query_string": b"", "headers": []}
-        with patch("canvas_mcp.server.get_config",
-                   return_value=self._cfg(access_request_enabled=False)):
+        scope = {
+            "type": "http",
+            "path": "/admin/access/approve",
+            "query_string": b"",
+            "headers": [],
+        }
+        with patch(
+            "canvas_mcp.server.get_config",
+            return_value=self._cfg(access_request_enabled=False),
+        ):
             await middleware(scope, AsyncMock(), send)
         assert send.call_args_list[0][0][0]["status"] == 404

--- a/tests/test_role_filtering.py
+++ b/tests/test_role_filtering.py
@@ -60,6 +60,15 @@ SHARED_TOOLS = {
     # self-identity (issue #171) — caller-scoped, no roster permission needed
     "get_my_enrollments",
     "get_my_profile",
+    # Classic Quiz discovery is read-only and shared.
+    "list_quizzes",
+    "get_quiz_details",
+}
+
+QUIZ_WRITE_TOOLS = {
+    "start_quiz_attempt",
+    "answer_quiz_questions",
+    "submit_quiz_attempt",
 }
 
 # These two answer only about the authenticated caller, so unlike
@@ -169,7 +178,9 @@ class TestRoleFiltering:
 
         combined = student_tools | educator_tools
         missing = all_tools - combined
-        assert not missing, f"Tools in 'all' but missing from student+educator: {missing}"
+        assert (
+            not missing
+        ), f"Tools in 'all' but missing from student+educator: {missing}"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("role", ["student", "educator", "all"])
@@ -189,17 +200,48 @@ class TestRoleFiltering:
         assert "check_enrollment" not in await _get_tool_names(mcp)
 
     @pytest.mark.asyncio
+    async def test_quiz_taking_tools_are_absent_by_default(self, monkeypatch):
+        from canvas_mcp.core.config import reset_config
+
+        monkeypatch.delenv("QUIZ_TAKING_ENABLED", raising=False)
+        reset_config()
+        mcp = FastMCP(name="test-student")
+        register_all_tools(mcp, role="student")
+        assert not (QUIZ_WRITE_TOOLS & await _get_tool_names(mcp))
+        reset_config()
+
+    @pytest.mark.asyncio
+    async def test_quiz_taking_tools_require_student_role_and_flag(self, monkeypatch):
+        from canvas_mcp.core.config import reset_config
+
+        monkeypatch.setenv("QUIZ_TAKING_ENABLED", "true")
+        reset_config()
+
+        student = FastMCP(name="test-student")
+        register_all_tools(student, role="student")
+        assert QUIZ_WRITE_TOOLS <= await _get_tool_names(student)
+
+        educator = FastMCP(name="test-educator")
+        register_all_tools(educator, role="educator")
+        assert not (QUIZ_WRITE_TOOLS & await _get_tool_names(educator))
+        reset_config()
+
+    @pytest.mark.asyncio
     async def test_student_tool_count(self):
-        """Student role should have approximately 37 tools."""
+        """Student role should have approximately 39 tools."""
         mcp = FastMCP(name="test-student")
         register_all_tools(mcp, role="student")
         tools = await _get_tool_names(mcp)
-        assert 25 <= len(tools) <= 40, f"Expected ~37 student tools, got {len(tools)}: {sorted(tools)}"
+        assert (
+            25 <= len(tools) <= 40
+        ), f"Expected ~39 student tools, got {len(tools)}: {sorted(tools)}"
 
     @pytest.mark.asyncio
     async def test_educator_tool_count(self):
-        """Educator role should have approximately 88 tools."""
+        """Educator role should have approximately 90 tools."""
         mcp = FastMCP(name="test-educator")
         register_all_tools(mcp, role="educator")
         tools = await _get_tool_names(mcp)
-        assert 75 <= len(tools) <= 95, f"Expected ~88 educator tools, got {len(tools)}: {sorted(tools)}"
+        assert (
+            75 <= len(tools) <= 95
+        ), f"Expected ~90 educator tools, got {len(tools)}: {sorted(tools)}"

--- a/tests/test_tool_metadata.py
+++ b/tests/test_tool_metadata.py
@@ -30,15 +30,19 @@ from canvas_mcp.server import register_all_tools
 def _all_feature_gated_tools_enabled(monkeypatch):
     """Register the feature-gated tools too, or the gate has a blind spot.
 
-    ``execute_typescript`` (off unless ``EXECUTE_TYPESCRIPT_ENABLED``) and the
-    student write tools (off unless ``STUDENT_WRITE_TOOLS`` lists them) are
-    absent from a default registry. A gate that only sees the default set would
+    ``execute_typescript`` (off unless ``EXECUTE_TYPESCRIPT_ENABLED``), Classic
+    Quiz taking (off unless ``QUIZ_TAKING_ENABLED``), and the student write
+    tools (off unless ``STUDENT_WRITE_TOOLS`` lists them) are absent from a
+    default registry. A gate that only sees the default set would
     pass while the most powerful tool in the server — arbitrary TypeScript
     against the caller's Canvas token — shipped with no annotations at all.
     Coverage has to follow capability, not configuration.
     """
     monkeypatch.setenv("EXECUTE_TYPESCRIPT_ENABLED", "true")
-    monkeypatch.setenv("STUDENT_WRITE_TOOLS", ",".join(sorted(STUDENT_WRITE_TOOL_NAMES)))
+    monkeypatch.setenv("QUIZ_TAKING_ENABLED", "true")
+    monkeypatch.setenv(
+        "STUDENT_WRITE_TOOLS", ",".join(sorted(STUDENT_WRITE_TOOL_NAMES))
+    )
     monkeypatch.setattr(config_module, "_config", None, raising=False)
     yield
     monkeypatch.setattr(config_module, "_config", None, raising=False)
@@ -83,6 +87,11 @@ DESTRUCTIVE = {
     "delete_announcement_with_confirmation",
     "delete_announcements_by_criteria",
     "bulk_delete_announcements",
+    # Starts can spend an attempt; answer saves replace prior answer state;
+    # submit irreversibly completes the attempt.
+    "start_quiz_attempt",
+    "answer_quiz_questions",
+    "submit_quiz_attempt",
 }
 
 # Additive: each call adds something and removes nothing.
@@ -156,8 +165,15 @@ async def test_the_gate_actually_sees_the_feature_gated_tools():
         "EXECUTE_TYPESCRIPT_ENABLED is not reaching the registry — the gate is "
         "blind to the most powerful tool in the server"
     )
+    assert {
+        "start_quiz_attempt",
+        "answer_quiz_questions",
+        "submit_quiz_attempt",
+    } <= names, "QUIZ_TAKING_ENABLED is not reaching the registry"
     missing = STUDENT_WRITE_TOOL_NAMES - names
-    assert not missing, f"STUDENT_WRITE_TOOLS not reaching the registry: {sorted(missing)}"
+    assert (
+        not missing
+    ), f"STUDENT_WRITE_TOOLS not reaching the registry: {sorted(missing)}"
 
 
 @pytest.mark.asyncio
@@ -227,11 +243,17 @@ async def test_repeatable_tools_declare_idempotency_honestly():
     # Converge on the same end state AND have no repeat-triggered side effect:
     # edit_page_content notably does not expose notify_of_update, unlike its
     # two siblings above.
-    for name in ("update_assignment", "update_module", "update_discussion_topic",
-                 "edit_page_content", "delete_page", "bulk_delete_announcements"):
-        assert tools[name].annotations.idempotentHint is True, (
-            f"{name} converges on the same end state when repeated"
-        )
+    for name in (
+        "update_assignment",
+        "update_module",
+        "update_discussion_topic",
+        "edit_page_content",
+        "delete_page",
+        "bulk_delete_announcements",
+    ):
+        assert (
+            tools[name].annotations.idempotentHint is True
+        ), f"{name} converges on the same end state when repeated"
 
 
 @pytest.mark.asyncio
@@ -239,18 +261,24 @@ async def test_read_tools_are_marked_read_only():
     """Sampled rather than exhaustive: the gate above covers the general case."""
     tools = {tool.name: tool for tool in await _registry().list_tools()}
 
-    for name in ("list_courses", "get_course_details", "check_enrollment",
-                 "list_submissions", "get_syllabus", "read_course_file"):
-        assert tools[name].annotations.readOnlyHint is True, (
-            f"{name} does not write and should say so"
-        )
+    for name in (
+        "list_courses",
+        "get_course_details",
+        "check_enrollment",
+        "list_submissions",
+        "get_syllabus",
+        "read_course_file",
+    ):
+        assert (
+            tools[name].annotations.readOnlyHint is True
+        ), f"{name} does not write and should say so"
 
 
 @pytest.mark.asyncio
 async def test_tool_manifest_matches_registry_exactly():
     """tools/TOOL_MANIFEST.json must document exactly the registered tools (#173).
 
-    The manifest drifted to ~24 entries while the registry grew to 99 because
+    The manifest drifted to ~24 entries while the registry grew past 99 because
     nothing failed when a tool shipped undocumented. Same pattern as the
     annotation gate above: enumerate the live registry with every feature flag
     on, and require set equality — a missing manifest entry (new tool, no docs)
@@ -276,7 +304,9 @@ async def test_tool_manifest_matches_registry_exactly():
     )
 
     known_categories = {c["id"] for c in manifest["categories"]}
-    bad = [t["name"] for t in manifest["tools"] if t["category"] not in known_categories]
+    bad = [
+        t["name"] for t in manifest["tools"] if t["category"] not in known_categories
+    ]
     assert not bad, f"manifest entries with unknown category: {bad}"
 
 

--- a/tests/tools/test_quizzes.py
+++ b/tests/tools/test_quizzes.py
@@ -1,0 +1,736 @@
+"""
+Quiz Tools Unit Tests
+
+Tests for the Canvas Classic Quiz tools:
+- list_quizzes
+- get_quiz_details
+- start_quiz_attempt
+- answer_quiz_questions
+- submit_quiz_attempt
+
+These tests mock the Canvas API so no real credentials/network are required.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from canvas_mcp.core.credentials import (
+    RequestCredentials,
+    clear_request_credentials,
+    set_request_credentials,
+)
+from canvas_mcp.tools.quizzes import (
+    _normalize_answers,
+    reset_quiz_confirmations,
+)
+
+# --- Mock data -------------------------------------------------------------
+
+MOCK_QUIZZES = [
+    {
+        "id": 101,
+        "title": "Hamlet Act 3 Quiz",
+        "quiz_type": "assignment",
+        "points_possible": 20,
+        "question_count": 12,
+        "due_at": "2026-02-01T23:59:00Z",
+        "published": True,
+        "locked_for_user": False,
+    },
+    {
+        "id": 102,
+        "title": "Practice Survey",
+        "quiz_type": "survey",
+        "points_possible": 0,
+        "question_count": 5,
+        "due_at": None,
+        "published": False,
+        "locked_for_user": True,
+    },
+]
+
+MOCK_QUIZ_DETAIL = {
+    "id": 101,
+    "title": "Hamlet Act 3 Quiz",
+    "quiz_type": "assignment",
+    "description": "<p>This is a quiz on <b>Act 3</b> of Hamlet.</p>",
+    "points_possible": 20,
+    "question_count": 12,
+    "question_types": ["multiple_choice_question", "essay_question"],
+    "allowed_attempts": 3,
+    "time_limit": 30,
+    "scoring_policy": "keep_highest",
+    "one_question_at_a_time": False,
+    "cant_go_back": False,
+    "shuffle_answers": True,
+    "due_at": "2026-02-01T23:59:00Z",
+    "unlock_at": None,
+    "lock_at": None,
+    "published": True,
+    "access_code": None,
+    "locked_for_user": False,
+}
+
+MOCK_SUBMISSION = {
+    "id": 555,
+    "quiz_id": 101,
+    "user_id": 7,
+    "attempt": 1,
+    "validation_token": "VTOKEN123",
+    "workflow_state": "untaken",
+    "end_at": "2026-02-01T22:30:00Z",
+}
+
+MOCK_SUBMISSION_QUESTIONS = {
+    "quiz_submission_questions": [
+        {
+            "id": 1,
+            "question_type": "multiple_choice_question",
+            "question_name": "Q1",
+            "question_text": "<p>Pick the best answer.</p>",
+            "answers": [{"id": 3, "text": "Option A"}, {"id": 6, "text": "Option B"}],
+            "answer": None,
+            "flagged": False,
+        },
+        {
+            "id": 2,
+            "question_type": "essay_question",
+            "question_name": "Q2",
+            "question_text": "Explain your reasoning.",
+            "answers": None,
+            "answer": None,
+            "flagged": False,
+        },
+    ]
+}
+
+
+@pytest.fixture
+def mock_quiz_api():
+    """Mock the Canvas API helpers used by the quizzes module."""
+    with (
+        patch("canvas_mcp.tools.quizzes.get_course_id") as mock_get_id,
+        patch("canvas_mcp.tools.quizzes.get_course_code") as mock_get_code,
+        patch("canvas_mcp.tools.quizzes.fetch_all_paginated_results") as mock_fetch,
+        patch("canvas_mcp.tools.quizzes.make_canvas_request") as mock_request,
+    ):
+
+        mock_get_id.return_value = "60366"
+        mock_get_code.return_value = "badm_350_120251"
+
+        yield {
+            "get_course_id": mock_get_id,
+            "get_course_code": mock_get_code,
+            "fetch_all_paginated_results": mock_fetch,
+            "make_canvas_request": mock_request,
+        }
+
+
+@pytest.fixture(autouse=True)
+def reset_confirmation_state():
+    reset_quiz_confirmations()
+    yield
+    reset_quiz_confirmations()
+
+
+def _confirmation_token(preview: str) -> str:
+    return preview.split("confirmation_token: ", 1)[1].splitlines()[0]
+
+
+def _submission_response(submission=MOCK_SUBMISSION):
+    return {"quiz_submissions": [submission] if submission else []}
+
+
+def get_tool_function(tool_name: str):
+    """Capture a registered quiz tool function by name."""
+    from fastmcp import FastMCP
+
+    from canvas_mcp.tools.quizzes import (
+        register_shared_quiz_tools,
+        register_student_quiz_tools,
+    )
+
+    mcp = FastMCP("test")
+    captured: dict = {}
+
+    original_tool = mcp.tool
+
+    def capturing_tool(*args, **kwargs):
+        decorator = original_tool(*args, **kwargs)
+
+        def wrapper(fn):
+            captured[fn.__name__] = fn
+            return decorator(fn)
+
+        return wrapper
+
+    mcp.tool = capturing_tool
+    register_shared_quiz_tools(mcp)
+    register_student_quiz_tools(mcp)
+
+    return captured.get(tool_name)
+
+
+# --- list_quizzes ----------------------------------------------------------
+
+
+class TestListQuizzes:
+    @pytest.mark.asyncio
+    async def test_list_quizzes_basic(self, mock_quiz_api):
+        mock_quiz_api["fetch_all_paginated_results"].return_value = MOCK_QUIZZES
+
+        list_quizzes = get_tool_function("list_quizzes")
+        assert list_quizzes is not None
+
+        result = await list_quizzes("badm_350_120251")
+
+        mock_quiz_api["get_course_id"].assert_called_once_with("badm_350_120251")
+        assert "Hamlet Act 3 Quiz" in result
+        assert "quiz title" in result
+        assert "UNTRUSTED CANVAS CONTENT" in result
+        assert "Practice Survey" in result
+        assert "101" in result
+        assert "Points: 20" in result
+        # Locked survey should be flagged
+        assert "🔒" in result
+        assert "unpublished" in result
+
+    @pytest.mark.asyncio
+    async def test_list_quizzes_empty(self, mock_quiz_api):
+        mock_quiz_api["fetch_all_paginated_results"].return_value = []
+
+        list_quizzes = get_tool_function("list_quizzes")
+        result = await list_quizzes("empty_course")
+
+        assert "No quizzes found" in result
+
+    @pytest.mark.asyncio
+    async def test_list_quizzes_error(self, mock_quiz_api):
+        mock_quiz_api["fetch_all_paginated_results"].return_value = {
+            "error": "Course not found"
+        }
+
+        list_quizzes = get_tool_function("list_quizzes")
+        result = await list_quizzes("invalid_course")
+
+        assert "Error" in result
+        assert "Course not found" in result
+
+    @pytest.mark.asyncio
+    async def test_list_quizzes_search_term(self, mock_quiz_api):
+        mock_quiz_api["fetch_all_paginated_results"].return_value = [MOCK_QUIZZES[0]]
+
+        list_quizzes = get_tool_function("list_quizzes")
+        await list_quizzes("60366", search_term="Hamlet")
+
+        # search_term should be forwarded as a query param
+        call_args = mock_quiz_api["fetch_all_paginated_results"].call_args
+        params = call_args[0][1]
+        assert params.get("search_term") == "Hamlet"
+
+
+# --- get_quiz_details ------------------------------------------------------
+
+
+class TestGetQuizDetails:
+    @pytest.mark.asyncio
+    async def test_get_quiz_details_success(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].return_value = MOCK_QUIZ_DETAIL
+
+        get_quiz_details = get_tool_function("get_quiz_details")
+        result = await get_quiz_details("badm_350_120251", 101)
+
+        assert "Hamlet Act 3 Quiz" in result
+        assert "Allowed Attempts: 3" in result
+        assert "Time Limit: 30 minutes" in result
+        assert "keep_highest" in result
+        # HTML stripped from description
+        assert "Act 3" in result
+        assert "<b>" not in result
+        assert "quiz title" in result
+        assert "quiz description" in result
+
+    @pytest.mark.asyncio
+    async def test_get_quiz_details_unlimited_attempts(self, mock_quiz_api):
+        quiz = dict(MOCK_QUIZ_DETAIL, allowed_attempts=-1, time_limit=None)
+        mock_quiz_api["make_canvas_request"].return_value = quiz
+
+        get_quiz_details = get_tool_function("get_quiz_details")
+        result = await get_quiz_details("60366", 101)
+
+        assert "Allowed Attempts: Unlimited" in result
+        assert "Time Limit: No time limit" in result
+
+    @pytest.mark.asyncio
+    async def test_get_quiz_details_error(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].return_value = {"error": "Quiz not found"}
+
+        get_quiz_details = get_tool_function("get_quiz_details")
+        result = await get_quiz_details("60366", 999)
+
+        assert "Error" in result
+        assert "Quiz not found" in result
+
+
+# --- start_quiz_attempt ----------------------------------------------------
+
+
+class TestStartQuizAttempt:
+    @pytest.mark.asyncio
+    async def test_preview_starts_nothing(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(None),
+        ]
+
+        start_quiz_attempt = get_tool_function("start_quiz_attempt")
+        preview = await start_quiz_attempt("60366", 101)
+
+        assert "nothing started" in preview
+        assert "confirmation_token:" in preview
+        assert "UNTRUSTED CANVAS CONTENT" in preview
+        assert all(
+            call.args[0] == "get"
+            for call in mock_quiz_api["make_canvas_request"].call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_confirmed_start_attempt_success(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(None),
+            MOCK_QUIZ_DETAIL,
+            _submission_response(None),
+            {"quiz_submissions": [MOCK_SUBMISSION]},
+            MOCK_SUBMISSION_QUESTIONS,
+        ]
+
+        start_quiz_attempt = get_tool_function("start_quiz_attempt")
+        preview = await start_quiz_attempt("60366", 101)
+        result = await start_quiz_attempt(
+            "60366", 101, confirmation_token=_confirmation_token(preview)
+        )
+
+        assert "Started quiz attempt" in result
+        assert "VTOKEN123" in result
+        assert "quiz_submission_id: 555" in result
+        assert "attempt: 1" in result
+        # Questions and their answer choices surfaced
+        assert "Pick the best answer." in result
+        assert "id=3" in result
+        assert "multiple_choice_question" in result
+        # Answer-format guidance present so the agent can build answers
+        assert "matching_question" in result
+        assert "UNTRUSTED CANVAS CONTENT" in result
+        assert "quiz question name" in result
+        assert "quiz question text" in result
+        assert "quiz answer choice" in result
+
+    @pytest.mark.asyncio
+    async def test_start_attempt_resumes_on_conflict(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(MOCK_SUBMISSION),
+            MOCK_QUIZ_DETAIL,
+            _submission_response(MOCK_SUBMISSION),
+            {"error": "HTTP error: 409, Details: {'message': 'already exists'}"},
+            {"quiz_submissions": [MOCK_SUBMISSION]},
+            MOCK_SUBMISSION_QUESTIONS,
+        ]
+
+        start_quiz_attempt = get_tool_function("start_quiz_attempt")
+        preview = await start_quiz_attempt("60366", 101)
+        result = await start_quiz_attempt(
+            "60366", 101, confirmation_token=_confirmation_token(preview)
+        )
+
+        assert "Resumed in-progress quiz attempt" in result
+        assert "VTOKEN123" in result
+        assert "Pick the best answer." in result
+
+        # The resume path must hit the singular /submission endpoint, NOT re-POST
+        # to the plural /submissions create endpoint.
+        calls = mock_quiz_api["make_canvas_request"].call_args_list
+        assert calls[4].args[1].endswith("/submissions")
+        assert calls[5].args[1].endswith("/submission")
+
+    @pytest.mark.asyncio
+    async def test_start_confirmation_rejected_after_state_change(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(None),
+            MOCK_QUIZ_DETAIL,
+            _submission_response(MOCK_SUBMISSION),
+        ]
+
+        start_quiz_attempt = get_tool_function("start_quiz_attempt")
+        preview = await start_quiz_attempt("60366", 101)
+        result = await start_quiz_attempt(
+            "60366", 101, confirmation_token=_confirmation_token(preview)
+        )
+
+        assert "does not match" in result
+        assert "Nothing was started" in result
+        assert not any(
+            call.args[0] == "post"
+            for call in mock_quiz_api["make_canvas_request"].call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_start_attempt_passes_access_code(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(None),
+            MOCK_QUIZ_DETAIL,
+            _submission_response(None),
+            {"quiz_submissions": [MOCK_SUBMISSION]},
+            MOCK_SUBMISSION_QUESTIONS,
+        ]
+
+        start_quiz_attempt = get_tool_function("start_quiz_attempt")
+        preview = await start_quiz_attempt("60366", 101, access_code="secret")
+        await start_quiz_attempt(
+            "60366",
+            101,
+            access_code="secret",
+            confirmation_token=_confirmation_token(preview),
+        )
+
+        post_call = mock_quiz_api["make_canvas_request"].call_args_list[4]
+        assert post_call.kwargs["data"] == {"access_code": "secret"}
+        assert "secret" not in preview
+
+    @pytest.mark.asyncio
+    async def test_start_confirmation_is_single_use(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(None),
+            MOCK_QUIZ_DETAIL,
+            _submission_response(None),
+            {"quiz_submissions": [MOCK_SUBMISSION]},
+            MOCK_SUBMISSION_QUESTIONS,
+            MOCK_QUIZ_DETAIL,
+            _submission_response(None),
+        ]
+
+        start_quiz_attempt = get_tool_function("start_quiz_attempt")
+        preview = await start_quiz_attempt("60366", 101)
+        token = _confirmation_token(preview)
+        first = await start_quiz_attempt("60366", 101, confirmation_token=token)
+        replay = await start_quiz_attempt("60366", 101, confirmation_token=token)
+
+        assert "Started quiz attempt" in first
+        assert "already used" in replay
+        post_calls = [
+            call
+            for call in mock_quiz_api["make_canvas_request"].call_args_list
+            if call.args[0] == "post"
+        ]
+        assert len(post_calls) == 1
+
+
+# --- answer_quiz_questions -------------------------------------------------
+
+
+class TestAnswerQuizQuestions:
+    @pytest.mark.asyncio
+    async def test_answer_dict_form(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].return_value = {
+            "quiz_submission_questions": [
+                {"id": 1, "answer": 3, "flagged": False},
+                {"id": 2, "answer": "My essay", "flagged": False},
+            ]
+        }
+
+        answer_quiz_questions = get_tool_function("answer_quiz_questions")
+        result = await answer_quiz_questions(
+            555, 1, "VTOKEN123", '{"1": 3, "2": "My essay"}'
+        )
+
+        assert "Recorded answers for 2" in result
+        assert "Not yet submitted" in result
+
+        # Body must carry attempt, validation_token, and normalized quiz_questions
+        body = mock_quiz_api["make_canvas_request"].call_args.kwargs["data"]
+        assert body["attempt"] == 1
+        assert body["validation_token"] == "VTOKEN123"
+        assert {"id": "1", "answer": 3} in body["quiz_questions"]
+        assert {"id": "2", "answer": "My essay"} in body["quiz_questions"]
+
+    @pytest.mark.asyncio
+    async def test_answer_array_form(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].return_value = {
+            "quiz_submission_questions": [{"id": 1, "answer": [3, 6]}]
+        }
+
+        answer_quiz_questions = get_tool_function("answer_quiz_questions")
+        result = await answer_quiz_questions(
+            555, 1, "VTOKEN123", '[{"id": 1, "answer": [3, 6]}]'
+        )
+
+        assert "Recorded answers for 1" in result
+        body = mock_quiz_api["make_canvas_request"].call_args.kwargs["data"]
+        assert body["quiz_questions"] == [{"id": "1", "answer": [3, 6]}]
+
+    @pytest.mark.asyncio
+    async def test_answer_invalid_json(self, mock_quiz_api):
+        answer_quiz_questions = get_tool_function("answer_quiz_questions")
+        result = await answer_quiz_questions(555, 1, "VTOKEN123", "not json at all")
+
+        assert "Error" in result
+        assert "Invalid answers JSON" in result
+        # No API call should have been made for malformed input
+        mock_quiz_api["make_canvas_request"].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_answer_api_error(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].return_value = {
+            "error": "HTTP error: 401, Details: invalid token"
+        }
+
+        answer_quiz_questions = get_tool_function("answer_quiz_questions")
+        result = await answer_quiz_questions(555, 1, "BAD", '{"1": 3}')
+
+        assert "Error recording answers" in result
+        assert "401" in result
+
+    @pytest.mark.asyncio
+    async def test_answer_no_confirmation_questions(self, mock_quiz_api):
+        # 2xx body lacking quiz_submission_questions -> graceful fallback message
+        mock_quiz_api["make_canvas_request"].return_value = {}
+
+        answer_quiz_questions = get_tool_function("answer_quiz_questions")
+        result = await answer_quiz_questions(555, 1, "VTOKEN123", '{"1": 3}')
+
+        assert "no confirmation questions" in result
+
+
+# --- submit_quiz_attempt ---------------------------------------------------
+
+
+class TestSubmitQuizAttempt:
+    @pytest.mark.asyncio
+    async def test_preview_submits_nothing(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+        ]
+
+        submit_quiz_attempt = get_tool_function("submit_quiz_attempt")
+        preview = await submit_quiz_attempt("60366", 101, 555, 1, "VTOKEN123")
+
+        assert "nothing submitted" in preview
+        assert "confirmation_token:" in preview
+        assert "UNTRUSTED CANVAS CONTENT" in preview
+        assert not any(
+            call.args[0] == "post"
+            for call in mock_quiz_api["make_canvas_request"].call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_confirmed_submit_success(self, mock_quiz_api):
+        completed = {
+            "quiz_submissions": [
+                {
+                    "attempt": 1,
+                    "workflow_state": "complete",
+                    "score": 18,
+                    "kept_score": 18,
+                }
+            ]
+        }
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+            completed,
+        ]
+
+        submit_quiz_attempt = get_tool_function("submit_quiz_attempt")
+        preview = await submit_quiz_attempt("60366", 101, 555, 1, "VTOKEN123")
+        result = await submit_quiz_attempt(
+            "60366",
+            101,
+            555,
+            1,
+            "VTOKEN123",
+            confirmation_token=_confirmation_token(preview),
+        )
+
+        assert "Quiz submitted" in result
+        assert "Score: 18" in result
+        call = mock_quiz_api["make_canvas_request"].call_args_list[6]
+        assert call.args[1].endswith("/submissions/555/complete")
+        body = call.kwargs["data"]
+        assert body["attempt"] == 1
+        assert body["validation_token"] == "VTOKEN123"
+
+    @pytest.mark.asyncio
+    async def test_answer_change_invalidates_confirmation(self, mock_quiz_api):
+        changed_questions = {
+            "quiz_submission_questions": [
+                {
+                    **MOCK_SUBMISSION_QUESTIONS["quiz_submission_questions"][0],
+                    "answer": 6,
+                },
+                MOCK_SUBMISSION_QUESTIONS["quiz_submission_questions"][1],
+            ]
+        }
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            changed_questions,
+        ]
+
+        submit_quiz_attempt = get_tool_function("submit_quiz_attempt")
+        preview = await submit_quiz_attempt("60366", 101, 555, 1, "VTOKEN123")
+        result = await submit_quiz_attempt(
+            "60366",
+            101,
+            555,
+            1,
+            "VTOKEN123",
+            confirmation_token=_confirmation_token(preview),
+        )
+
+        assert "does not match" in result
+        assert "Nothing was submitted" in result
+        assert not any(
+            call.args[0] == "post"
+            for call in mock_quiz_api["make_canvas_request"].call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_submit_confirmation_is_single_use(self, mock_quiz_api):
+        completed = {"quiz_submissions": [{"attempt": 1, "workflow_state": "complete"}]}
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+            completed,
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+        ]
+
+        submit_quiz_attempt = get_tool_function("submit_quiz_attempt")
+        preview = await submit_quiz_attempt("60366", 101, 555, 1, "VTOKEN123")
+        token = _confirmation_token(preview)
+        first = await submit_quiz_attempt(
+            "60366", 101, 555, 1, "VTOKEN123", confirmation_token=token
+        )
+        replay = await submit_quiz_attempt(
+            "60366", 101, 555, 1, "VTOKEN123", confirmation_token=token
+        )
+
+        assert "Quiz submitted" in first
+        assert "already used" in replay
+        post_calls = [
+            call
+            for call in mock_quiz_api["make_canvas_request"].call_args_list
+            if call.args[0] == "post"
+        ]
+        assert len(post_calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_expired_confirmation_is_rejected(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+        ]
+
+        submit_quiz_attempt = get_tool_function("submit_quiz_attempt")
+        with patch("canvas_mcp.core.write_confirmation.time.time", return_value=1000):
+            preview = await submit_quiz_attempt("60366", 101, 555, 1, "VTOKEN123")
+        with patch("canvas_mcp.core.write_confirmation.time.time", return_value=1301):
+            result = await submit_quiz_attempt(
+                "60366",
+                101,
+                555,
+                1,
+                "VTOKEN123",
+                confirmation_token=_confirmation_token(preview),
+            )
+
+        assert "expired" in result
+        assert "Nothing was submitted" in result
+
+    @pytest.mark.asyncio
+    async def test_confirmation_is_bound_to_caller(self, mock_quiz_api):
+        mock_quiz_api["make_canvas_request"].side_effect = [
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+            MOCK_QUIZ_DETAIL,
+            _submission_response(),
+            MOCK_SUBMISSION_QUESTIONS,
+        ]
+        submit_quiz_attempt = get_tool_function("submit_quiz_attempt")
+
+        try:
+            set_request_credentials(
+                RequestCredentials("student-a", "https://canvas.example/api/v1")
+            )
+            preview = await submit_quiz_attempt("60366", 101, 555, 1, "VTOKEN123")
+            set_request_credentials(
+                RequestCredentials("student-b", "https://canvas.example/api/v1")
+            )
+            result = await submit_quiz_attempt(
+                "60366",
+                101,
+                555,
+                1,
+                "VTOKEN123",
+                confirmation_token=_confirmation_token(preview),
+            )
+        finally:
+            clear_request_credentials()
+
+        assert "does not match" in result
+        assert "Nothing was submitted" in result
+
+
+# --- _normalize_answers (helper) -------------------------------------------
+
+
+class TestNormalizeAnswers:
+    def test_dict_form(self):
+        qq, err = _normalize_answers('{"4": 5, "5": "Paris"}')
+        assert err is None
+        assert {"id": "4", "answer": 5} in qq
+        assert {"id": "5", "answer": "Paris"} in qq
+
+    def test_array_form_with_question_id_key(self):
+        qq, err = _normalize_answers('[{"question_id": 9, "answer": [1, 2]}]')
+        assert err is None
+        assert qq == [{"id": "9", "answer": [1, 2]}]
+
+    def test_array_item_missing_answer(self):
+        qq, err = _normalize_answers('[{"id": 9}]')
+        assert qq is None
+        assert "missing" in err.lower()
+
+    def test_invalid_json(self):
+        qq, err = _normalize_answers("{nope")
+        assert qq is None
+        assert "Invalid answers JSON" in err
+
+    def test_wrong_top_level_type(self):
+        qq, err = _normalize_answers("42")
+        assert qq is None
+        assert "must be a JSON object or array" in err

--- a/tools/README.md
+++ b/tools/README.md
@@ -271,6 +271,100 @@ List peer reviews you need to complete.
 
 ---
 
+### Taking Quizzes (Classic Quizzes)
+
+> **Off by default.** These tools exist only when the server operator sets
+> `QUIZ_TAKING_ENABLED=true`. They take a **Classic Quiz** as the authenticated student. **New Quizzes**
+> (the `quiz_lti` engine) are not exposed by the Canvas REST API and must be taken in
+> the Canvas web UI. Browse/inspect quizzes with `list_quizzes` and `get_quiz_details`
+> (see [Shared Tools](#shared-tools-both-students--educators)).
+>
+> Starting and submitting are both two-call operations. First omit
+> `confirmation_token`, show the returned preview to the student, then repeat
+> the same call with that token. Tokens are caller-bound, single-use, expire in
+> five minutes, and fail if the observed Canvas state changes.
+
+#### `start_quiz_attempt`
+Preview, then start (or resume) an attempt at a Classic Quiz and return its questions.
+
+**Parameters:**
+- `course_identifier` (required): Course code or Canvas ID
+- `quiz_id` (required): Canvas quiz ID (from `list_quizzes`)
+- `access_code` (optional): Access code, if the quiz requires one
+- `confirmation_token` (optional): Token from the preview; omit to preview
+
+**Example:**
+```
+"Start the Hamlet quiz in BADM 350"                → returns a preview
+"Yes, start it"                                    → confirms with the token
+```
+
+**Returns:** The first call returns timing, attempt state, and a confirmation
+token without starting anything. The confirmed call returns the
+`quiz_submission_id`, `attempt` number, `validation_token`, end time, and
+questions. Starting may consume one allowed attempt; it does **not** submit.
+
+---
+
+#### `answer_quiz_questions`
+Record answers for an in-progress quiz attempt. Can be called repeatedly; never submits.
+
+**Parameters:**
+- `quiz_submission_id` (required): From `start_quiz_attempt`
+- `attempt` (required): The attempt number from `start_quiz_attempt` (must be the latest)
+- `validation_token` (required): The token from `start_quiz_attempt`
+- `answers` (required): A JSON string — either an object mapping question ID to answer value
+  (`{"4": 5, "5": "Paris"}`) or an array of `{"id": <question_id>, "answer": <value>}` objects.
+  The answer **value** format depends on the question type:
+  - `multiple_choice_question` / `true_false_question` → answer id (int)
+  - `multiple_answers_question` → array of answer ids, e.g. `[3, 6]`
+  - `short_answer_question` (fill-in-the-blank) → string
+  - `essay_question` → string (may contain HTML)
+  - `numerical_question` / `calculated_question` → number (or numeric string)
+  - `fill_in_multiple_blanks_question` → object `{"blank_name": "text"}`
+  - `multiple_dropdowns_question` → object `{"blank_name": answer_id}`
+  - `matching_question` → array of `{"answer_id": id, "match_id": id}`
+- `access_code` (optional): Access code, if the quiz requires one
+
+**Example:**
+```
+"Answer question 4 with choice 5 and question 5 with 'Paris'"
+→ answer_quiz_questions(submission_id, 1, token, answers='{"4": 5, "5": "Paris"}')
+```
+
+**Returns:** Confirmation of the recorded answers per question. The attempt is still open —
+nothing is turned in until you call `submit_quiz_attempt`.
+
+---
+
+#### `submit_quiz_attempt`
+Preview, then submit (turn in) an in-progress quiz attempt. **Irreversible** —
+once complete, no further changes are allowed.
+
+**Parameters:**
+- `course_identifier` (required): Course code or Canvas ID
+- `quiz_id` (required): Canvas quiz ID
+- `quiz_submission_id` (required): From `start_quiz_attempt`
+- `attempt` (required): The attempt number from `start_quiz_attempt` (must be the latest)
+- `validation_token` (required): The token from `start_quiz_attempt`
+- `access_code` (optional): Access code, if the quiz requires one
+- `confirmation_token` (optional): Token from the preview; omit to preview
+
+**Example:**
+```
+"Turn in my quiz"
+→ returns the current saved-answer preview
+"Yes, turn it in"
+→ repeats the call with the confirmation token
+```
+
+**Returns:** The first call returns the current attempt state and saved answers
+without submitting. The confirmed call returns the final workflow state
+(`complete` or `pending_review`) and score when available. Any saved-answer or
+attempt-state change invalidates the token.
+
+---
+
 ## Educator Tools
 
 These tools provide instructors and TAs with course management, grading, analytics, and communication capabilities.
@@ -1860,6 +1954,48 @@ Create a new discussion post.
 - `course_identifier`: Course code or ID
 - `topic_id`: Discussion topic ID
 - `message`: Post content
+
+---
+
+### Quizzes (Classic Quizzes)
+
+> Read-only browse/inspect for **Classic Quizzes**. To take a quiz as a student, see
+> [Taking Quizzes](#taking-quizzes-classic-quizzes) under Student Tools. **New Quizzes**
+> (`quiz_lti`) are not exposed by the REST API and appear via `list_assignments` instead.
+
+#### `list_quizzes`
+List the Classic Quizzes available in a course.
+
+**Parameters:**
+- `course_identifier` (required): Course code or Canvas ID
+- `search_term` (optional): Partial quiz title to filter by
+
+**Example:**
+```
+"What quizzes are in BADM 350?"
+"Find the midterm quiz"
+```
+
+**Returns:** Each quiz's ID, title, type, question count, points, due date, and
+published/locked status.
+
+---
+
+#### `get_quiz_details`
+Get detailed settings for a single Classic Quiz.
+
+**Parameters:**
+- `course_identifier` (required): Course code or Canvas ID
+- `quiz_id` (required): Canvas quiz ID (from `list_quizzes`)
+
+**Example:**
+```
+"Show me the settings for quiz 101"
+"How many attempts and how long do I get on the Hamlet quiz?"
+```
+
+**Returns:** Type, points, question count and types, allowed attempts, time limit, scoring
+policy, navigation settings, due/unlock/lock dates, access-code/lock state, and description.
 
 ---
 

--- a/tools/TOOL_MANIFEST.json
+++ b/tools/TOOL_MANIFEST.json
@@ -146,6 +146,135 @@
       ]
     },
     {
+      "name": "start_quiz_attempt",
+      "category": "student",
+      "description": "Preview, then start or resume a Classic Quiz attempt and return its questions. Available only when QUIZ_TAKING_ENABLED=true",
+      "parameters": [
+        {
+          "name": "course_identifier",
+          "type": "string | integer",
+          "required": true,
+          "description": "Course code or Canvas ID"
+        },
+        {
+          "name": "quiz_id",
+          "type": "string | integer",
+          "required": true,
+          "description": "Canvas quiz ID (from list_quizzes)"
+        },
+        {
+          "name": "access_code",
+          "type": "string",
+          "required": false,
+          "description": "Access code, if the quiz requires one"
+        },
+        {
+          "name": "confirmation_token",
+          "type": "string",
+          "required": false,
+          "description": "Short-lived token from the preview call; omit to preview"
+        }
+      ],
+      "returns": "First call: human-readable preview and confirmation token, with no attempt started. Confirmed call: quiz_submission_id, attempt, validation_token, and fenced questions",
+      "examples": [
+        "Start the Hamlet quiz and show me the questions"
+      ]
+    },
+    {
+      "name": "answer_quiz_questions",
+      "category": "student",
+      "description": "Record answers for an in-progress quiz attempt (repeatable; never submits). Available only when QUIZ_TAKING_ENABLED=true",
+      "parameters": [
+        {
+          "name": "quiz_submission_id",
+          "type": "string | integer",
+          "required": true,
+          "description": "From start_quiz_attempt"
+        },
+        {
+          "name": "attempt",
+          "type": "integer",
+          "required": true,
+          "description": "Attempt number from start_quiz_attempt (must be the latest)"
+        },
+        {
+          "name": "validation_token",
+          "type": "string",
+          "required": true,
+          "description": "Token from start_quiz_attempt"
+        },
+        {
+          "name": "answers",
+          "type": "string",
+          "required": true,
+          "description": "JSON string: object {question_id: answer} or array of {id, answer}. Answer value format depends on question type (mc/true-false=int id; multiple-answers=array of ids; essay/short=string; numerical=number; fill-in-blanks={blank: text}; dropdowns={blank: id}; matching=[{answer_id, match_id}])"
+        },
+        {
+          "name": "access_code",
+          "type": "string",
+          "required": false,
+          "description": "Access code, if the quiz requires one"
+        }
+      ],
+      "returns": "Confirmation of recorded answers per question. Attempt stays open until submit_quiz_attempt",
+      "examples": [
+        "Answer question 4 with choice 5 and question 5 with 'Paris'"
+      ]
+    },
+    {
+      "name": "submit_quiz_attempt",
+      "category": "student",
+      "description": "Preview current answers, then submit an in-progress quiz attempt. Irreversible and available only when QUIZ_TAKING_ENABLED=true",
+      "parameters": [
+        {
+          "name": "course_identifier",
+          "type": "string | integer",
+          "required": true,
+          "description": "Course code or Canvas ID"
+        },
+        {
+          "name": "quiz_id",
+          "type": "string | integer",
+          "required": true,
+          "description": "Canvas quiz ID"
+        },
+        {
+          "name": "quiz_submission_id",
+          "type": "string | integer",
+          "required": true,
+          "description": "From start_quiz_attempt"
+        },
+        {
+          "name": "attempt",
+          "type": "integer",
+          "required": true,
+          "description": "Attempt number from start_quiz_attempt (must be the latest)"
+        },
+        {
+          "name": "validation_token",
+          "type": "string",
+          "required": true,
+          "description": "Token from start_quiz_attempt"
+        },
+        {
+          "name": "access_code",
+          "type": "string",
+          "required": false,
+          "description": "Access code, if the quiz requires one"
+        },
+        {
+          "name": "confirmation_token",
+          "type": "string",
+          "required": false,
+          "description": "Short-lived token from the preview call; omit to preview"
+        }
+      ],
+      "returns": "First call: saved-answer preview and confirmation token, with no submission. Confirmed call: final workflow state and score when available",
+      "examples": [
+        "Turn in my quiz"
+      ]
+    },
+    {
       "name": "list_assignments",
       "category": "educator",
       "description": "List all assignments for a course",
@@ -687,6 +816,54 @@
       "returns": "Confirmation with updated fields and topic type",
       "examples": [
         "Update the Week 1 discussion prompt to mention Claude and Gemini"
+      ]
+    },
+    {
+      "name": "list_quizzes",
+      "category": "shared",
+      "description": "List Classic Quizzes in a course. New Quizzes (quiz_lti) are not exposed by the REST API and appear via list_assignments",
+      "parameters": [
+        {
+          "name": "course_identifier",
+          "type": "string | integer",
+          "required": true,
+          "description": "Course code or Canvas ID"
+        },
+        {
+          "name": "search_term",
+          "type": "string",
+          "required": false,
+          "description": "Partial quiz title to filter by"
+        }
+      ],
+      "returns": "Each quiz's ID, title, type, question count, points, due date, and published/locked status",
+      "examples": [
+        "What quizzes are in BADM 350?",
+        "Find the midterm quiz"
+      ]
+    },
+    {
+      "name": "get_quiz_details",
+      "category": "shared",
+      "description": "Get detailed settings for a single Classic Quiz",
+      "parameters": [
+        {
+          "name": "course_identifier",
+          "type": "string | integer",
+          "required": true,
+          "description": "Course code or Canvas ID"
+        },
+        {
+          "name": "quiz_id",
+          "type": "string | integer",
+          "required": true,
+          "description": "Canvas quiz ID (from list_quizzes)"
+        }
+      ],
+      "returns": "Type, points, question count/types, allowed attempts, time limit, scoring policy, navigation settings, due/unlock/lock dates, access-code/lock state, and description",
+      "examples": [
+        "Show me the settings for quiz 101",
+        "How many attempts do I get on the Hamlet quiz?"
       ]
     },
     {
@@ -3423,6 +3600,19 @@
         "get_my_upcoming_assignments(days=7)",
         "get_my_submission_status()",
         "get_my_peer_reviews_todo()"
+      ]
+    },
+    {
+      "name": "student_take_quiz",
+      "description": "Take a Classic Quiz end to end when QUIZ_TAKING_ENABLED=true; start and submit each require preview then confirmation",
+      "steps": [
+        "list_quizzes(course_id)",
+        "get_quiz_details(course_id, quiz_id)",
+        "start_quiz_attempt(course_id, quiz_id) to preview",
+        "start_quiz_attempt(course_id, quiz_id, confirmation_token=token) to begin",
+        "answer_quiz_questions(quiz_submission_id, attempt, validation_token, answers)",
+        "submit_quiz_attempt(course_id, quiz_id, quiz_submission_id, attempt, validation_token) to preview",
+        "submit_quiz_attempt(course_id, quiz_id, quiz_submission_id, attempt, validation_token, confirmation_token=token) to turn in"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- add a private Streamable HTTP credential mode for remote MCP clients such as Poke while preserving stdio and per-request Canvas-token deployments
- authenticate `/mcp` with standard bearer API keys, retain the legacy access-key header, reject conflicting credentials, and expose a minimal unauthenticated `/healthz`
- keep the Canvas token request-local in server credential mode and treat `X-Poke-User-Id` as optional audit metadata only
- port Classic Quiz listing/details support and gate all quiz-taking tools behind `QUIZ_TAKING_ENABLED`
- fence Canvas-authored quiz content and require caller-bound, expiring, single-use confirmation tokens before starting timed attempts or submitting attempts
- document the private Poke profile and add a conservative Fly.io deployment configuration with student-only tools, code execution disabled, and quiz taking disabled

## Why

The existing HTTP transport expected every MCP request to include a Canvas-specific credential header. Private remote clients such as Poke use `Authorization: Bearer <api-key>` instead and need the hosted server to retain the Canvas credential securely. This adds that deployment model without changing the existing stdio or multi-user request-header defaults.

## Impact

Operators can run Canvas MCP as a private remote service at `/mcp`. Authentication is required before discovery or tool execution, failures return a standard bearer challenge, and the health endpoint reveals only service health. Existing deployments remain on `request-header` mode unless explicitly changed.

Quiz browsing remains available to student and shared profiles. Starting, answering, or submitting a quiz remains unregistered unless the operator deliberately enables quiz taking; irreversible quiz transitions use a two-step preview and confirmation flow.

## Validation

- full test suite: 1,377 passed, 22 skipped
- Ruff lint passed
- mypy type checks passed
- Docker image built successfully
- container health check and stdio regression smoke test passed
- unauthenticated `/mcp` rejected with `401` and `WWW-Authenticate: Bearer`
- Poke-shaped bearer `initialize` and `tools/list` requests passed without Canvas request headers
- server-mode Canvas-backed tool smoke test passed
- default remote profile exposed read-only quiz tools while omitting quiz-taking and TypeScript execution tools
