### PR TITLE
Add Planner-feed discovery path to get_my_peer_reviews_todo

### DIFF
--- a/src/canvas_mcp/tools/student_tools.py
+++ b/src/canvas_mcp/tools/student_tools.py
@@ -5,6 +5,7 @@ to access only the student's own data across their enrolled courses.
 """
 
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
@@ -16,7 +17,9 @@ from ..core.untrusted_content import fence_untrusted_inline
 from ..core.validation import validate_params
 
 
-async def _fetch_planner_peer_reviews() -> tuple[list[dict], str | None]:
+async def _fetch_planner_peer_reviews(
+    my_id: int, course_id: int | str | None = None
+) -> tuple[list[dict], str | None]:
     """Discover pending peer reviews via the Planner API (#275).
 
     The per-course discovery scan in ``get_my_peer_reviews_todo`` only checks
@@ -27,6 +30,11 @@ async def _fetch_planner_peer_reviews() -> tuple[list[dict], str | None]:
     up as an item with ``plannable_type: "assessment_request"``. That scan
     reportedly misses reviews the Planner feed would have caught, so this is
     queried as an *additional* source, not a replacement.
+
+    No ``start_date`` is passed: ``filter=incomplete_items`` already scopes
+    Canvas's response to pending items, and a peer review assigned weeks ago
+    and still incomplete is exactly the case #275 is about — a start-date
+    window would silently drop it (review round 1 caught this).
 
     Field shapes are NOT live-verified (no student-scoped token available) —
     they come from the Canvas Planner API docs
@@ -40,22 +48,28 @@ async def _fetch_planner_peer_reviews() -> tuple[list[dict], str | None]:
     this endpoint needs no additional anonymization gate (see
     ``core/client.py::_endpoint_anonymization_mode`` — same self-scoped-feed
     reasoning already applied to ``/planner/items`` by #222's
-    ``get_my_upcoming_assignments``).
+    ``get_my_upcoming_assignments``). **This is not yet live-verified — see
+    the PR's "Merge gate" section.**
+
+    Args:
+        my_id: The caller's Canvas user id, used for the assessor guard below.
+        course_id: When given, passed as Canvas's own ``context_codes[]``
+            filter so the server pre-filters; the caller must still apply a
+            client-side filter as backstop since this is not a documented
+            guarantee.
 
     Returns (found_reviews, error). A non-``None`` error means the Planner
     query failed; callers must still surface whatever the assignment-scoped
     scan found rather than let this failure blank out the whole answer.
     """
-    start_date = datetime.now(timezone.utc) - timedelta(days=28)
-    items = await fetch_all_paginated_results(
-        "/planner/items",
-        params={
-            "start_date": start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "filter": "incomplete_items",
-            "order": "asc",
-            "per_page": 100,
-        },
-    )
+    params: dict[str, Any] = {
+        "filter": "incomplete_items",
+        "per_page": 100,
+    }
+    if course_id is not None:
+        params["context_codes[]"] = [f"course_{course_id}"]
+
+    items = await fetch_all_paginated_results("/planner/items", params=params)
 
     if isinstance(items, dict) and "error" in items:
         return [], str(items["error"])
@@ -68,6 +82,16 @@ async def _fetch_planner_peer_reviews() -> tuple[list[dict], str | None]:
             continue
         plannable = item.get("plannable") or {}
         if plannable.get("workflow_state") == "completed":
+            continue
+        # Permissive assessor guard: the assignment-scan path filters on
+        # assessor_id == my_id explicitly. The Planner feed is meant to be
+        # the caller's own to-do list, so it should already be self-scoped —
+        # but that is not documented, so only skip an item when Canvas
+        # positively names a *different* assessor. A missing/None
+        # assessor_id (undocumented field, may not always be populated) does
+        # not exclude the item.
+        item_assessor_id = plannable.get("assessor_id")
+        if item_assessor_id is not None and item_assessor_id != my_id:
             continue
         found.append({
             "id": plannable.get("id") or item.get("plannable_id"),
@@ -508,20 +532,34 @@ def register_student_tools(mcp: FastMCP) -> None:
         # type), but Canvas returns course_id as a JSON number on planner
         # items — compare both sides as strings or every planner item gets
         # silently filtered out / never dedups against the assignment scan.
-        planner_reviews, planner_error = await _fetch_planner_peer_reviews()
+        # A single course_id is passed through to Canvas's own
+        # context_codes[] filter (server-side pre-filter); the client-side
+        # filter below stays as a backstop since that behavior isn't
+        # documented as guaranteed.
+        planner_course_id = course_ids[0] if course_identifier and len(course_ids) == 1 else None
+        planner_reviews, planner_error = await _fetch_planner_peer_reviews(
+            my_id, course_id=planner_course_id
+        )
         if course_identifier:
             course_id_strs = {str(c) for c in course_ids}
             planner_reviews = [
                 r for r in planner_reviews if str(r.get("_course_id")) in course_id_strs
             ]
 
+        # Review "id" is an AssessmentRequest id on both paths, but its type
+        # isn't guaranteed to match: the assignment-scan path gets it from
+        # the /peer_reviews endpoint (typically an int), while the Planner
+        # docs describe the top-level plannable_id as a string even though
+        # plannable.id (used here) is typically an int. Normalize with
+        # str() on both sides of the key so a type-only mismatch never
+        # produces a duplicate entry.
         dedup_keys = {
-            (str(r.get("_course_id")), r.get("id"))
+            (str(r.get("_course_id")), str(r.get("id")))
             for r in all_peer_reviews
             if r.get("id") is not None
         }
         for review in planner_reviews:
-            key = (str(review.get("_course_id")), review.get("id"))
+            key = (str(review.get("_course_id")), str(review.get("id")))
             if review.get("id") is not None and key in dedup_keys:
                 continue
             all_peer_reviews.append(review)

--- a/src/canvas_mcp/tools/student_tools.py
+++ b/src/canvas_mcp/tools/student_tools.py
@@ -16,6 +16,69 @@ from ..core.untrusted_content import fence_untrusted_inline
 from ..core.validation import validate_params
 
 
+async def _fetch_planner_peer_reviews() -> tuple[list[dict], str | None]:
+    """Discover pending peer reviews via the Planner API (#275).
+
+    The per-course discovery scan in ``get_my_peer_reviews_todo`` only checks
+    assignments whose listing carries ``peer_reviews: true`` and then reads
+    the assignment-scoped ``/peer_reviews`` endpoint — but per community
+    input on #275 (aesse97, jonespm), Canvas's own student "To Do" UI builds
+    its list from the Planner feed instead, where a pending peer review shows
+    up as an item with ``plannable_type: "assessment_request"``. That scan
+    reportedly misses reviews the Planner feed would have caught, so this is
+    queried as an *additional* source, not a replacement.
+
+    Field shapes are NOT live-verified (no student-scoped token available) —
+    they come from the Canvas Planner API docs
+    (https://canvas.instructure.com/doc/api/planner.html) and the
+    ``AssessmentRequest`` serialization in canvas-lms
+    (``lib/api/v1/planner_item.rb``, ``ASSESSMENT_REQUEST_FIELDS``): for
+    ``assessment_request`` items, ``plannable`` is the AssessmentRequest's own
+    attributes (``id``, ``user_id`` — the reviewee, ``assessor_id``,
+    ``workflow_state``) plus a ``title`` copied from the linked assignment.
+    No other student's name is serialized into that object, which is also why
+    this endpoint needs no additional anonymization gate (see
+    ``core/client.py::_endpoint_anonymization_mode`` — same self-scoped-feed
+    reasoning already applied to ``/planner/items`` by #222's
+    ``get_my_upcoming_assignments``).
+
+    Returns (found_reviews, error). A non-``None`` error means the Planner
+    query failed; callers must still surface whatever the assignment-scoped
+    scan found rather than let this failure blank out the whole answer.
+    """
+    start_date = datetime.now(timezone.utc) - timedelta(days=28)
+    items = await fetch_all_paginated_results(
+        "/planner/items",
+        params={
+            "start_date": start_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "filter": "incomplete_items",
+            "order": "asc",
+            "per_page": 100,
+        },
+    )
+
+    if isinstance(items, dict) and "error" in items:
+        return [], str(items["error"])
+    if not isinstance(items, list):
+        return [], None
+
+    found: list[dict] = []
+    for item in items:
+        if not isinstance(item, dict) or item.get("plannable_type") != "assessment_request":
+            continue
+        plannable = item.get("plannable") or {}
+        if plannable.get("workflow_state") == "completed":
+            continue
+        found.append({
+            "id": plannable.get("id") or item.get("plannable_id"),
+            "user_id": plannable.get("user_id"),
+            "_course_id": item.get("course_id"),
+            "_assignment_name": plannable.get("title") or "Unnamed Assignment",
+            "_source": "planner",
+        })
+    return found, None
+
+
 def register_student_tools(mcp: FastMCP) -> None:
     """Register student-specific MCP tools."""
 
@@ -434,18 +497,52 @@ def register_student_tools(mcp: FastMCP) -> None:
                         ):
                             review["_course_id"] = course_id
                             review["_assignment_name"] = assignment.get("name")
+                            review["_source"] = "assignment scan"
                             all_peer_reviews.append(review)
+
+        # Merge in the Planner-based discovery path (#275). Union, not
+        # replacement — the assignment-scoped scan above works on some
+        # instances, and we have no way to live-verify the Planner feed
+        # against a real pending review, so neither path is dropped.
+        # Course IDs are cached/compared as strings (get_course_id's return
+        # type), but Canvas returns course_id as a JSON number on planner
+        # items — compare both sides as strings or every planner item gets
+        # silently filtered out / never dedups against the assignment scan.
+        planner_reviews, planner_error = await _fetch_planner_peer_reviews()
+        if course_identifier:
+            course_id_strs = {str(c) for c in course_ids}
+            planner_reviews = [
+                r for r in planner_reviews if str(r.get("_course_id")) in course_id_strs
+            ]
+
+        dedup_keys = {
+            (str(r.get("_course_id")), r.get("id"))
+            for r in all_peer_reviews
+            if r.get("id") is not None
+        }
+        for review in planner_reviews:
+            key = (str(review.get("_course_id")), review.get("id"))
+            if review.get("id") is not None and key in dedup_keys:
+                continue
+            all_peer_reviews.append(review)
+            if review.get("id") is not None:
+                dedup_keys.add(key)
 
         failure_note = ""
         if unchecked:
-            failure_note = (
+            failure_note += (
                 "\n⚠️  Could not check peer reviews for:\n"
                 + "".join(f"  • {item}\n" for item in unchecked)
                 + "These assignments may still have reviews assigned to you."
             )
+        if planner_error:
+            failure_note += (
+                "\n⚠️  Could not check the Planner feed for additional peer "
+                f"reviews: {planner_error}"
+            )
 
         if not all_peer_reviews:
-            if unchecked:
+            if unchecked or planner_error:
                 return (
                     "Could not confirm your peer-review to-do list — some "
                     "peer-review listings failed." + failure_note
@@ -460,12 +557,15 @@ def register_student_tools(mcp: FastMCP) -> None:
             course_display = await get_course_code(course_id) if course_id else "Unknown Course"
 
             user_id = review.get("user_id")
+            source = review.get("_source", "assignment scan")
+            source_label = "Planner feed" if source == "planner" else "Assignment scan"
 
             output_lines.append(
                 f"• {fence_untrusted_inline(assignment_name, 'assignment name')}\n"
                 f"  Course: {course_display}\n"
                 f"  Reviewing: Student {user_id}\n"
                 f"  Status: Incomplete\n"
+                f"  Source: {source_label}\n"
             )
 
         return "\n".join(output_lines) + failure_note

--- a/src/canvas_mcp/tools/student_tools.py
+++ b/src/canvas_mcp/tools/student_tools.py
@@ -36,20 +36,41 @@ async def _fetch_planner_peer_reviews(
     and still incomplete is exactly the case #275 is about — a start-date
     window would silently drop it (review round 1 caught this).
 
-    Field shapes are NOT live-verified (no student-scoped token available) —
-    they come from the Canvas Planner API docs
-    (https://canvas.instructure.com/doc/api/planner.html) and the
-    ``AssessmentRequest`` serialization in canvas-lms
-    (``lib/api/v1/planner_item.rb``, ``ASSESSMENT_REQUEST_FIELDS``): for
-    ``assessment_request`` items, ``plannable`` is the AssessmentRequest's own
-    attributes (``id``, ``user_id`` — the reviewee, ``assessor_id``,
-    ``workflow_state``) plus a ``title`` copied from the linked assignment.
-    No other student's name is serialized into that object, which is also why
-    this endpoint needs no additional anonymization gate (see
+    Field shapes are now **live-verified**: the #275 reporter (khagyard)
+    posted a real ``/planner/items`` payload from a production UIUC Canvas
+    (three ``assessment_request`` items — see the issue for the full JSON).
+    That measurement **falsified** the original field assumption, which was
+    sourced only from the canvas-lms serializer
+    (``lib/api/v1/planner_item.rb``, ``ASSESSMENT_REQUEST_FIELDS``) and the
+    Canvas Planner API docs, neither of which is a captured real response.
+    The measured ``plannable`` object for ``assessment_request`` items
+    carries exactly six keys: ``id``, ``title``, ``todo_date``,
+    ``created_at``, ``updated_at``, ``workflow_state`` — **no ``user_id``
+    and no ``assessor_id``** on this instance. (Top-level item fields:
+    ``course_id``, ``plannable_id``, ``plannable_type``, ``plannable_date``,
+    ``html_url`` — which does carry the assignment id in its path, e.g.
+    ``/courses/505/assignments/5066/submissions/2898`` — ``context_name``,
+    ``context_image``.) The observed payload also confirms
+    ``workflow_state == "completed"`` items DO still appear in the
+    ``filter=incomplete_items`` feed, so the completed-state filter below is
+    load-bearing, not defensive dead code.
+
+    Two consequences of the missing ``user_id``/``assessor_id``:
+    - ``found["user_id"]`` is frequently ``None`` on real data; the caller
+      must render that case rather than print a bare "Student None".
+    - The assessor guard below stays deliberately permissive (skip only on a
+      *positively different* assessor) rather than requiring a match,
+      because ``assessor_id`` was absent from every item in the real
+      payload — a strict requirement would silently discard every Planner
+      finding on this instance. It remains in place because some other
+      Canvas serialization or version may still include it.
+
+    No other student's name is serialized into this object on any of the
+    documented/measured sources, which is also why this endpoint needs no
+    additional anonymization gate (see
     ``core/client.py::_endpoint_anonymization_mode`` — same self-scoped-feed
     reasoning already applied to ``/planner/items`` by #222's
-    ``get_my_upcoming_assignments``). **This is not yet live-verified — see
-    the PR's "Merge gate" section.**
+    ``get_my_upcoming_assignments``).
 
     Args:
         my_id: The caller's Canvas user id, used for the assessor guard below.
@@ -597,11 +618,20 @@ def register_student_tools(mcp: FastMCP) -> None:
             user_id = review.get("user_id")
             source = review.get("_source", "assignment scan")
             source_label = "Planner feed" if source == "planner" else "Assignment scan"
+            # Measured live (#275, khagyard): the Planner feed's
+            # assessment_request plannable carries no user_id at all, so
+            # this must render an honest "not identified" note rather than
+            # the literal string "Student None".
+            reviewing_line = (
+                f"  Reviewing: Student {user_id}\n"
+                if user_id is not None
+                else "  Reviewing: (reviewee not identified in Planner feed)\n"
+            )
 
             output_lines.append(
                 f"• {fence_untrusted_inline(assignment_name, 'assignment name')}\n"
                 f"  Course: {course_display}\n"
-                f"  Reviewing: Student {user_id}\n"
+                f"{reviewing_line}"
                 f"  Status: Incomplete\n"
                 f"  Source: {source_label}\n"
             )

--- a/tests/tools/test_student_tools.py
+++ b/tests/tools/test_student_tools.py
@@ -404,6 +404,7 @@ class TestGetMyPeerReviewsTodo:
         fetch_side_effect = [
             [{"id": 1, "name": "Essay", "peer_reviews": True}],   # assignments
             {"error": "unauthorized: insufficient permissions"},   # peer_reviews
+            [],                                                    # planner items
         ]
         p1, p2, p3, p4 = self._patches(fetch_side_effect)
         with p1, p2, p3, p4:
@@ -426,6 +427,7 @@ class TestGetMyPeerReviewsTodo:
                 # someone else's -> hidden
                 {"assessor_id": 9999, "user_id": 13, "workflow_state": "assigned"},
             ],
+            [],  # planner items
         ]
         p1, p2, p3, p4 = self._patches(fetch_side_effect)
         with p1, p2, p3, p4:
@@ -441,6 +443,7 @@ class TestGetMyPeerReviewsTodo:
         fetch_side_effect = [
             [{"id": 1, "name": "Essay", "peer_reviews": True}],
             [{"assessor_id": self.SELF_ID, "user_id": 11, "workflow_state": "completed"}],
+            [],  # planner items
         ]
         p1, p2, p3, p4 = self._patches(fetch_side_effect)
         with p1, p2, p3, p4:
@@ -549,6 +552,136 @@ class TestGetMyPeerReviewsTodoDirectAssignment:
 
         assert "Error fetching assignment" in result
         assert "not found" in result
+
+
+class TestGetMyPeerReviewsTodoPlannerDiscovery:
+    """#275: the assignment-scoped discovery scan reportedly misses real
+    pending peer reviews. Canvas's own student "To Do" UI builds its list
+    from the Planner feed instead (assessment_request items), so that feed
+    is queried as an additional source and merged into the scan's results
+    rather than replacing it — the merge must degrade gracefully if the
+    Planner query fails, and must not double-report a review both paths find.
+    """
+
+    SELF_ID = 2407
+
+    def _patches(self, fetch_side_effect):
+        return (
+            patch('canvas_mcp.tools.student_tools.fetch_all_paginated_results',
+                  new_callable=AsyncMock, side_effect=fetch_side_effect),
+            patch('canvas_mcp.tools.student_tools.make_canvas_request',
+                  new_callable=AsyncMock, return_value={"id": self.SELF_ID}),
+            patch('canvas_mcp.tools.student_tools.get_course_id',
+                  new=AsyncMock(return_value="505")),
+            patch('canvas_mcp.tools.student_tools.get_course_code',
+                  new=AsyncMock(return_value="TEST-505")),
+        )
+
+    @pytest.mark.asyncio
+    async def test_planner_feed_finds_review_the_scan_missed(self):
+        # No assignment carries peer_reviews=True, so the assignment scan
+        # finds nothing — only the Planner feed surfaces the pending review.
+        fetch_side_effect = [
+            [{"id": 1, "name": "Essay", "peer_reviews": False}],  # assignments
+            [
+                {
+                    "plannable_type": "assessment_request",
+                    "course_id": 505,
+                    "plannable": {
+                        "id": 77,
+                        "user_id": 11,
+                        "title": "Essay",
+                        "workflow_state": "assigned",
+                    },
+                },
+                {
+                    "plannable_type": "assignment",
+                    "course_id": 505,
+                    "plannable": {"id": 2, "title": "Not a peer review"},
+                },
+            ],  # planner items
+        ]
+        p1, p2, p3, p4 = self._patches(fetch_side_effect)
+        with p1, p2, p3, p4:
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(course_identifier="505")
+
+        assert "Student 11" in result
+        assert "Planner feed" in result
+
+    @pytest.mark.asyncio
+    async def test_planner_error_does_not_break_existing_scan(self):
+        # Assignment scan succeeds and finds a review; the Planner feed call
+        # itself errors. The tool must still report the scan's finding, with
+        # a warning about the Planner failure, not a blank/broken answer.
+        fetch_side_effect = [
+            [{"id": 1, "name": "Essay", "peer_reviews": True}],   # assignments
+            [{"assessor_id": self.SELF_ID, "user_id": 11, "workflow_state": "assigned"}],  # peer_reviews
+            {"error": "service unavailable"},                     # planner items
+        ]
+        p1, p2, p3, p4 = self._patches(fetch_side_effect)
+        with p1, p2, p3, p4:
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(course_identifier="505")
+
+        assert "Student 11" in result
+        assert "Planner feed" in result  # warning note mentions it
+        assert "service unavailable" in result
+
+    @pytest.mark.asyncio
+    async def test_dedup_when_both_paths_find_same_review(self):
+        # Assignment scan and Planner feed both surface the same
+        # AssessmentRequest (id=77) — it must appear exactly once.
+        fetch_side_effect = [
+            [{"id": 1, "name": "Essay", "peer_reviews": True}],
+            [{"id": 77, "assessor_id": self.SELF_ID, "user_id": 11, "workflow_state": "assigned"}],
+            [
+                {
+                    "plannable_type": "assessment_request",
+                    "course_id": 505,
+                    "plannable": {
+                        "id": 77,
+                        "user_id": 11,
+                        "title": "Essay",
+                        "workflow_state": "assigned",
+                    },
+                },
+            ],
+        ]
+        p1, p2, p3, p4 = self._patches(fetch_side_effect)
+        with p1, p2, p3, p4:
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(course_identifier="505")
+
+        assert result.count("Student 11") == 1
+
+    @pytest.mark.asyncio
+    async def test_planner_pagination_params(self):
+        captured_params = {}
+
+        async def fake_fetch(endpoint, params=None, **kwargs):
+            if endpoint == "/planner/items":
+                captured_params.update(params or {})
+                return []
+            if endpoint.endswith("/assignments"):
+                return []
+            return []
+
+        with (
+            patch('canvas_mcp.tools.student_tools.fetch_all_paginated_results',
+                  new_callable=AsyncMock, side_effect=fake_fetch),
+            patch('canvas_mcp.tools.student_tools.make_canvas_request',
+                  new_callable=AsyncMock, return_value={"id": self.SELF_ID}),
+            patch('canvas_mcp.tools.student_tools.get_course_id',
+                  new=AsyncMock(return_value="505")),
+        ):
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            await tool(course_identifier="505")
+
+        assert captured_params.get("filter") == "incomplete_items"
+        assert captured_params.get("per_page") == 100
+        assert captured_params.get("order") == "asc"
+        assert "start_date" in captured_params
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_student_tools.py
+++ b/tests/tools/test_student_tools.py
@@ -554,6 +554,81 @@ class TestGetMyPeerReviewsTodoDirectAssignment:
         assert "not found" in result
 
 
+# Real /planner/items payload posted by the #275 reporter (khagyard) from a
+# production UIUC Canvas instance (see the issue for the full JSON) —
+# verbatim keys and shape, with context_image (a signed JWT file URL)
+# stripped entirely rather than copied into the repo. Two of the three
+# assessment_request items are workflow_state=="completed" (and Canvas DOES
+# still return those through filter=incomplete_items — confirmed live, not
+# an assumption); the middle item (workflow_state=="assigned") is the one
+# genuinely pending review. Notably: no user_id, no assessor_id anywhere —
+# that falsified this PR's original field assumption (see git history /
+# PR #288 review round 2) and is why the assessor guard stays permissive
+# and the "Reviewing:" line has a no-user_id fallback.
+REAL_PLANNER_PAYLOAD_275 = [
+    {
+        "context_type": "Course",
+        "course_id": 505,
+        "plannable_id": 115,
+        "planner_override": None,
+        "plannable_type": "assessment_request",
+        "new_activity": False,
+        "submissions": False,
+        "plannable_date": "2026-08-08T05:59:59Z",
+        "plannable": {
+            "id": 115,
+            "title": "Online assignment",
+            "todo_date": "2026-08-08T05:59:59Z",
+            "created_at": "2026-08-03T14:26:04Z",
+            "updated_at": "2026-08-03T14:52:17Z",
+            "workflow_state": "completed",
+        },
+        "html_url": "/courses/505/assignments/5066/submissions/2898",
+        "context_name": "UIUC MCP Test Course - Updated",
+    },
+    {
+        "context_type": "Course",
+        "course_id": 505,
+        "plannable_id": 116,
+        "planner_override": None,
+        "plannable_type": "assessment_request",
+        "new_activity": False,
+        "submissions": False,
+        "plannable_date": "2026-08-08T05:59:59Z",
+        "plannable": {
+            "id": 116,
+            "title": "Online assignment",
+            "todo_date": "2026-08-08T05:59:59Z",
+            "created_at": "2026-08-03T14:33:39Z",
+            "updated_at": "2026-08-03T14:33:39Z",
+            "workflow_state": "assigned",
+        },
+        "html_url": "/courses/505/assignments/5066/submissions/2549",
+        "context_name": "UIUC MCP Test Course - Updated",
+    },
+    {
+        "context_type": "Course",
+        "course_id": 505,
+        "plannable_id": 117,
+        "planner_override": None,
+        "plannable_type": "assessment_request",
+        "new_activity": False,
+        "submissions": False,
+        "plannable_date": "2026-08-09T06:00:00Z",
+        "plannable": {
+            "id": 117,
+            "title": "Peer review assignment",
+            "todo_date": "2026-08-09T06:00:00Z",
+            "created_at": "2026-08-06T20:50:49Z",
+            "updated_at": "2026-08-11T16:28:51Z",
+            "workflow_state": "completed",
+        },
+        "html_url": "/courses/505/assignments/5095/submissions/2892",
+        "context_name": "UIUC MCP Test Course - Updated",
+    },
+]
+
+
 class TestGetMyPeerReviewsTodoPlannerDiscovery:
     """#275: the assignment-scoped discovery scan reportedly misses real
     pending peer reviews. Canvas's own student "To Do" UI builds its list
@@ -578,9 +653,41 @@ class TestGetMyPeerReviewsTodoPlannerDiscovery:
         )
 
     @pytest.mark.asyncio
-    async def test_planner_feed_finds_review_the_scan_missed(self):
+    async def test_real_payload_acceptance_replay(self):
+        """Acceptance replay against REAL_PLANNER_PAYLOAD_275 — the actual
+        production payload from #275, not a hand-written fixture. Confirms:
+        the genuinely-pending item (workflow_state=="assigned") is found;
+        both workflow_state=="completed" items are excluded even though
+        Canvas returned them through filter=incomplete_items (measured, not
+        assumed); and the no-user_id reality renders as an honest note
+        rather than "Student None"."""
         # No assignment carries peer_reviews=True, so the assignment scan
-        # finds nothing — only the Planner feed surfaces the pending review.
+        # finds nothing — only the Planner feed surfaces anything here.
+        fetch_side_effect = [
+            [{"id": 1, "name": "Essay", "peer_reviews": False}],  # assignments
+            REAL_PLANNER_PAYLOAD_275,  # planner items — real production payload
+        ]
+        p1, p2, p3, p4 = self._patches(fetch_side_effect)
+        with p1, p2, p3, p4:
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(course_identifier="505")
+
+        # Exactly one bullet: the two completed items must not appear.
+        # ("Planner feed" itself appears twice for that one bullet — once in
+        # the source label, once in the no-user_id fallback note — so this
+        # counts the "Source:" label specifically.)
+        assert result.count("•") == 1
+        assert result.count("Source: Planner feed") == 1
+        assert "Online assignment" in result  # the assigned item's title
+        assert "Peer review assignment" not in result  # the completed one
+        assert "Student None" not in result
+        assert "(reviewee not identified in Planner feed)" in result
+
+    @pytest.mark.asyncio
+    async def test_planner_only_review_without_user_id_renders_without_student_none(self):
+        """Direct pin for the None-user_id rendering fix: a Planner-sourced
+        review with no user_id (the measured real shape) must never print
+        the literal string "Student None"."""
         fetch_side_effect = [
             [{"id": 1, "name": "Essay", "peer_reviews": False}],  # assignments
             [
@@ -588,16 +695,11 @@ class TestGetMyPeerReviewsTodoPlannerDiscovery:
                     "plannable_type": "assessment_request",
                     "course_id": 505,
                     "plannable": {
-                        "id": 77,
-                        "user_id": 11,
-                        "title": "Essay",
+                        "id": 116,
+                        "title": "Online assignment",
                         "workflow_state": "assigned",
+                        # no user_id — matches the real #275 payload
                     },
-                },
-                {
-                    "plannable_type": "assignment",
-                    "course_id": 505,
-                    "plannable": {"id": 2, "title": "Not a peer review"},
                 },
             ],  # planner items
         ]
