### PR TITLE
fix: pre-check announcement permission + clean up silent discussion downgrade

### DIFF
--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -1092,6 +1092,26 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
 
         course_id = await get_course_id(course_identifier)
 
+        # Pre-check (#283): the single-course endpoint reports whether this
+        # token may create announcements here. Measured live 2026-08-14:
+        # only /courses/:id?include[]=permissions carries these two flags —
+        # the list endpoint ignores the include and the dedicated
+        # /permissions endpoint omits them. Refuse only on an explicit
+        # False; any other shape (error, missing key) falls open to the
+        # post-create backstop below.
+        course_info = await make_canvas_request(
+            "get", f"/courses/{course_id}", params={"include[]": "permissions"}
+        )
+        if isinstance(course_info, dict) and "error" not in course_info:
+            permissions = course_info.get("permissions")
+            if isinstance(permissions, dict) and permissions.get("create_announcement") is False:
+                return (
+                    "Error creating announcement: your Canvas token does not have "
+                    "permission to create announcements in this course (checked "
+                    "via the course permissions API before posting anything).\n\n"
+                    f"{ANNOUNCEMENT_PERMISSION_FALLBACK_WARNING}"
+                )
+
         data = {
             "title": title,
             "message": message,
@@ -1128,8 +1148,24 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
         # announcement permission — it silently drops is_announcement and
         # creates a regular discussion topic instead (#220). The response
         # echoes the flag (measured live), so its absence means the write
-        # did not do what was asked.
+        # did not do what was asked. Backstop to the pre-check above: clean
+        # up the unintended topic instead of leaving it visible (#283).
         if not response.get("is_announcement"):
+            if announcement_id is not None:
+                delete_response = await make_canvas_request(
+                    "delete", f"/courses/{course_id}/discussion_topics/{announcement_id}"
+                )
+                if "error" not in delete_response:
+                    return (
+                        "Error creating announcement: Canvas ignored "
+                        "is_announcement and created a regular discussion topic "
+                        "instead — this usually means your token lacks permission "
+                        "to post announcements in this course (e.g. a student "
+                        f"account). The unintended topic (ID: {announcement_id}) "
+                        "was deleted automatically; nothing is visible to the "
+                        "course.\n\n"
+                        f"{ANNOUNCEMENT_PERMISSION_FALLBACK_WARNING}"
+                    )
             return unconfirmed_write_warning(
                 "the announcement was created",
                 {
@@ -1139,8 +1175,9 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
                 },
                 "Canvas ignored is_announcement — this usually means your token "
                 "lacks permission to post announcements in this course (e.g. a "
-                "student account). The discussion topic above is visible to the "
-                "course; delete it in Canvas if it was unintended.",
+                "student account). Automatic cleanup of the topic did not "
+                "succeed, so it is visible to the course; delete it in Canvas "
+                "if it was unintended.",
             )
 
         return f"Announcement created successfully in course {course_display}:\n\n" + \

--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -1155,7 +1155,10 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
                 delete_response = await make_canvas_request(
                     "delete", f"/courses/{course_id}/discussion_topics/{announcement_id}"
                 )
-                if "error" not in delete_response:
+                # A null 200 body would surface here as None — treat any
+                # non-dict as unconfirmed cleanup, never claim the delete
+                # succeeded (and never crash on `in`).
+                if isinstance(delete_response, dict) and "error" not in delete_response:
                     return (
                         "Error creating announcement: Canvas ignored "
                         "is_announcement and created a regular discussion topic "

--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -1151,7 +1151,17 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
         # did not do what was asked. Backstop to the pre-check above: clean
         # up the unintended topic instead of leaving it visible (#283).
         if not response.get("is_announcement"):
+            cleanup_note = (
+                "Canvas did not return a topic ID, so automatic cleanup could "
+                "not be attempted; check the course and delete the topic in "
+                "Canvas if it was unintended."
+            )
             if announcement_id is not None:
+                cleanup_note = (
+                    "Automatic cleanup of the topic did not succeed, so it is "
+                    "visible to the course; delete it in Canvas if it was "
+                    "unintended."
+                )
                 delete_response = await make_canvas_request(
                     "delete", f"/courses/{course_id}/discussion_topics/{announcement_id}"
                 )
@@ -1178,9 +1188,7 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
                 },
                 "Canvas ignored is_announcement — this usually means your token "
                 "lacks permission to post announcements in this course (e.g. a "
-                "student account). Automatic cleanup of the topic did not "
-                "succeed, so it is visible to the course; delete it in Canvas "
-                "if it was unintended.",
+                f"student account). {cleanup_note}",
             )
 
         return f"Announcement created successfully in course {course_display}:\n\n" + \

