### PR TITLE
triage: GitHub activity brief 2026-08-12

### DIFF
--- a/internal/issue-triage/2026-08-12.md
+++ b/internal/issue-triage/2026-08-12.md
@@ -1,0 +1,121 @@
+# Triage brief — 2026-08-12
+
+**Read path used:** GitHub MCP tools (`gh` CLI not checked; MCP tools worked directly).
+**Cutoff:** 2026-08-11T02:11:08Z — the merge timestamp of PR #280 (the 2026-08-11 brief itself),
+per the precedent set by the last several briefs. Everything below is activity strictly after
+that timestamp, cross-checked against the 2026-08-11 brief's contents so nothing already reported
+gets repeated.
+
+## Needs your reply
+
+### ⚠️ #275 — [Bug]: peer review tools still not working (student-role tool; khagyard, first-time reporter)
+
+You'd already ruled out field-mapping and anonymization, shipped PR #277 (`assignment_identifier`
+direct lookup), and — after the reporter confirmed a regular, non-anonymous assignment assigned
+before its due date — clarified that #277 landed *after* v1.9.0 shipped, so a packaged-release
+user couldn't have tried it yet (your 2026-08-11T02:19Z comment, just after the previous brief's
+cutoff).
+
+Two outside contributors picked the thread up from there — new since cutoff:
+
+- **aesse97** (2026-08-11T16:42Z): suggests the Canvas `peer_reviews` listing endpoint is
+  instructor-focused, not student-focused, and the **Planner API** is the one built for a
+  student's own to-do view.
+- **jonespm** (2026-08-11T17:28Z, most recent comment, 1 reaction): points at the concrete
+  endpoint the Canvas UI itself calls to build that to-do list —
+  `/api/v1/planner/items?start_date=...&filter=incomplete_items&order=asc&per_page=100` — and
+  notes it would probably need a start-date bound.
+
+This is a genuinely different lead than anything tried so far: `get_my_todo_items`
+(`student_tools.py:273-276`) already calls Canvas's `/users/self/todo`, a different endpoint from
+Planner: worth checking whether Planner surfaces peer-review items that `/users/self/todo` misses,
+before deciding whether to extend the existing todo tool or add a Planner-backed path to
+`get_my_peer_reviews_todo` specifically.
+
+```
+Thanks both — that's a genuinely different angle than what I'd already ruled out. jonespm's
+right that `peer_reviews` on the assignment listing is built for the grading/instructor view,
+and the student-facing Planner endpoint sounds like it's built for exactly this case instead of
+being adapted to it.
+
+I'll look at wiring `get_my_peer_reviews_todo` through the Planner API — likely alongside the
+existing assessor-listing lookup rather than replacing it, since I don't yet know whether Planner
+carries the same completion/due-date detail. Will report back once I've verified it against a
+real instance rather than just the docs.
+
+@khagyard — no need to re-test again until that lands; I'll ping this thread when there's
+something new to try.
+```
+
+### #281 — [Bug]: search_canvas_tools didn't return peer review tools (zqian, reporter)
+
+Filed by zqian just after the previous cutoff (2026-08-11T02:54Z). New since then, both after
+cutoff:
+
+- **bruchris** (10:26Z, external maintainer of a different Canvas MCP server, no stake in this
+  repo) did the actual root-cause work: `search_canvas_tools` only walks
+  `code_api/canvas/**/*.ts` — the TypeScript code-execution surface, 9 real files after the
+  index barrels are skipped — never the live 99-tool MCP registry. A query for "peer reviews"
+  gets a coincidental substring hit (`bulkGradeDiscussion.ts`, which happens to use the phrase
+  "peer review" for grading math) rather than any of the 14 actual `peer_review`-named tools,
+  which live entirely outside that tree. He frames the real defect as the same
+  confident-plausible-wrong class as #199/#171: nothing distinguishes "no such tool" from "not
+  in this particular index." He proposes three fix directions (widen the search to the real
+  registry / keep scope but rename honestly / keep scope but flag low-confidence results) and
+  deliberately didn't open a PR since it's a design call, noting #271 may already be reworking
+  this surface.
+- **zqian** (13:10Z, most recent comment) thanked bruchris and said they'd removed an
+  "incomplete descriptions" line from the original report — i.e. retracted their own working
+  theory in favor of bruchris's.
+
+```
+@bruchris — thank you for this, genuinely. I'd have gone looking at tool docstrings first, and
+that would have fixed nothing.
+
+Confirmed your read: `search_canvas_tools` only searches the code-execution API tree, not the
+MCP tool registry, so a query for anything outside those 9 files either gets a coincidental
+substring hit or nothing, with no signal to tell the two apart.
+
+Between your three options, I'm leaning toward the "be honest about scope" fix as the near-term
+change — rename or restate the tool so a miss reads as out-of-scope rather than absent, and
+return an explicit low-confidence note instead of a bare best-effort result — and holding
+"widen to the full registry" for when #271's output-schema rework touches this surface anyway,
+since that's the bigger change and I'd rather not rush it alongside this fix.
+
+@zqian — thanks for confirming. If either of you wants to send a PR for the scope-honesty fix
+in the meantime, happy to review.
+```
+
+## PRs
+
+| PR | Author | Draft | Mergeable | CI | Next action |
+|---|---|---|---|---|---|
+| #272 chore(deps): bump actions group (5 updates) | dependabot | no | behind main | 19 checks: 17 success, 2 neutral (Cursor agents), 1 failure (`claude-review`, **not** a required check — required set is `test-enhancements` + `lint`, both green) | Safe to merge after a rebase; the one failing check isn't gating |
+| #266 chore(deps-dev): typescript 5.9.3 → 7.0.2 | dependabot | no | behind main | **0 recorded checks** despite being open 2 days | CI hasn't run on this branch at all yet (unlike #272, opened the same day). This is also a 2-major jump (skips 6.x). Worth a manual CI trigger/rebase and a quick `tsc` smoke-test on `code_api/` before merging blind |
+| #265 chore(deps-dev): @types/node 20.19.24 → 26.1.2 | dependabot | no | behind main | 0 recorded checks | Same "CI never ran" pattern as #266 — worth checking why dependabot branches from 2026-08-10 aren't triggering Actions uniformly (#272 did, these two + #264 didn't) |
+| #264 chore(deps): python 3.12-slim → 3.14-slim (Dockerfile) | dependabot | no | behind main | 0 recorded checks | Same CI-never-ran pattern. Also: the test matrix (per CLAUDE.md) covers 3.10-3.13, not 3.14 — bumping the container's Python ahead of what's actually tested is worth a second look before merging |
+| #253 fix: form-data for create_announcement (addresses #252) | ChickenisLegit (fork) | no | behind main | 0 recorded checks — fork PR, not yet approved to run (expected, not a failure) | No new activity since your 2026-08-09 comment holding it pending zqian's v1.7.0+ retest on #252. Nothing to do until that retest lands |
+| #191 feat: dual-engine read tools for Canvas Quizzes | Copilot (same-repo branch) | **yes** | **dirty** (conflicts with main) | 0 recorded checks | Same-repo Copilot branch with zero triggered runs — per the known pattern here, `update-branch` both rebases and kicks CI. Still blocked on the New-Quizzes-detection correctness bug documented in #172 (measured live: `is_quiz_assignment AND external_tool` marks *Classic* quizzes). Its own PR body still carries a GitHub auto-close keyword pointed at issue 172 — strip that before any merge, per the precedent already logged in #172's thread |
+
+## New since 2026-08-11T02:11:08Z
+
+- **#281** (issue) — opened by zqian, 02:54Z. See "Needs your reply" above.
+- No new PRs since cutoff (all 6 open PRs predate it).
+
+## Going stale
+
+- ⚠️ **#170** (zqian, student-write-tools/FERPA-adjacent) — your last comment (2026-07-30) shipped
+  Tier 1 and left two design questions open: default posture (`COURSE_AGENT_POLICY_DEFAULT`) and
+  whether the syllabus is an acceptable policy carrier. zqian's last touch was 2026-07-29 — 14
+  days with no answer on either question.
+- **#157** (sandbox hardening backlog) — no comment since your 2026-07-10 scoping note (33 days).
+  No external party waiting; self-tracked backlog item, flagged for visibility only.
+
+## Checked, nothing needed
+
+#172 (blocked on external New-Quizzes sandbox access, you already have the last word), #142
+(intentionally converted to a watch item with a documented trigger), #236, #239, #252, #262,
+#270, #271 (all your own filed issues, single self-comment, no external activity since cutoff).
+
+---
+_Generated by [Claude Code](https://claude.ai/code)_

--- a/internal/issue-triage/2026-08-12.md
+++ b/internal/issue-triage/2026-08-12.md
@@ -6,6 +6,20 @@ per the precedent set by the last several briefs. Everything below is activity s
 that timestamp, cross-checked against the 2026-08-11 brief's contents so nothing already reported
 gets repeated.
 
+### Correction to this brief (post-publish, caught by PR review)
+
+The PR table originally reported "0 recorded checks" / "CI never ran" for #266, #265, and #264,
+with next-action text recommending a manual CI trigger and an investigation into why dependabot
+branches from 2026-08-10 weren't running Actions. **That was wrong** — the 2026-08-11 brief had
+already hit and documented this exact trap in its own "Corrections" section: this repo's legacy
+commit-status API reliably returns `total_count: 0` for every PR here (nothing publishes legacy
+statuses), because every check is a GitHub Actions check run, a different API. The first pass at
+this table queried the wrong endpoint for these three PRs specifically (unlike #272, #253, and
+#191, which were queried correctly). Re-queried check runs directly: all three have full,
+completed, green-on-required-checks CI from 2026-08-10 — see the corrected table below. Caught by
+`claude[bot]`'s and Codex's independent review comments on this PR; both flagged the same three
+rows.
+
 ## Needs your reply
 
 ### ⚠️ #275 — [Bug]: peer review tools still not working (student-role tool; khagyard, first-time reporter)
@@ -91,9 +105,9 @@ in the meantime, happy to review.
 | PR | Author | Draft | Mergeable | CI | Next action |
 |---|---|---|---|---|---|
 | #272 chore(deps): bump actions group (5 updates) | dependabot | no | behind main | 19 checks: 17 success, 2 neutral (Cursor agents), 1 failure (`claude-review`, **not** a required check — required set is `test-enhancements` + `lint`, both green) | Safe to merge after a rebase; the one failing check isn't gating |
-| #266 chore(deps-dev): typescript 5.9.3 → 7.0.2 | dependabot | no | behind main | **0 recorded checks** despite being open 2 days | CI hasn't run on this branch at all yet (unlike #272, opened the same day). This is also a 2-major jump (skips 6.x). Worth a manual CI trigger/rebase and a quick `tsc` smoke-test on `code_api/` before merging blind |
-| #265 chore(deps-dev): @types/node 20.19.24 → 26.1.2 | dependabot | no | behind main | 0 recorded checks | Same "CI never ran" pattern as #266 — worth checking why dependabot branches from 2026-08-10 aren't triggering Actions uniformly (#272 did, these two + #264 didn't) |
-| #264 chore(deps): python 3.12-slim → 3.14-slim (Dockerfile) | dependabot | no | behind main | 0 recorded checks | Same CI-never-ran pattern. Also: the test matrix (per CLAUDE.md) covers 3.10-3.13, not 3.14 — bumping the container's Python ahead of what's actually tested is worth a second look before merging |
+| #266 chore(deps-dev): typescript 5.9.3 → 7.0.2 | dependabot | no | behind main | 17 checks, completed 2026-08-10T11:48-11:50Z: all green except non-required `claude-review` | Same green-required-checks state as #272. Safe to merge after a rebase. It is a 2-major jump (skips 6.x) — worth a quick `tsc` smoke-test on `code_api/` given #271's TS surface, but not blocked on CI |
+| #265 chore(deps-dev): @types/node 20.19.24 → 26.1.2 | dependabot | no | behind main | 19 checks, completed 2026-08-10T11:48-11:50Z: all green except non-required `claude-review` | Same green-required-checks state as #272. Safe to merge after a rebase |
+| #264 chore(deps): python 3.12-slim → 3.14-slim (Dockerfile) | dependabot | no | behind main | 17 checks, completed 2026-08-10T05:14-05:16Z: all green except non-required `claude-review` | Same green-required-checks state as #272. Safe to merge after a rebase. The test matrix (per CLAUDE.md) covers 3.10-3.13, not 3.14 — bumping the container's Python ahead of what's actually tested is still worth a second look, but CI is not the blocker |
 | #253 fix: form-data for create_announcement (addresses #252) | ChickenisLegit (fork) | no | behind main | 0 recorded checks — fork PR, not yet approved to run (expected, not a failure) | No new activity since your 2026-08-09 comment holding it pending zqian's v1.7.0+ retest on #252. Nothing to do until that retest lands |
 | #191 feat: dual-engine read tools for Canvas Quizzes | Copilot (same-repo branch) | **yes** | **dirty** (conflicts with main) | 0 recorded checks | Same-repo Copilot branch with zero triggered runs — per the known pattern here, `update-branch` both rebases and kicks CI. Still blocked on the New-Quizzes-detection correctness bug documented in #172 (measured live: `is_quiz_assignment AND external_tool` marks *Classic* quizzes). Its own PR body still carries a GitHub auto-close keyword pointed at issue 172 — strip that before any merge, per the precedent already logged in #172's thread |
 

--- a/internal/issue-triage/2026-08-12.md
+++ b/internal/issue-triage/2026-08-12.md
@@ -132,4 +132,135 @@ in the meantime, happy to review.
 #270, #271 (all your own filed issues, single self-comment, no external activity since cutoff).
 
 ---
+
+## Executor results (2026-08-12T01:52Z)
+
+Ran against brief head `8d81775` (i.e. after the brief's own post-publish correction commit).
+
+### Closing-keyword check
+
+`scripts/check_closing_keywords.py --strict` on the brief: **exit 0, clean**. PR #282's body:
+manually checked, clean (it describes #191's keyword without reproducing one).
+
+### Branch updates performed
+
+All four dependabot PRs were `behind` main, and #272's `mergeable_state` is literally `behind` —
+so this repo's branch protection **requires branches be up to date**, meaning "behind" is a hard
+merge blocker here, not cosmetic. Requested update-branch on all four; GitHub accepted each
+("update is in progress"):
+
+| PR | Action | Result |
+|---|---|---|
+| #272 | update-branch | accepted |
+| #266 | update-branch | accepted |
+| #265 | update-branch | accepted |
+| #264 | update-branch | accepted |
+
+These will re-run CI on new head SHAs. Expect `claude-review` to fail again on each — it is not a
+required check.
+
+### Local verification (tests + lint)
+
+Every PR was tested **as merged into current `main`** (detached `origin/main` + `--no-ff` merge),
+not as its stale branch tip, since that is what CI actually validates.
+
+Baseline on the triage branch: `1324 passed, 22 skipped, 2 warnings`.
+
+| PR | Merges into main | `pytest tests/` | `ruff check .` |
+|---|---|---|---|
+| #272 | clean | 1324 passed, 22 skipped | All checks passed! |
+| #266 | clean | 1324 passed, 22 skipped | All checks passed! |
+| #265 | clean | 1324 passed, 22 skipped | All checks passed! |
+| #264 | clean | 1324 passed, 22 skipped | All checks passed! |
+| #253 | clean | 1324 passed, 22 skipped | All checks passed! |
+| #191 | **CONFLICT** | not run | not run |
+
+**Not tested, and why:** #191 — conflicts with `main` in `src/canvas_mcp/tools/assignments.py`,
+so there is no merged state to test. Note also that #266/#265 (npm devDeps) and #264 (Dockerfile)
+are not exercised by the Python suite at all — their green runs confirm no regression, they do
+**not** validate the bumps themselves. #266's 2-major TypeScript jump and #264's 3.14 container
+still need the `tsc` / container smoke-tests the brief already flagged.
+
+### Corrections and refinements to the brief
+
+1. **The CI correction is independently confirmed.** Before pulling the brief's correction commit,
+   I re-derived it from scratch: `get_status` returns `total_count: 0` for **every** PR in this
+   repo including #272, because nothing here publishes legacy commit statuses. Querying workflow
+   runs by branch shows #266 (head `d2cee9ba`), #265 (`35dc720e`), and #264 (`e519af94`) each have
+   completed runs from 2026-08-10 — Closing Keyword Guard, Canvas MCP Enhancement Testing, and
+   Security Testing all `success`, only `Claude Code Review` `failure`. The corrected table is
+   right. No CI retrigger was needed for any of them.
+
+2. **#191's CI is not "0 recorded checks" — it is `action_required`.** Its branch has 14 runs;
+   the ones on current head `8a7e3933` (2026-07-30T10:19Z) are all `completed / action_required`,
+   i.e. queued behind the maintainer-approval gate that applies to Copilot-authored PRs. The
+   distinction matters: the brief's suggested unblock (update-branch to kick CI) would not work,
+   because the branch is `dirty` and update-branch refuses on conflicts. **I deliberately did not
+   push an empty retrigger commit**, even though my mandate permits it — the PR cannot merge
+   (conflicted), must not merge as-is (see below), and is blocked on the New-Quizzes-detection
+   correctness bug, so CI results would tell us nothing actionable. The real unblock is a human
+   clicking "Approve and run workflows", and that is only worth doing after the conflict and the
+   detection bug are resolved.
+
+3. **#191's auto-close keyword is confirmed live and is a real hazard.** Its body ends with a
+   literal `- Fixes [issue 172]` line (keyword de-fanged here on purpose — see below). Merging it
+   in that state would auto-close [issue 172], the exact failure mode that burned this repo twice.
+   I am not permitted to edit another PR's body, so this stays on the Needs-Vishal list.
+   (Verified 2026-08-12T01:51Z.)
+
+   *Note for future executor runs:* writing this finding up in the obvious way — quoting the
+   offending line verbatim — reproduces the hazard inside the brief itself, and
+   `check_closing_keywords.py --strict` correctly rejected my first draft of this very paragraph.
+   Quote such lines in the bracketed `[issue N]` form, never verbatim.
+
+4. **#281's root cause is verified in code — the draft reply's "Confirmed your read" is safe to
+   send.** I checked every number bruchris asserted:
+   - `discovery.py:38` scopes the search to `Path(__file__).parent.parent / "code_api" / "canvas"`,
+     and line 50 does `rglob("*.ts")` over that tree only. The MCP registry is never consulted.
+   - That tree holds **15** `.ts` files, **9** after `index.ts` barrels are skipped — matches.
+   - `bulkGradeDiscussion.ts` is the **only** file in the tree matching `peer.review` — so it is
+     indeed the sole coincidental hit.
+   - There are exactly **14** MCP tools with `peer_review` in the name, none in that tree — matches.
+
+   One addition worth folding into the reply: the docstring already says "Search available Canvas
+   **code API** tools", so the scope is documented — it is the *tool name* and the empty/miss
+   result that mislead, which strengthens the "be honest about scope" option the draft prefers.
+
+5. **#275: the brief understates how close this already is — the Planner endpoint is already
+   wired.** The brief frames Planner as new work and contrasts it with `/users/self/todo`. In
+   fact `get_upcoming_assignments` (`student_tools.py:42`) **already calls `/planner/items`** with
+   `start_date`/`end_date`/`per_page=100`, added by #222 for exactly the reason jonespm gives.
+   So this is not "add Planner support" — it is "reuse the existing call and stop discarding the
+   rows we want."
+
+   Concretely, and verifiable in code: that loop reads `plannable_type` and `continue`s on
+   anything outside `assignment`, `quiz`, and `discussion_topic` (`student_tools.py:54-68`). Any
+   peer-review plannable is therefore dropped before it is ever examined.
+
+   **Unmeasured, flag before asserting:** Canvas's plannable type for a peer review is *believed*
+   to be `assessment_request`, but I cannot hit a live Canvas instance and neither can the brief —
+   do not state that type name as fact in the reply. It is a one-call check against any real
+   instance, and it would confirm or kill the whole lead in minutes.
+
+### Needs Vishal
+
+1. **Post the #275 reply** (drafted in this brief). Recommend adding the Planner finding above —
+   it turns "I'll look at wiring it" into "the endpoint is already in the codebase; I need to
+   check which plannable type peer reviews use." Keep the type name hedged.
+2. **Post the #281 reply** (drafted in this brief) — root cause verified against the code, safe
+   to send as written; optionally add the docstring-scope point from correction 4.
+3. **Merge decision on #272 / #266 / #265 / #264.** All four are green on required checks, all
+   four now have update-branch in flight, and all four pass the full suite + ruff merged into
+   `main` locally. #266 (TypeScript 5.9 → 7.0, skipping 6.x) and #264 (container Python 3.14 vs a
+   3.10–3.13 test matrix) still warrant the human look the brief flagged. Merging is not something
+   I am permitted to do.
+4. **#191: strip the `- Fixes [issue 172]` line from the PR body** before any merge, and decide
+   its fate — it is conflicted, draft, CI-gated at `action_required`, and blocked on the
+   New-Quizzes-detection bug.
+   Closing it may be cleaner than rebasing 398 commits.
+5. **#170 / #157 staleness** — unchanged, still needs your call; no action available to me.
+6. Nothing FERPA-adjacent was touched. No comments, labels, closes, or merges were made on any
+   issue or PR other than this brief's own PR.
+
+---
 _Generated by [Claude Code](https://claude.ai/code)_


### PR DESCRIPTION
## Summary

Daily GitHub activity brief for 2026-08-12 (cutoff: 2026-08-11T02:11:08Z, the prior brief's merge
commit, PR #280).

- **Needs a reply:** #275 ([Bug]: peer review tools still not working, `khagyard`) — two outside
  commenters (`aesse97`, `jonespm`) point at the Canvas Planner API (`/api/v1/planner/items`) as a
  student-facing alternative to the instructor-focused `peer_reviews` listing endpoint. New,
  concrete lead not tried yet. #281 ([Bug]: search_canvas_tools returned unrelated results,
  `zqian`) — an outside contributor (`bruchris`) diagnosed the real cause: the tool only searches
  the TypeScript code-execution API tree (9 files), never the live 99-tool MCP registry, so a
  peer-review query gets a coincidental substring hit instead of any of the 14 real
  `peer_review`-named tools. Both have draft replies in the brief.
- **PRs:** full status table for all 6 open PRs. Flagged: #266/#265/#264 (dependabot majors from
  2026-08-10) show zero recorded CI checks unlike sibling PR #272 from the same day, worth a look;
  #191 (Copilot, targets #172) is draft + merge-conflicted with zero triggered CI runs, still
  blocked on the New-Quizzes-detection bug already logged on #172, and its own description still
  carries a GitHub auto-close keyword aimed at issue 172 that should be stripped before any merge.
- **New since cutoff:** #281 (issue, opened by zqian). No new PRs since cutoff.
- **Going stale:** #170 (zqian, student-write-tools design questions unanswered 14 days), #157
  (backlog, no external asker, flagged for visibility only).
- **Checked, nothing needed:** #172, #142, #236, #239, #252, #262, #270, #271.

Docs-only change (single markdown file under `internal/issue-triage/`) — no test plan applies,
matching prior triage-brief PRs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pn1J8ET4LdPTQuqZ7SZfy4)_