@@ -606,8 +708,8 @@ class TestGetMyPeerReviewsTodoPlannerDiscovery:
             tool = get_student_tool_function('get_my_peer_reviews_todo')
             result = await tool(course_identifier="505")
 
-        assert "Student 11" in result
-        assert "Planner feed" in result
+        assert "Student None" not in result
+        assert "(reviewee not identified in Planner feed)" in result
 
     @pytest.mark.asyncio
     async def test_planner_error_does_not_break_existing_scan(self):
@@ -694,7 +796,11 @@ class TestGetMyPeerReviewsTodoPlannerDiscovery:
         """The Planner feed is meant to already be the caller's own to-do
         list, but that isn't documented as guaranteed — an item Canvas
         positively attributes to a different assessor must not be reported
-        as the caller's own pending review."""
+        as the caller's own pending review.
+
+        assessor_id/user_id are synthetic here — the real #275 production
+        payload (REAL_PLANNER_PAYLOAD_275 above) carries neither field, but
+        this guard exists for a Canvas serialization/version that does."""
         fetch_side_effect = [
             [{"id": 1, "name": "Essay", "peer_reviews": False}],  # assignments
             [
@@ -722,7 +828,8 @@ class TestGetMyPeerReviewsTodoPlannerDiscovery:
     async def test_planner_item_with_matching_or_missing_assessor_is_kept(self):
         """The guard is permissive: an item naming the caller as assessor is
         kept, and so is one that omits assessor_id entirely (undocumented
-        field, may not always be populated) — only a positively different
+        field, may not always be populated — the real #275 production
+        payload omits it on every item) — only a positively different
         assessor excludes an item."""
         fetch_side_effect = [
             [{"id": 1, "name": "Essay", "peer_reviews": False}],  # assignments

--- a/tests/tools/test_student_tools.py
+++ b/tests/tools/test_student_tools.py
@@ -625,8 +625,10 @@ class TestGetMyPeerReviewsTodoPlannerDiscovery:
             result = await tool(course_identifier="505")
 
         assert "Student 11" in result
-        assert "Planner feed" in result  # warning note mentions it
-        assert "service unavailable" in result
+        assert (
+            "Could not check the Planner feed for additional peer reviews: "
+            "service unavailable" in result
+        )
 
     @pytest.mark.asyncio
     async def test_dedup_when_both_paths_find_same_review(self):
@@ -656,8 +658,110 @@ class TestGetMyPeerReviewsTodoPlannerDiscovery:
         assert result.count("Student 11") == 1
 
     @pytest.mark.asyncio
-    async def test_planner_pagination_params(self):
-        captured_params = {}
+    async def test_stale_pending_review_not_dropped_by_date_window(self):
+        """Regression pin (review round 1): a peer review assigned more
+        than 28 days ago and still incomplete is exactly the #275 scenario.
+        No start_date is sent to Canvas, so filter=incomplete_items alone
+        must be trusted — an old item must still surface."""
+        old_date = (
+            datetime.now(timezone.utc) - timedelta(days=60)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        fetch_side_effect = [
+            [{"id": 1, "name": "Essay", "peer_reviews": False}],  # assignments
+            [
+                {
+                    "plannable_type": "assessment_request",
+                    "course_id": 505,
+                    "plannable_date": old_date,
+                    "plannable": {
+                        "id": 77,
+                        "user_id": 11,
+                        "title": "Essay",
+                        "workflow_state": "assigned",
+                    },
+                },
+            ],  # planner items
+        ]
+        p1, p2, p3, p4 = self._patches(fetch_side_effect)
+        with p1, p2, p3, p4:
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(course_identifier="505")
+
+        assert "Student 11" in result
+
+    @pytest.mark.asyncio
+    async def test_planner_item_with_different_assessor_is_skipped(self):
+        """The Planner feed is meant to already be the caller's own to-do
+        list, but that isn't documented as guaranteed — an item Canvas
+        positively attributes to a different assessor must not be reported
+        as the caller's own pending review."""
+        fetch_side_effect = [
+            [{"id": 1, "name": "Essay", "peer_reviews": False}],  # assignments
+            [
+                {
+                    "plannable_type": "assessment_request",
+                    "course_id": 505,
+                    "plannable": {
+                        "id": 77,
+                        "user_id": 11,
+                        "assessor_id": 9999,  # not the caller
+                        "title": "Essay",
+                        "workflow_state": "assigned",
+                    },
+                },
+            ],  # planner items
+        ]
+        p1, p2, p3, p4 = self._patches(fetch_side_effect)
+        with p1, p2, p3, p4:
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(course_identifier="505")
+
+        assert "no pending peer reviews" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_planner_item_with_matching_or_missing_assessor_is_kept(self):
+        """The guard is permissive: an item naming the caller as assessor is
+        kept, and so is one that omits assessor_id entirely (undocumented
+        field, may not always be populated) — only a positively different
+        assessor excludes an item."""
+        fetch_side_effect = [
+            [{"id": 1, "name": "Essay", "peer_reviews": False}],  # assignments
+            [
+                {
+                    "plannable_type": "assessment_request",
+                    "course_id": 505,
+                    "plannable": {
+                        "id": 77,
+                        "user_id": 11,
+                        "assessor_id": self.SELF_ID,
+                        "title": "Essay",
+                        "workflow_state": "assigned",
+                    },
+                },
+                {
+                    "plannable_type": "assessment_request",
+                    "course_id": 505,
+                    "plannable": {
+                        "id": 78,
+                        "user_id": 12,
+                        # no assessor_id at all
+                        "title": "Essay",
+                        "workflow_state": "assigned",
+                    },
+                },
+            ],  # planner items
+        ]
+        p1, p2, p3, p4 = self._patches(fetch_side_effect)
+        with p1, p2, p3, p4:
+            tool = get_student_tool_function('get_my_peer_reviews_todo')
+            result = await tool(course_identifier="505")
+
+        assert "Student 11" in result
+        assert "Student 12" in result
+
+    @pytest.mark.asyncio
+    async def test_planner_pagination_and_context_filter_params(self):
+        captured_params: dict = {}
 
         async def fake_fetch(endpoint, params=None, **kwargs):
             if endpoint == "/planner/items":
