### PR TITLE
triage: GitHub activity brief 2026-08-17

### DIFF
--- a/internal/issue-triage/2026-08-17.md
+++ b/internal/issue-triage/2026-08-17.md
@@ -30,11 +30,14 @@ v1.10.0; you're the last commenter on both).
     (blocked on the New Quizzes sandbox question), so merging #191 as-is would auto-close it — this
     would be the third time. This is a one-line, zero-cost edit (swap `Fixes` for `Addresses`)
     that's been sitting open for two triage cycles now.
-  - **Next action, unchanged:** not mergeable today. Needs (1) your approval of the pending
-    `action_required` workflow runs, (2) a manual conflict resolution in `assignments.py` (a
-    non-empty commit — out of scope for automated triage), (3) the New Quizzes sandbox to validate
-    the `is_quiz_assignment AND external_tool` detection logic per #172, and (4) the PR-body edit
-    above. Recommend continuing to leave it as draft.
+  - **Next action, unchanged, order corrected:** not mergeable today. The pending `action_required`
+    runs belong to four obsolete 2026-07-30 SHAs — approving those first would only test old
+    revisions, not the current head or whatever new commit resolves the conflict, so do the
+    conflict resolution first: (1) a manual conflict resolution in `assignments.py` (a non-empty
+    commit — out of scope for automated triage), which will produce a fresh head and fresh workflow
+    runs; (2) approve *those* new runs if they land at `action_required` too; (3) the New Quizzes
+    sandbox to validate the `is_quiz_assignment AND external_tool` detection logic per #172; and (4)
+    the PR-body edit above. Recommend continuing to leave it as draft.
 
 ## New since 2026-08-15
 

--- a/internal/issue-triage/2026-08-17.md
+++ b/internal/issue-triage/2026-08-17.md
@@ -66,3 +66,105 @@ pending on your side), #170, #172, #142 (see "Going stale" — none need a reply
 #239, #262, #270, #271, #236 (self-filed by you; no external ask since creation; #270/#271 each
 have exactly one non-substantive automated-labeling comment), #293 (automated weekly-maintenance
 report — not duplicated per standing instructions).
