### PR TITLE
fix: steer clients away from discussion fallback when announcements fail (#283 mitigation)

### DIFF
--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -20,6 +20,33 @@ from ..core.untrusted_content import (
 from ..core.validation import validate_params
 from ..core.write_confirmation import unconfirmed_write_warning
 
+# Issue #283: a permission error on create_announcement is not license to
+# post the same content as a discussion instead. Client models were doing
+# exactly that — a silent, unconfirmed write the user never asked for. This
+# text rides along with the error so the model sees the guardrail at the
+# moment it would otherwise reach for a fallback tool.
+ANNOUNCEMENT_PERMISSION_FALLBACK_WARNING = (
+    "Do not attempt to post this content via discussion tools as a "
+    "fallback; announcements require instructor/TA permissions in this "
+    "course. Report this to the user instead."
+)
+
+# Substrings that show up in make_canvas_request's {"error": ...} payload
+# for an authorization failure (see core/client.py: "HTTP error: 401/403,
+# Details: {...}"), plus the Canvas API's own wording for the same failure.
+_PERMISSION_ERROR_MARKERS = (
+    "HTTP error: 401",
+    "HTTP error: 403",
+    "unauthorized",
+    "forbidden",
+)
+
+
+def _is_permission_error(error_text: str) -> bool:
+    """True if a Canvas API error looks like an auth/permission failure."""
+    lowered = error_text.lower()
+    return any(marker.lower() in lowered for marker in _PERMISSION_ERROR_MARKERS)
+
 
 def register_shared_discussion_tools(mcp: FastMCP) -> None:
     """Register discussion tools accessible to both students and educators."""
@@ -766,6 +793,11 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
                                   message: str) -> str:
         """Post a new top-level entry to a discussion topic.
 
+        IMPORTANT: Never use this tool to post or work around a failed course
+        announcement. If create_announcement failed (e.g. insufficient
+        permissions), report the failure to the user — do NOT post the
+        content as a discussion instead.
+
         Args:
             course_identifier: Course code or Canvas ID
             topic_id: Discussion topic ID
@@ -877,6 +909,11 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
                                     require_initial_post: bool = False,
                                     pinned: bool = False) -> str:
         """Create a new discussion topic for a course.
+
+        IMPORTANT: Never use this tool to post or work around a failed course
+        announcement. If create_announcement failed (e.g. insufficient
+        permissions), report the failure to the user — do NOT post the
+        content as a discussion instead.
 
         Args:
             course_identifier: Course code or Canvas ID
@@ -1073,7 +1110,13 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
         )
 
         if "error" in response:
-            return f"Error creating announcement: {response['error']}"
+            error_text = str(response["error"])
+            if _is_permission_error(error_text):
+                return (
+                    f"Error creating announcement: {error_text}\n\n"
+                    f"{ANNOUNCEMENT_PERMISSION_FALLBACK_WARNING}"
+                )
+            return f"Error creating announcement: {error_text}"
 
         announcement_id = response.get("id")
         announcement_title = response.get("title", title)

--- a/tests/tools/test_discussions.py
+++ b/tests/tools/test_discussions.py
@@ -455,5 +455,94 @@ class TestCreateAnnouncementConfirmsWrite:
         assert "1001" in result
 
 