--- a/tests/tools/test_discussions.py
+++ b/tests/tools/test_discussions.py
@@ -608,6 +608,8 @@ class TestCreateAnnouncementConfirmsWrite:
 
         assert "created successfully" not in result
         assert "Could not confirm" in result
+        # Must not claim cleanup was attempted when it wasn't (round-2 note).
+        assert "could not be attempted" in result
 
     @pytest.mark.asyncio
     async def test_confirmed_announcement_reports_success(self, mock_canvas_api):

--- a/tests/tools/test_discussions.py
+++ b/tests/tools/test_discussions.py
@@ -551,6 +551,29 @@ class TestCreateAnnouncementConfirmsWrite:
         assert "delete it in Canvas" in result
 
     @pytest.mark.asyncio
+    async def test_silent_downgrade_delete_returns_none_warns(self, mock_canvas_api):
+        """make_canvas_request returns response.json() verbatim, so a null
+        200 body surfaces as None — must warn, not crash on `in` (found by
+        adversarial review probe)."""
+        mock_canvas_api['make_canvas_request'].side_effect = [
+            _course_with_permissions(can_announce=True),
+            {
+                "id": 999,
+                "title": "HI",
+                "is_announcement": False,
+                "created_at": "2026-08-03T15:00:00Z",
+            },
+            None,  # cleanup DELETE answered 200 with a null body
+        ]
+
+        create_announcement = get_tool_function('create_announcement')
+        result = await create_announcement("badm_350_120251", "HI", "Hello class")
+
+        assert "created successfully" not in result
+        assert "Could not confirm" in result
+        assert "delete it in Canvas" in result
+
+    @pytest.mark.asyncio
     async def test_missing_flag_in_response_is_not_success(self, mock_canvas_api):
         """A response without the is_announcement key is also unconfirmed."""
         mock_canvas_api['make_canvas_request'].side_effect = [

--- a/tests/tools/test_discussions.py
+++ b/tests/tools/test_discussions.py
@@ -402,20 +402,145 @@ class TestDiscussionTools:
             assert result == []
 
 
+# The course payload the permission pre-check (#283) reads. Shapes measured
+# live 2026-08-14 on UIUC Canvas: GET /courses/:id?include[]=permissions
+# returns exactly {"create_discussion_topic": bool, "create_announcement":
+# bool} on the single-course endpoint (the list endpoint ignores the
+# include, and the dedicated /permissions endpoint omits both keys).
+def _course_with_permissions(can_announce):
+    return {
+        "id": 60366,
+        "name": "Test Course",
+        "permissions": {
+            "create_discussion_topic": True,
+            "create_announcement": can_announce,
+        },
+    }
+
+
+class TestCreateAnnouncementPermissionPrecheck:
+    """#283: check course-level create_announcement permission before the
+    POST, so a student token is refused up front instead of Canvas silently
+    creating a regular discussion topic."""
+
+    @pytest.mark.asyncio
+    async def test_permission_false_refuses_without_posting(self, mock_canvas_api):
+        mock_canvas_api['make_canvas_request'].side_effect = [
+            _course_with_permissions(can_announce=False),
+        ]
+
+        create_announcement = get_tool_function('create_announcement')
+        result = await create_announcement("badm_350_120251", "HI", "Hello class")
+
+        assert "Error creating announcement" in result
+        assert "permission" in result.lower()
+        # The anti-fallback steering must ride along (issue #283).
+        assert "Do not attempt to post this content via discussion tools" in result
+        # Exactly one API call — the pre-check GET; no POST ever happened.
+        assert mock_canvas_api['make_canvas_request'].call_count == 1
+        method = mock_canvas_api['make_canvas_request'].call_args_list[0][0][0]
+        assert method == "get"
+
+    @pytest.mark.asyncio
+    async def test_permission_true_proceeds_to_create(self, mock_canvas_api):
+        mock_canvas_api['make_canvas_request'].side_effect = [
+            _course_with_permissions(can_announce=True),
+            {
+                "id": 1001,
+                "title": "Real announcement",
+                "is_announcement": True,
+                "created_at": "2026-08-03T15:00:00Z",
+            },
+        ]
+
+        create_announcement = get_tool_function('create_announcement')
+        result = await create_announcement("badm_350_120251", "Real announcement", "Hello")
+
+        assert "created successfully" in result
+        assert mock_canvas_api['make_canvas_request'].call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_missing_permissions_key_fails_open(self, mock_canvas_api):
+        """Older Canvas / unexpected shapes: no permissions dict means we
+        proceed and rely on the post-create backstop, not refuse."""
+        mock_canvas_api['make_canvas_request'].side_effect = [
+            {"id": 60366, "name": "Test Course"},  # no permissions key
+            {
+                "id": 1002,
+                "title": "HI",
+                "is_announcement": True,
+                "created_at": "2026-08-03T15:00:00Z",
+            },
+        ]
+
+        create_announcement = get_tool_function('create_announcement')
+        result = await create_announcement("badm_350_120251", "HI", "Hello")
+
+        assert "created successfully" in result
+
+    @pytest.mark.asyncio
+    async def test_precheck_error_fails_open(self, mock_canvas_api):
+        """A failed pre-check GET must not block the create attempt."""
+        mock_canvas_api['make_canvas_request'].side_effect = [
+            {"error": "HTTP error: 500"},
+            {
+                "id": 1003,
+                "title": "HI",
+                "is_announcement": True,
+                "created_at": "2026-08-03T15:00:00Z",
+            },
+        ]
+
+        create_announcement = get_tool_function('create_announcement')
+        result = await create_announcement("badm_350_120251", "HI", "Hello")
+
+        assert "created successfully" in result
+
+
 class TestCreateAnnouncementConfirmsWrite:
-    """#220: Canvas silently drops is_announcement for tokens without
+    """#220/#283: Canvas silently drops is_announcement for tokens without
     announcement permission and creates a regular discussion, returning 200.
-    The tool must not report success unless the response confirms the flag.
+    The tool must not report success — and must clean up the unintended
+    topic rather than leave it visible to the course.
     """
 
     @pytest.mark.asyncio
-    async def test_silent_discussion_downgrade_is_not_success(self, mock_canvas_api):
-        mock_canvas_api['make_canvas_request'].return_value = {
-            "id": 999,
-            "title": "HI",
-            "is_announcement": False,
-            "created_at": "2026-08-03T15:00:00Z",
-        }
+    async def test_silent_downgrade_deletes_orphan_and_reports_failure(self, mock_canvas_api):
+        mock_canvas_api['make_canvas_request'].side_effect = [
+            _course_with_permissions(can_announce=True),  # pre-check passes (stale/racy)
+            {
+                "id": 999,
+                "title": "HI",
+                "is_announcement": False,
+                "created_at": "2026-08-03T15:00:00Z",
+            },
+            {"id": 999, "deleted": True},  # cleanup DELETE succeeds
+        ]
+
+        create_announcement = get_tool_function('create_announcement')
+        result = await create_announcement("badm_350_120251", "HI", "Hello class")
+
+        assert "created successfully" not in result
+        assert "Error creating announcement" in result
+        assert "deleted" in result.lower()  # says the orphan was cleaned up
+        assert "Do not attempt to post this content via discussion tools" in result
+        # Third call is the cleanup DELETE aimed at the orphan topic.
+        method, endpoint = mock_canvas_api['make_canvas_request'].call_args_list[2][0][:2]
+        assert method == "delete"
+        assert endpoint.endswith("/discussion_topics/999")
+
+    @pytest.mark.asyncio
+    async def test_silent_downgrade_delete_fails_warns_with_manual_remedy(self, mock_canvas_api):
+        mock_canvas_api['make_canvas_request'].side_effect = [
+            _course_with_permissions(can_announce=True),
+            {
+                "id": 999,
+                "title": "HI",
+                "is_announcement": False,
+                "created_at": "2026-08-03T15:00:00Z",
+            },
+            {"error": "HTTP error: 403"},  # cleanup DELETE refused
+        ]
 
         create_announcement = get_tool_function('create_announcement')
         result = await create_announcement("badm_350_120251", "HI", "Hello class")
@@ -423,15 +548,37 @@ class TestCreateAnnouncementConfirmsWrite:
         assert "created successfully" not in result
         assert "Could not confirm" in result
         assert "999" in result  # points at the stray discussion topic
+        assert "delete it in Canvas" in result
 
     @pytest.mark.asyncio
     async def test_missing_flag_in_response_is_not_success(self, mock_canvas_api):
         """A response without the is_announcement key is also unconfirmed."""
-        mock_canvas_api['make_canvas_request'].return_value = {
-            "id": 1000,
-            "title": "HI",
-            "created_at": "2026-08-03T15:00:00Z",
-        }
+        mock_canvas_api['make_canvas_request'].side_effect = [
+            _course_with_permissions(can_announce=True),
+            {
+                "id": 1000,
+                "title": "HI",
+                "created_at": "2026-08-03T15:00:00Z",
+            },
+            {"id": 1000, "deleted": True},
+        ]
+
+        create_announcement = get_tool_function('create_announcement')
+        result = await create_announcement("badm_350_120251", "HI", "Hello class")
+
+        assert "created successfully" not in result
+
+    @pytest.mark.asyncio
+    async def test_downgrade_without_topic_id_cannot_clean_up(self, mock_canvas_api):
+        """No id in the response: nothing to delete — warn, don't crash."""
+        mock_canvas_api['make_canvas_request'].side_effect = [
+            _course_with_permissions(can_announce=True),
+            {
+                "title": "HI",
+                "is_announcement": False,
+                "created_at": "2026-08-03T15:00:00Z",
+            },
+        ]
 
         create_announcement = get_tool_function('create_announcement')
         result = await create_announcement("badm_350_120251", "HI", "Hello class")
@@ -441,12 +588,15 @@ class TestCreateAnnouncementConfirmsWrite:
 
     @pytest.mark.asyncio
     async def test_confirmed_announcement_reports_success(self, mock_canvas_api):
-        mock_canvas_api['make_canvas_request'].return_value = {
-            "id": 1001,
-            "title": "Real announcement",
-            "is_announcement": True,
-            "created_at": "2026-08-03T15:00:00Z",
-        }
+        mock_canvas_api['make_canvas_request'].side_effect = [
+            _course_with_permissions(can_announce=True),
+            {
+                "id": 1001,
+                "title": "Real announcement",
+                "is_announcement": True,
+                "created_at": "2026-08-03T15:00:00Z",
+            },
+        ]
 
         create_announcement = get_tool_function('create_announcement')
         result = await create_announcement("badm_350_120251", "Real announcement", "Hello")


### PR DESCRIPTION
## What changed

Two-layer fix for the `create_announcement` student-token path — implements both remedies @jonespm proposed on #283 (they're complementary, not alternatives):

1. **Permission pre-check** — `GET /courses/:id?include[]=permissions` before posting; refuse with the anti-fallback steering when `create_announcement` is explicitly `false`. Nothing is ever created.
2. **Backstop cleanup** — when Canvas still answers 200 while silently dropping `is_announcement` (the #220 case: section-limited perms, races, other quirks the pre-check can't see), delete the unintended discussion topic instead of leaving it visible to the course. If the delete itself fails, keep the unconfirmed-write warning with a manual-remedy note.

## Measured (not assumed)

Live A/B on UIUC Canvas, 2026-08-14:
- Single-course `GET /courses/:id?include[]=permissions` → `create_announcement: true` on a course I teach, `false` on one I can't post to (positive + negative control).
- The **list** endpoint (`/courses?include[]=permissions`) ignores the include entirely (permissions absent) — which is why the pre-check fails open on any missing/odd shape rather than trusting absence.
- The dedicated `/permissions` endpoint returns 210 keys and neither flag, confirming @jonespm's observation.
- **Live acceptance:** called the real tool against the no-permission course — refused pre-write with the steering text; zero writes.

## Verification

- New tests: 4 pre-check (refuse / proceed / fail-open ×2) + downgrade-cleanup paths (delete succeeds / delete fails / no id to delete); the #220 tests updated to the new call sequence.
- Full suite: **1357 passed, 21 skipped**. `ruff` clean.

Addresses #283 (leaving it open for @khagyard's retest, per the thread).