+
+---
+
+## Executor results (2026-08-17T01:43Z)
+
+Quiet-day brief; every factual claim in it was independently re-measured and **all held**. No
+mechanical unblock was available — details and one new finding below.
+
+### Verified
+
+- **Open PRs: exactly two** — #294 (this brief) and #191. Nothing else open, so category 3(b)
+  ("green but unreviewed non-draft PRs") is **empty**: there was no PR to check out and test other
+  than this branch. #191 was **not** test-run — it is draft, un-mergeable, and testing it would mean
+  resolving its conflict locally, which is a non-mechanical change.
+- **#191 conflict is real, and narrower than "assignments.py plus whatever else."** Measured
+  locally rather than trusting the earlier 422: the sandbox clone is shallow, so the first
+  `merge-tree` returned a misleading `refusing to merge unrelated histories`; after
+  `git fetch --unshallow`, merge base is `5652175` and
+  `git merge-tree --write-tree origin/main 9e2d146` exits 1 with exactly one conflicted path:
+
+  ```
+  Auto-merging src/canvas_mcp/server.py
+  Auto-merging src/canvas_mcp/tools/assignments.py
+  CONFLICT (content): Merge conflict in src/canvas_mcp/tools/assignments.py
+  ```
+
+  `server.py` auto-merges cleanly. So the manual work is one file.
+- **#191 CI: still zero check runs on head `9e2d146`** (`get_check_runs` → `total_count: 0`). The 14
+  workflow runs that exist are all from 2026-07-30 on older shas (`66ce3d5`, `f093a53`, `f56e94b`,
+  `8a7e393`); every `pull_request`-triggered one is `completed / action_required`.
+- **#191 body still ends with the closing keyword**, verbatim, targeting [issue 172]. Confirmed
+  against the live PR body, not the brief.
+- **Issue state**: #275's last comment is yours (2026-08-13T23:18Z); #283's last comment is yours
+  (2026-08-14T18:19Z) — the brief's "waiting on `khagyard`" reading is correct in both. Newest
+  activity anywhere in the repo is #293 (2026-08-16T00:40Z, automated, zero comments). No open
+  issue has an unanswered external comment.
+- **Closing-keyword scan of this brief and PR #294's body**: `scripts/check_closing_keywords.py
+  --strict` exits 0 on the brief; the PR body uses `[issue 172]` bracket form throughout. Clean.
+  Worth recording that this was *not* clean for about two minutes: the brief's second commit
+  originally landed as `triage: fix [PR 191] …` (bracketed here for the same reason), which the
+  checker rejects — the keyword sits mid-line, directly before a reference. The triage agent caught it and force-updated the branch
+  (`578e95d` → `fb82c6d`, message reworded to `reorder PR 191 …`) before the guard job ran, and the
+  guard then passed on the new head. The layered defense worked, but note the near-miss came from
+  the routine's *own* commit message rather than from a PR body — the vector CLAUDE.md already
+  flags as how `98643ce` closed [issue 172] the second time.
+- **Repo health on this branch** (`triage/2026-08-17` = `main` + this one doc file):
+  `uv run python -m pytest tests/ -q` → **1358 passed, 21 skipped, 2 warnings in 25.02s** (exit 0);
+  `uv run ruff check .` → **All checks passed!** Both warnings are pre-existing and benign (an
+  un-awaited `AsyncMock` coroutine in `test_untrusted_content.py`, a Starlette/httpx deprecation).
+
+### New finding — #191's branch predates the #247 CI rework, so "approve the pending runs" is not enough
+
+The brief (as amended in `fb82c6d`) already reaches the right ordering — resolve the conflict
+first, because the pending runs sit on obsolete SHAs. The measurement below supports that and adds
+a second, independent reason. Diffing `.github/workflows/` between
+`9e2d146` and `origin/main`: the branch is missing `closing-keyword-guard.yml` and `scorecard.yml`
+entirely, and `canvas-mcp-testing.yml` differs by 144 lines — i.e. the branch still carries the
+**pre-#247 placebo test job** (the hand-written "✅ Basic Validation Completed" echo), not the
+3.10–3.13 pytest matrix. Two consequences:
+
+1. Approving those four stale `action_required` run groups would produce a green that asserts
+   nothing. The branch has to take `main` first for its CI to mean anything — which is the same
+   conflict resolution it already needs.
+2. **The closing-keyword guard is not currently protecting #191.** It has never run on this PR (zero
+   check runs), so nothing mechanical is standing between the `Fixes`-line body and a merge today.
+   Once the branch is mergeable again the guard should fire on `synchronize` and block it — but
+   that is an inference from the workflow's trigger list, not something measurable while the PR
+   produces no runs. Treat the body edit as the real protection, not CI.
+
+Consistent with all of the above (and offered as inference, not measurement): a `pull_request`
+workflow is evaluated against the PR's merge ref, and an un-mergeable PR has no merge ref — which
+would explain why the current head produced no runs at all, and why the earlier empty-commit
+retrigger had no effect.
+
+### Actions considered and deliberately not taken
+
+- **`update_pull_request_branch` on #191** — permitted, but skipped: the conflict is now confirmed
+  by direct measurement (above), which is stronger evidence than re-collecting the 422. It cannot
+  succeed.
+- **Empty retrigger commit on `copilot/feature-add-tools-for-canvas-quizzes`** — permitted (same-repo
+  branch, not a fork), but skipped: the 2026-08-15 executor already measured that it does not cause
+  runs to fire while the PR is `dirty`, and the mechanism above explains why. Repeating it would add
+  a junk commit to someone else's branch for no measured benefit. Recommend re-attempting **only
+  after** the conflict is resolved, if checks are still missing then.
+
+### Needs Vishal
+
+1. **#191 PR-body edit (one line, 30 seconds, third triage cycle carrying it).** Change the trailing
+   `Fixes` to `Addresses` so a merge cannot auto-close [issue 172]. I am not permitted to edit a PR
+   I did not open, and — per the finding above — no CI guard is currently covering this PR.
+2. **#191 conflict resolution** in `src/canvas_mcp/tools/assignments.py` (only that file). A
+   non-mechanical, non-empty commit on a branch I did not create — out of bounds for me.
+3. **#191 CI approval** — the four `action_required` run groups need a maintainer click, but see the
+   new finding: do the merge-from-`main` first, or the green is meaningless.
+4. **#191 correctness blocker unchanged** — the `is_quiz_assignment AND external_tool` New Quizzes
+   detection still needs a New-Quizzes-enabled sandbox (zqian's scoping question 4). Recommend it
+   stays draft.
+5. **Nothing to send.** No public reply is owed anywhere today: no draft replies in this brief, and
+   no open issue is waiting on you. #283/#275 are both correctly parked on `khagyard`'s retest.
+6. **Optional, from #293** (out of scope for this routine, flagged only): the two P1 doc gaps —
+   #281's `schema_version: 2` break and #291's permission pre-check — are still undocumented in
+   `tools/README.md` / `AGENTS.md`.

--- a/internal/issue-triage/2026-08-17.md
+++ b/internal/issue-triage/2026-08-17.md
@@ -1,0 +1,65 @@
+# Triage brief — 2026-08-17
+
+**Read path used:** GitHub MCP tools (`mcp__github__*`).
+**Cutoff:** 2026-08-15 (date of the newest prior brief, `internal/issue-triage/2026-08-15.md`).
+
+Categories 1 and 3 are empty in substance (see below), but PR #191 still carries the same
+unresolved problem flagged in the last two briefs, so this isn't a clean early-exit day by the
+letter of the rule. Nothing material has changed since 2026-08-15 — this is mostly a
+"still waiting" confirmation, not new findings.
+
+## Needs your reply
+
+None. No open issue has a comment since 2026-08-15 whose most recent commenter is someone other
+than you. #283 and #275 are unchanged since the last brief (still awaiting `khagyard`'s retest on
+v1.10.0; you're the last commenter on both).
+
+## PRs
+
+- **#191 — `feat: Add dual-engine read tools for Canvas Quizzes (Classic and New)`** (Copilot,
+  draft, targets #172) — **unchanged since 2026-08-15.**
+  - Same head commit (`9e2d146`), still `mergeable_state: dirty`, still **zero CI checks** (0 check
+    runs, confirmed again today). The 2026-08-15 brief's executor already measured the two root
+    causes in detail: a real conflict with `main` in `assignments.py` (`update-branch` refused with
+    a 422), and every workflow run that *did* fire back on 2026-07-30 is stuck at `action_required`
+    awaiting maintainer approval — the current head produced no runs at all because a prior
+    empty-commit retrigger attempt on a `dirty` PR doesn't cause `pull_request`-event workflows to
+    fire. See that brief for the full measurement writeup; nothing here has moved.
+  - **Still unresolved: the closing-keyword landmine.** The PR body's last line still reads
+    `Fixes` immediately followed by a reference to [issue 172], verbatim. That issue is still open
+    (blocked on the New Quizzes sandbox question), so merging #191 as-is would auto-close it — this
+    would be the third time. This is a one-line, zero-cost edit (swap `Fixes` for `Addresses`)
+    that's been sitting open for two triage cycles now.
+  - **Next action, unchanged:** not mergeable today. Needs (1) your approval of the pending
+    `action_required` workflow runs, (2) a manual conflict resolution in `assignments.py` (a
+    non-empty commit — out of scope for automated triage), (3) the New Quizzes sandbox to validate
+    the `is_quiz_assignment AND external_tool` detection logic per #172, and (4) the PR-body edit
+    above. Recommend continuing to leave it as draft.
+
+## New since 2026-08-15
+
+- **#293 — "Weekly maintenance report — 2026-08-16"**, opened by the `weekly-maintenance.yml`
+  automation (not a person). Per standing instructions this triage routine doesn't duplicate or
+  re-analyze repo-health sweeps — flagging its existence only. No comments on it, no action implied
+  for this brief. Its P1 items (undocumented #281 schema-v2 break, undocumented #291 permission
+  pre-check in `tools/README.md`/`AGENTS.md`) are yours to triage separately if you want them.
+
+No other issues or PRs were opened since the cutoff.
+
+## Going stale
+
+- **#170** (zqian, **HIGH-SENSITIVITY — student write tools / FERPA policy default**): last
+  external touch was zqian's 2026-07-29 comment — now 19 days with no follow-up on either blocking
+  question (deny-by-default vs allow-by-default; syllabus-as-policy-carrier visibility).
+- **#172** (zqian/jonespm, quizzes): last external touch was jonespm's 2026-08-04 comment — now 13
+  days waiting on New-Quizzes sandbox access, which is also what's blocking #191 above.
+- **#142** (Ash, `blocked-upstream` watch item): last external touch from `ashcastelinocs124` was
+  2026-07-01. Deliberately a no-action watch item since 2026-07-30 — flagged for awareness only.
+
+## Checked, nothing needed
+
+#283, #275 (you are the most recent commenter on both, waiting on `khagyard`'s retest — no action
+pending on your side), #170, #172, #142 (see "Going stale" — none need a reply right now), #157,
+#239, #262, #270, #271, #236 (self-filed by you; no external ask since creation; #270/#271 each
+have exactly one non-substantive automated-labeling comment), #293 (automated weekly-maintenance
+report — not duplicated per standing instructions).


### PR DESCRIPTION
## Summary

Daily triage sweep for canvas-mcp GitHub activity, cutoff 2026-08-15. Nothing materially new since the last brief — this is mostly a "still waiting" confirmation.

- **Needs your reply:** none. #283 and #275 are unchanged, still awaiting `khagyard`'s retest on v1.10.0.
- **PRs:** #191 is unchanged — still a real merge conflict in `assignments.py`, CI stuck at `action_required` / zero runs on the current head, and the PR body still carries a closing-keyword line targeting [issue 172] (swap `Fixes` for `Addresses` before it ever merges).
- **New since cutoff:** only #293, the automated `weekly-maintenance.yml` repo-health report — not duplicated here per standing instructions.
- **Going stale:** #170 (19 days, zqian, high-sensitivity FERPA/write-tools policy default), [issue 172] (13 days, New Quizzes sandbox access), #142 (watch item, no action expected).

Full detail, draft replies, and reasoning in `internal/issue-triage/2026-08-17.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UH3sNauqbXkJ7V97e7dvHC)_