+class TestAnnouncementPermissionErrorSteersAwayFromDiscussionFallback:
+    """#283: a client model watched create_announcement fail for a student
+    (insufficient permissions) and silently posted the same content as a
+    discussion topic instead — an unwanted, unconfirmed write. When the
+    Canvas API error looks like a permission failure, the returned message
+    must explicitly tell the caller not to fall back to a discussion tool.
+    """
+
+    @pytest.mark.asyncio
+    async def test_403_error_includes_no_fallback_guidance(self, mock_canvas_api):
+        mock_canvas_api['make_canvas_request'].return_value = {
+            "error": "HTTP error: 403, Details: {'status': 'unauthorized'}"
+        }
+
+        create_announcement = get_tool_function('create_announcement')
+        result = await create_announcement("badm_350_120251", "HI", "Hello class")
+
+        assert "Error creating announcement" in result
+        assert "do not attempt to post this content via discussion" in result.lower()
+        assert "report this to the user" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_401_error_includes_no_fallback_guidance(self, mock_canvas_api):
+        mock_canvas_api['make_canvas_request'].return_value = {
+            "error": "HTTP error: 401, Text: Unauthorized"
+        }
+
+        create_announcement = get_tool_function('create_announcement')
+        result = await create_announcement("badm_350_120251", "HI", "Hello class")
+
+        assert "do not attempt to post this content via discussion" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_non_permission_error_has_no_fallback_guidance(self, mock_canvas_api):
+        """A plain 500/network error isn't a permissions story — don't
+        editorialize about fallback behavior that isn't the cause here."""
+        mock_canvas_api['make_canvas_request'].return_value = {
+            "error": "HTTP error: 500, Details: {'status': 'internal_server_error'}"
+        }
+
+        create_announcement = get_tool_function('create_announcement')
+        result = await create_announcement("badm_350_120251", "HI", "Hello class")
+
+        assert "Error creating announcement" in result
+        assert "do not attempt to post this content via discussion" not in result.lower()
+
+
+class TestDiscussionToolDocstringsWarnAgainstAnnouncementFallback:
+    """#283: the MCP server can't block a client model's tool choice, but it
+    controls the descriptions the model reads. post_discussion_entry and
+    create_discussion_topic must carry an explicit anti-fallback warning.
+    """
+
+    @staticmethod
+    def _registered_descriptions() -> dict[str, str]:
+        import asyncio
+
+        from fastmcp import FastMCP
+
+        from canvas_mcp.tools.discussions import (
+            register_educator_discussion_tools,
+            register_shared_discussion_tools,
+        )
+
+        mcp = FastMCP("test-descriptions")
+        register_shared_discussion_tools(mcp)
+        register_educator_discussion_tools(mcp)
+
+        async def _collect():
+            tools = await mcp.list_tools()
+            return {tool.name: (tool.description or "") for tool in tools}
+
+        return asyncio.run(_collect())
+
+    def test_post_discussion_entry_warns_against_announcement_fallback(self):
+        descriptions = self._registered_descriptions()
+        description = descriptions["post_discussion_entry"].lower()
+
+        assert "create_announcement" in description
+        assert "do not" in description or "never" in description
+
+    def test_create_discussion_topic_warns_against_announcement_fallback(self):
+        descriptions = self._registered_descriptions()
+        description = descriptions["create_discussion_topic"].lower()
+
+        assert "create_announcement" in description
+        assert "do not" in description or "never" in description
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Issue #283 (reporter khagyard, testing as a student): `create_announcement`
correctly failed for a caller without announcement permission, but the
client model then silently fell back to posting the same content as a
regular discussion topic — an unwanted write with no confirmation.

The MCP server can't block a client's tool choice, but it controls the
docstrings and error messages the model reads. Maintainer jonespm's
suggestion was to harden those to steer the model away from this fallback.

## What changed

- `post_discussion_entry` and `create_discussion_topic` docstrings
  (`src/canvas_mcp/tools/discussions.py`) now open with an explicit warning:
  never use these tools to post or work around a failed announcement — report
  the failure to the user instead.
- `create_announcement`'s error path now recognizes permission-shaped errors
  (401/403/"unauthorized"/"forbidden" in the Canvas API response) and appends
  guidance telling the caller not to fall back to discussion tools and to
  report the failure instead. Non-permission errors (5xx, network failures)
  are left as plain errors — no editorializing about a cause that isn't it.

## Why this shape

- Docstrings are token-budgeted, so the warning is 2-3 lines, placed at the
  top where it's most likely to be read before the model reaches for a
  fallback tool.
- The error-path guidance only fires for permission-shaped failures, mirroring
  the actual reported scenario (student lacking announcement rights) rather
  than attaching unrelated advice to every possible error.
- Follows the module's existing `-> str` "Error ..." convention used
  throughout `discussions.py` (including the neighboring `#220`
  `unconfirmed_write_warning` pattern for the silent-downgrade case).

## Testing

- New tests in `tests/tools/test_discussions.py`:
  - `TestAnnouncementPermissionErrorSteersAwayFromDiscussionFallback`: 401/403
    responses carry the anti-fallback guidance; a 500 does not.
  - `TestDiscussionToolDocstringsWarnAgainstAnnouncementFallback`: asserts the
    *registered* tool descriptions (via `FastMCP.list_tools()`, not just the
    raw docstring) mention `create_announcement` and contain "do not"/"never".
- Full suite: `uv run python -m pytest tests/ -q` → **1330 passed, 21 skipped**
- Lint: `uv run ruff check src/ tests/` → **All checks passed**

## Scope note

This is a mitigation, not a fix for the underlying issue class — nothing on
the server can force a client model to honor a docstring warning. `create_announcement`
already had a separate, stronger guard (#220) for the case where Canvas
returns 200 while silently downgrading to a discussion topic; this PR only
covers the explicit-error path the reporter hit.

Addresses #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)