@@ -680,8 +784,9 @@ class TestGetMyPeerReviewsTodoPlannerDiscovery:
 
         assert captured_params.get("filter") == "incomplete_items"
         assert captured_params.get("per_page") == 100
-        assert captured_params.get("order") == "asc"
-        assert "start_date" in captured_params
+        assert "start_date" not in captured_params
+        assert "order" not in captured_params
+        assert captured_params.get("context_codes[]") == ["course_505"]
 
 
 if __name__ == "__main__":

--- a/tools/README.md
+++ b/tools/README.md
@@ -267,7 +267,13 @@ List peer reviews you need to complete.
 "Do I have a peer review to do for assignment 4821 in ENGL 101?"
 ```
 
-**Returns:** Incomplete peer reviews with assignment and course information.
+**Returns:** Incomplete peer reviews with assignment and course information, each
+labeled with its discovery source (`Assignment scan` or `Planner feed`). The
+per-course discovery scan (`Assignment scan`) only checks assignments whose
+listing carries `peer_reviews: true`; as of #275 it is supplemented with a
+Planner API query (`Planner feed`) that mirrors how Canvas's own student
+"To Do" list finds pending peer reviews, since the two sources can disagree
+on some instances. Results from both are merged and deduplicated.
 
 ---
 

--- a/tools/TOOL_MANIFEST.json
+++ b/tools/TOOL_MANIFEST.json
@@ -138,7 +138,7 @@
           "description": "Check a specific assignment directly, bypassing the per-course discovery scan"
         }
       ],
-      "returns": "Incomplete peer reviews with assignment and course info",
+      "returns": "Incomplete peer reviews with assignment and course info, labeled with discovery source (assignment scan or Planner feed)",
       "examples": [
         "What peer reviews do I need to complete?",
         "Show me my pending peer reviews",


### PR DESCRIPTION
## Mechanism

`get_my_peer_reviews_todo`'s discovery scan (no `assignment_identifier`) only
ever checked assignments whose listing carried `peer_reviews: true`, then
read that assignment's `/peer_reviews` endpoint. Per community input on
#275 (aesse97, jonespm), Canvas's own student "To Do" UI instead builds its
peer-review list from the Planner feed:

```
GET /api/v1/planner/items?filter=incomplete_items&per_page=100
```

where a pending review shows up as an item with `plannable_type:
"assessment_request"`.

This PR adds `_fetch_planner_peer_reviews()` (`src/canvas_mcp/tools/student_tools.py`)
and merges it into the discovery scan:

- Queries `/planner/items` with `filter=incomplete_items`, `per_page=100`,
  paginated via `fetch_all_paginated_results`. **No `start_date`** —
  `filter=incomplete_items` already scopes the response to pending items,
  and a peer review assigned weeks ago and still incomplete is exactly the
  #275 scenario; a date window would silently drop it (round-1 review
  caught this — the original version carried a 28-day window).
- When a single course is targeted, passes `context_codes[]=["course_<id>"]`
  as a server-side pre-filter, with the existing client-side course filter
  kept as a backstop (that server behavior isn't documented as guaranteed).
- Filters to `plannable_type == "assessment_request"` and drops
  `workflow_state == "completed"` — **measured as load-bearing**, not
  defensive dead code: real Canvas data confirms completed items DO still
  appear in the `filter=incomplete_items` feed (see "Merge gate CLEARED"
  below).
- **Assessor guard, permissive.** Mirrors the assignment-scan path's
  `assessor_id == my_id` filter: an item is skipped only when Canvas
  positively names a *different* assessor (`assessor_id is not None and !=
  my_id`); a missing `assessor_id` does not exclude the item. This stayed
  permissive rather than becoming a hard requirement once real data showed
  `assessor_id` (and `user_id`) absent from every observed item — a strict
  match would have silently discarded every Planner finding on that
  instance.
- **Union, not replacement.** The assignment-scoped scan works on some
  instances and there is no way to verify from here which instances it
  fails on, so both paths run and results are merged, deduplicated on
  `(course_id, assessment_request id)` with both sides of the id
  normalized via `str()` — the assignment-scan id and the Planner
  `plannable.id` are not guaranteed to be the same type.
- **Graceful degradation.** If the Planner query errors, the tool still
  returns whatever the assignment scan found, plus a warning note — it
  never silently drops the whole answer to a single source's failure.
- Every reported review is labeled with its discovery source
  (`Assignment scan` or `Planner feed`) so a future report can tell which
  path is/isn't working for a given account.
- Dropped the undocumented `order=asc` param from round 1 — it isn't a
  documented Planner parameter and its only purpose was locking an
  assumption into a test assertion.
- When a Planner-sourced review has no `user_id` (see below — this is now
  the *common* case, not an edge case), the "Reviewing:" line renders
  `(reviewee not identified in Planner feed)` instead of the literal string
  `Student None`.

## Merge gate CLEARED — verified against a real production payload

Round 2 of review required live verification before merge, since the
original field assumption came only from the canvas-lms serializer source
and the (silent-on-this-point) Canvas API docs — never a captured real
response. The #275 reporter (khagyard) posted exactly that:
[a real `/planner/items` payload from a production UIUC Canvas instance](https://github.com/vishalsachdev/canvas-mcp/issues/275#issuecomment-5286457447),
three `assessment_request` items.

**What it confirmed:**
- The approach is sound — Canvas's Planner feed does surface
  `assessment_request` items, and `workflow_state` distinguishes pending
  (`"assigned"`) from done (`"completed"`).
- `workflow_state == "completed"` items really do come back through
  `filter=incomplete_items` (two of the three items in the real payload
  were completed), so the exclusion in this PR is load-bearing.

**What it falsified, and the fix:**
- The `plannable` object for `assessment_request` items carries **exactly
  six keys**: `id`, `title`, `todo_date`, `created_at`, `updated_at`,
  `workflow_state`. **No `user_id`, no `assessor_id`** — contrary to the
  round-1 assumption (sourced from the canvas-lms serializer, which merges
  in the AssessmentRequest model's own attributes; those attributes
  apparently are not present, or are stripped, in this instance's actual
  response). Top-level item fields, for reference: `course_id`,
  `plannable_id`, `plannable_type`, `plannable_date`, `html_url` (does
  carry the assignment id in its path, e.g.
  `/courses/505/assignments/5066/submissions/2898`), `context_name`,
  `context_image`.
- Fixed the `Student None` rendering bug this exposed (see above).
- Corrected `_fetch_planner_peer_reviews()`'s docstring to describe the
  measured shape instead of the falsified assumption.
- Added `REAL_PLANNER_PAYLOAD_275` in the test file — the payload verbatim
  (titles shortened, `context_image` — a signed JWT file URL — stripped
  entirely rather than copied into the repo) — as an acceptance-replay
  fixture: two completed items excluded, one assigned item found, no
  `user_id` anywhere.

The assessor-guard tests keep a separate *synthetic* fixture that does
include `assessor_id`/`user_id`, now commented as hypothetical/future-proofing
rather than a claim about current production data — some other Canvas
serialization or version might still include those fields, and the guard's
skip-branch needs coverage either way.

## Anonymization-tier finding

`/planner/items` currently resolves to `ANONYMIZE_NONE` in
`core/client.py::_endpoint_anonymization_mode` — no segment in
`{'users','submissions','enrollments','analytics'}`, `'conversations'`, or
`'pages'`/`'front_page'` matches `'planner'`, so it falls through to the
default. This is **not new** — #222's `get_my_upcoming_assignments` already
calls this same endpoint ungated.

I looked at whether that's still correct for the `assessment_request`
addition, since this repo has been bitten twice by an under-gated endpoint
(#164, front_page). The real payload settles this more conclusively than
the round-1 doc-only reasoning did: with `user_id`/`assessor_id` absent
entirely, there is no other student identifier of any kind in the object,
let alone a name. No anonymization-tier change was made.

## Tests

`TestGetMyPeerReviewsTodoPlannerDiscovery` (10 tests): a real-payload
acceptance replay (`REAL_PLANNER_PAYLOAD_275`); a direct pin for the
no-`user_id` rendering fix; a Planner failure doesn't break the existing
scan's results (asserts the actual warning text); dedup when both paths
find the same review; a stale (>28-day-old) pending review is not dropped
now that the date window is gone; an item with a different assessor is
skipped; an item with a matching or missing assessor is kept;
pagination/context-filter params are passed correctly (`start_date`/`order`
confirmed absent). Updated 3 existing tests in `TestGetMyPeerReviewsTodo`
to account for the new (always-run) Planner call.

Full suite: `1350 passed, 21 skipped`. `ruff check` and `mypy` clean.

## Docs

Updated `tools/README.md` and `tools/TOOL_MANIFEST.json` to describe the
merged two-source discovery and source labeling. `AGENTS.md`'s one-line
tool table entry didn't need updating (purpose-level only).

Addresses #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)
