### PR TITLE
fix(discovery): cap full code API content

### DIFF
--- a/src/canvas_mcp/tools/discovery.py
+++ b/src/canvas_mcp/tools/discovery.py
@@ -34,6 +34,10 @@ _MCP_FULL_DESCRIPTION_CHARS = 400
 # short, but nothing enforces that — cap it so one verbose tool can't
 # dominate the response.
 _MCP_SIGNATURE_DESCRIPTION_CHARS = 200
+
+# Full TypeScript modules can be tens of thousands of characters. Bound each
+# match so discovery cannot consume the model context with source dumps.
+_CODE_API_FULL_CONTENT_CHARS = 2000
 _TRUNCATION_SENTINEL = "... [truncated]"
 
 
@@ -161,7 +165,7 @@ def register_discovery_tools(mcp: FastMCP) -> None:
                             content = ts_file.read_text()
                             code_api_matches.append({
                                 "file": relative_path,
-                                "content": content
+                                "content": _cap(content, _CODE_API_FULL_CONTENT_CHARS)
                             })
                         except Exception as e:
                             code_api_matches.append({

--- a/tests/tools/test_discovery.py
+++ b/tests/tools/test_discovery.py
@@ -176,6 +176,19 @@ async def test_detail_level_full_caps_description_size():
 
 
 @pytest.mark.asyncio
+async def test_detail_level_full_caps_code_api_content():
+    """Full code-API matches must not dump an entire TypeScript module."""
+    mcp = _registry()
+    data = await _search(mcp, "bulkGradeDiscussion", detail_level="full")
+
+    matches = data["code_execution_api"]["tools"]
+    assert len(matches) == 1
+    content = matches[0]["content"]
+    assert len(content) <= 2000
+    assert content.endswith("[truncated]")
+
+
+@pytest.mark.asyncio
 async def test_signatures_mode_caps_long_first_line():
     """A tool whose docstring first line is very long (2KB+) must be
     truncated with a sentinel in "signatures" mode, not propagated whole —


### PR DESCRIPTION
## What changed
Capped full-detail TypeScript code API content at 2,000 characters and added a regression test that asserts the truncation marker.

## Why
The `search_canvas_tools` full mode could return entire source files into the model context, including a ~19 KB module. The cap bounds each match while preserving a clear signal to narrow the query.

## Verification
- `python -m py_compile src/canvas_mcp/tools/discovery.py tests/tools/test_discovery.py`
- `git diff --check`

Closes #287
