### PR TITLE
triage: GitHub activity brief 2026-08-19

### DIFF
--- a/internal/issue-triage/2026-08-19.md
+++ b/internal/issue-triage/2026-08-19.md
@@ -78,7 +78,10 @@ No PR changed state since the last brief. Re-verified rather than assumed:
   You're right that this doesn't match: our tool composes a real Inbox message through
   _post_conversation rather than the empty refresh-updated_at POST Canvas's UI uses, and it doesn't
   touch the peer review's updated_at at all, so there's no record on the Canvas side that a
-  reminder went out. I also want to double check the role-gating angle you raised — this tool is
+  reminder went out. (One thing that's already true today: it's a two-step tool — it previews the
+  composed subject/body first and only sends on a second confirmed call, so it's not blind, just
+  mislabeled as a "reminder" when it's really a direct message.) I also want to double check the
+  role-gating angle you raised — this tool is
   meant to be educator-only, but CANVAS_ROLE defaults to "all" in a self-hosted install, so I need
   to confirm whether that's actually letting a student-scoped token reach it in practice, separate
   from the messaging-channel question.

--- a/internal/issue-triage/2026-08-19.md
+++ b/internal/issue-triage/2026-08-19.md
@@ -1,0 +1,164 @@
+# Triage brief — 2026-08-19
+
+**Read path used:** GitHub MCP tools (`mcp__github__*`).
+**Cutoff:** 2026-08-18. `internal/issue-triage/2026-08-18.md` is the newest prior brief; its own
+executor pass swept the repo at `2026-08-18T01:52Z`, so this run treats that timestamp as the
+effective boundary for "new since cutoff" (consistent with how the 2026-08-18 brief itself handled
+the 2026-08-17 cutoff).
+
+Not a quiet day: three new issues landed after the last sweep, all opened 2026-08-18 in the
+afternoon UTC, all by non-`vishalsachdev` authors. No open PR changed state, and no open issue
+picked up a new comment from someone other than `vishalsachdev`. Category 3 is non-empty, so
+proceeding past early exit.
+
+## Needs your reply
+
+None in the strict sense — no comment on an already-open issue postdates the cutoff with someone
+else as last commenter. All three new items are fresh issues, not follow-up comments; they're
+covered under **New since cutoff** below, two of them with draft replies since they're worth a
+response even though nothing is technically "waiting" on a thread.
+
+#283 and #275 are unchanged since 2026-08-18: still awaiting `khagyard`'s retest on v1.10.0+;
+you're the last commenter on both.
+
+## PRs
+
+No PR changed state since the last brief. Re-verified rather than assumed:
+
+- **#191 — `feat: Add dual-engine read tools for Canvas Quizzes (Classic and New)`** (Copilot,
+  draft, targets #172) — **unchanged for a sixth cycle.** Same head commit (`9e2d146`), still
+  `mergeable_state: dirty`, still zero CI checks. PR body still ends with a trailing `Fixes`
+  immediately followed by a reference to [issue 172], which is still open — merging as-is would
+  auto-close it. Next action, unchanged: (1) resolve the one-file conflict in
+  `assignments.py` (non-mechanical, out of scope for this routine); (2) approve the fresh CI that
+  produces; (3) reword the closing line to `Addresses` + the same reference; (4) still needs the
+  New Quizzes sandbox before this can leave draft.
+
+- **#295, #296, #297, #298 (dependabot)** — all four re-checked via `get_check_runs`: identical
+  17-check shape to the last brief, all required checks (`test-enhancements`, `lint`, `test`
+  3.10–3.13, security scans, CodeQL) still **success**, the only red is `claude-review`
+  (secrets withheld from dependabot-triggered runs, dropped from required checks in #188 — not a
+  signal about the diff). No new commits, no new comments on any of the four. Still safe to merge
+  at your discretion; #296 and #297 both touch `package.json`/`package-lock.json` so merging one
+  will transiently conflict the other until dependabot rebases it.
+
+## New since 2026-08-18
+
+- **#303 — "send_peer_review_reminders probably should not be doing reminders through the internal
+  Inbox"**, opened by **`jonespm`**, 2026-08-18T16:26:29Z. No comments yet.
+
+  ⚠️ **High-sensitivity: messaging / student-to-student contact.** jonespm reports that Canvas's own
+  "remind" action for peer reviews is an empty POST that just refreshes the review's `updated_at` —
+  invisible to the reminded student as a message, and not something a student can trigger themselves
+  in the Canvas UI. `send_peer_review_reminders` instead composes and sends a real Inbox conversation
+  via `_post_conversation` (`src/canvas_mcp/tools/messaging.py:625,721`), which (a) doesn't touch the
+  peer review's `updated_at` at all, so nothing records that a reminder was sent, and (b) is a much
+  more direct channel than Canvas's own "reminder" concept implies.
+
+  Unverified analysis, but worth citing precisely: `send_peer_review_reminders` is registered only
+  under `register_educator_messaging_tools` (`server.py:462`), which is gated on `CANVAS_ROLE`, not
+  on the caller's actual Canvas permissions. `CANVAS_ROLE` defaults to `"all"`
+  (`core/config.py:277`), meaning a self-hosted default deployment exposes this tool to whoever's
+  token is configured — including a student running the server against their own account, since
+  Canvas's `/conversations` endpoint doesn't itself require instructor permission to message another
+  user in a shared course context. That matches jonespm's claim that this "actually also allows a
+  student to send a message reminder direct to other students assigned to their peer reviews," and
+  it would hold even setting the role question aside, since the tool's behavior diverges from what
+  Canvas's own instructor-facing "remind" button does regardless of who calls it.
+
+  Draft reply:
+  ```
+  Thanks for the detailed writeup, and for including the screenshot of what Canvas's own reminder
+  action actually does — that's a clearer picture than the API docs give.
+
+  You're right that this doesn't match: our tool composes a real Inbox message through
+  _post_conversation rather than the empty refresh-updated_at POST Canvas's UI uses, and it doesn't
+  touch the peer review's updated_at at all, so there's no record on the Canvas side that a
+  reminder went out. I also want to double check the role-gating angle you raised — this tool is
+  meant to be educator-only, but CANVAS_ROLE defaults to "all" in a self-hosted install, so I need
+  to confirm whether that's actually letting a student-scoped token reach it in practice, separate
+  from the messaging-channel question.
+
+  Two things I want to get right before changing anything: (1) whether to mimic Canvas's native
+  empty-POST reminder (quieter, but Canvas may not expose that endpoint for third-party access —
+  need to check), or keep sending a message but make it unambiguous in the tool description/output
+  that it's a direct message rather than a "reminder" in the Canvas-UI sense; (2) tightening the
+  role check so this can't be reached with student-level Canvas permissions regardless of
+  CANVAS_ROLE. Given the messaging and permissions angle here I want to be careful rather than fast
+  — will follow up on this thread once I've looked at the actual Canvas API options.
+  ```
+
+- **#302 — "Skill Request - Generate an Analysis of each student to prevent them from falling
+  through the cracks"**, opened by **`rpsimon-ai`** (first-time contributor), 2026-08-18T16:10:15Z.
+  No comments yet. One-line request for per-student analysis covering missing assignments, low test
+  scores, low participation grades, and other risk signals.
+
+  Not high-sensitivity in the FERPA-write sense (read-only analytics), but touches student
+  performance data, so worth a considered reply. There's already a relevant tool:
+  `get_student_analytics` (`src/canvas_mcp/tools/admin_tools.py:170`) returns a ranked per-student
+  table via Canvas's `/analytics/student_summaries` endpoint — engagement score, on-time/late/missing
+  assignment counts, and page-view/participation counts — which covers most of what's asked except
+  test-score-specific thresholds. No existing tool or skill packages that into a narrative
+  "who's falling through the cracks" report; that would be new skill work layered on top.
+
+  Draft reply:
+  ```
+  Thanks for the request — this is close to something that already exists. get_student_analytics
+  pulls Canvas's per-student engagement data (missing/late assignment counts, page views,
+  participation, an engagement score) for a course in one call. It doesn't do grade-threshold
+  flagging ("low test scores") on its own, since that needs a gradebook-category read on top.
+
+  What would help most: is grades-by-category (e.g., "flag anyone under 70% on Assessments") the
+  main gap versus what's already there, or is it more about turning the raw numbers into a
+  written summary you'd read at a glance each week? That'd tell me whether this is a small addition
+  to an existing skill (canvas-morning-check or canvas-course-qc) or a new one. No need to open a
+  PR yourself — happy to scope this once I know which part matters most to you.
+  ```
+
+- **#301 — "[Skill Request] - Automating the set up of Assignment Groups and Weights Inside of a
+  Canvas Course"**, opened by **`rpsimon-ai`** (first-time contributor), 2026-08-18T16:07:53Z. No
+  comments yet. Requests department-based default grading-weight templates (example given: Science
+  — Participation 25% / Assignments 25% / Assessments 30% / Exam 20%) applied across courses. Notes
+  they don't know how to use GitHub and this is their first request.
+
+  Checked the codebase: there is currently no tool that creates or updates assignment groups or
+  their weights — `create_assignment`/`update_assignment` (`src/canvas_mcp/tools/assignments.py:608,766`)
+  can only attach an assignment to an *existing* `assignment_group_id`, nothing creates the group or
+  sets `group_weights`/`weighting_scheme` on the course. The department-template layer on top of that
+  would be new skill work; the underlying primitive doesn't exist yet either.
+
+  Draft reply:
+  ```
+  Thanks for writing this up, and don't worry about the GitHub mechanics — that's on me, not you.
+
+  Right now there isn't a tool for creating assignment groups or setting their weights at all (only
+  ones for adding an assignment to a group that already exists), so this would need a new base tool
+  before any department-template automation could sit on top of it. That's a reasonable thing to
+  build, but it's grading-structure-affecting, so it'll get a normal review pass rather than a quick
+  merge.
+
+  If you're open to it, the department templates you listed (weights, category names) would be
+  useful to see in full — even just pasted in a follow-up comment here, no GitHub skill needed. I'll
+  scope out the underlying tool first regardless.
+  ```
+
+No other issues or PRs were opened since the cutoff.
+
+## Going stale
+
+- **#170** (zqian, **HIGH-SENSITIVITY — student write tools / FERPA policy default**): last external
+  touch was zqian's 2026-07-29 comment — now 21 days with no follow-up on either blocking question
+  (deny-by-default vs allow-by-default; syllabus-as-policy-carrier visibility).
+- **#172** (zqian/jonespm, quizzes): last external touch was jonespm's 2026-08-04 comment — now 15
+  days waiting on New-Quizzes sandbox access, which is also what's blocking #191.
+- **#142** (Ash, `blocked-upstream` watch item): last external touch from `ashcastelinocs124` was
+  2026-07-01. Deliberately a no-action watch item since 2026-07-30 — flagged for awareness only.
+
+## Checked, nothing needed
+
+#283, #275 (you are the most recent commenter on both, waiting on `khagyard`'s retest — no action
+pending on your side), #170, #172, #142 (see "Going stale" — none need a reply right now beyond
+what's already logged), #157, #239, #262, #270, #271, #236 (self-filed by you; no external ask
+since creation), #293 (automated weekly-maintenance report, opened 2026-08-16 — not duplicated per
+standing instructions, no new comments), #299 (turner-moore's cookie-auth proposal — you already
+have a drafted reply pending from the last brief; no new activity from them since).

--- a/internal/issue-triage/2026-08-19.md
+++ b/internal/issue-triage/2026-08-19.md
@@ -55,13 +55,17 @@ No PR changed state since the last brief. Re-verified rather than assumed:
   peer review's `updated_at` at all, so nothing records that a reminder was sent, and (b) is a much
   more direct channel than Canvas's own "reminder" concept implies.
 
-  Unverified analysis, but worth citing precisely: `send_peer_review_reminders` is registered only
-  under `register_educator_messaging_tools` (`server.py:462`), which is gated on `CANVAS_ROLE`, not
-  on the caller's actual Canvas permissions. `CANVAS_ROLE` defaults to `"all"`
-  (`core/config.py:277`), meaning a self-hosted default deployment exposes this tool to whoever's
-  token is configured — including a student running the server against their own account, since
-  Canvas's `/conversations` endpoint doesn't itself require instructor permission to message another
-  user in a shared course context. That matches jonespm's claim that this "actually also allows a
+  The code citations below are confirmed against current `main`, not guessed:
+  `send_peer_review_reminders` is registered only under `register_educator_messaging_tools`
+  (`server.py:462`), which is gated on `CANVAS_ROLE`, not on the caller's actual Canvas permissions.
+  `CANVAS_ROLE` defaults to `"all"` (`core/config.py:277`, `os.getenv("CANVAS_ROLE", "all")`),
+  meaning a self-hosted default deployment exposes this tool to whoever's token is configured —
+  including a student running the server against their own account, since Canvas's
+  `/conversations` endpoint doesn't itself require instructor permission to message another user in
+  a shared course context. What's still unverified is the live behavior, not the code path: I have
+  not exercised this against a real Canvas instance with a student-scoped token to confirm the
+  Inbox message actually goes through end-to-end. That matches jonespm's claim that this "actually
+  also allows a
   student to send a message reminder direct to other students assigned to their peer reviews," and
   it would hold even setting the role question aside, since the tool's behavior diverges from what
   Canvas's own instructor-facing "remind" button does regardless of who calls it.

--- a/internal/issue-triage/2026-08-19.md
+++ b/internal/issue-triage/2026-08-19.md
@@ -169,3 +169,141 @@ what's already logged), #157, #239, #262, #270, #271, #236 (self-filed by you; n
 since creation), #293 (automated weekly-maintenance report, opened 2026-08-16 — not duplicated per
 standing instructions, no new comments), #299 (turner-moore's cookie-auth proposal — you already
 have a drafted reply pending from the last brief; no new activity from them since).
+
+---
+
+## Executor results (2026-08-19T02:25Z)
+
+Brief read at `f954465` (its current tip, including the two amendment commits `4d93b8b` and
+`f954465`). Nothing in the repo changed between the brief being written (01:42Z) and this pass:
+re-listed open issues sorted by `UPDATED_AT` — the three newest are still #303/#302/#301 with
+`updated_at == created_at` and zero comments, and no other open issue moved. The brief's coverage
+is complete as of this timestamp.
+
+### Closing-keyword scan
+
+`scripts/check_closing_keywords.py --strict` exits **0** on the brief file (including this section,
+re-scanned after writing it) and **0** on a verbatim copy of PR #306's body. Nothing to reword
+before merge.
+
+### Repo health on this branch
+
+`triage/2026-08-19` at `f954465`: `uv run python -m pytest tests/ -q` →
+**1358 passed, 21 skipped, 2 warnings**; `uv run ruff check .` → **All checks passed!**
+
+### PR work
+
+- **#295, #296, #297, #298 (dependabot)** — all four checked out and independently verified locally,
+  each on its own head:
+
+  | PR | head | pytest | ruff |
+  |----|------|--------|------|
+  | #295 `python` digest `a7fb1e6`→`ce40764` | `b2ad3d3` | 1358 passed, 21 skipped (22.29s) | All checks passed |
+  | #296 `tsx` 4.23.10→4.23.12 | `6acd6a3` | 1358 passed, 21 skipped (20.60s) | All checks passed |
+  | #297 `@types/node` 26.1.2→26.2.0 | `db30044` | 1358 passed, 21 skipped (19.84s) | All checks passed |
+  | #298 actions group (5 updates) | `eb497f2` | 1358 passed, 21 skipped (20.02s) | All checks passed |
+
+  Same counts as `main`, so none of the four moves the suite. CI re-checked on #298: 17 checks, the
+  single `failure` is `claude-review` (secrets withheld from dependabot-triggered runs; dropped from
+  required checks in #188), everything required is `success`, and the two Cursor agent checks are
+  `neutral`. The brief's read of the dependabot set is confirmed. Note `get_status` on #295 returns
+  `state: pending / total_count: 0` — that is the legacy *commit-status* API, which this repo does
+  not use; the check-runs API is the accurate view. Not a stalled PR.
+
+  **No branch update pushed.** All four are behind `main` only by triage-brief merges
+  (docs-only, `internal/issue-triage/` alone), so updating would invalidate 17 green checks to
+  re-prove nothing.
+
+- **#191** — re-measured, **unchanged for a seventh cycle**. Head still `9e2d146`, `updated_at`
+  still 2026-08-14, `mergeable_state: dirty`, `get_check_runs` → `total_count: 0`. Conflict
+  re-measured locally (after `git fetch --unshallow`; the shallow clone otherwise reports a
+  misleading `refusing to merge unrelated histories`): `git merge-tree --write-tree origin/main
+  origin/copilot/feature-add-tools-for-canvas-quizzes` exits 1 with exactly one conflicted path,
+  `src/canvas_mcp/tools/assignments.py`. The live PR body still ends with a real auto-close line
+  pointing at [issue 172].
+
+  **Actions considered and not taken:** `update_pull_request_branch` cannot succeed while the merge
+  is dirty; the empty retrigger commit was already measured ineffective in this exact state
+  (`9e2d146` *is* that commit, from 2026-08-15) because a `pull_request` workflow evaluates against
+  a merge ref an un-mergeable PR does not have. Re-attempt only after the conflict is resolved.
+
+### Brief verification — claims checked against `main`, not assumed
+
+Every code citation in the brief was opened and read. All of them hold:
+
+- **#303:** `send_peer_review_reminders` at `messaging.py:625`, sending via `_post_conversation` at
+  `:721` — confirmed. `register_educator_messaging_tools` at `server.py:462`, inside the
+  `if role in ("educator", "all"):` block at `server.py:452` — confirmed. `CANVAS_ROLE` default
+  `"all"` at `core/config.py:277` — confirmed verbatim. No `/remind` or peer-review `updated_at`
+  POST exists anywhere in `src/` (grep clean), so the brief's "nothing records that a reminder was
+  sent" is a code fact, not an inference.
+- **Two-step claim in the #303 draft reply is accurate and safe to send.** Verified at
+  `messaging.py:690-707`: the no-token call returns `preview: True`, `nothing_sent: True`, plus the
+  composed `subject` and `body` (fence-wrapped for display) and a single-use token; the fingerprint
+  at `:682` covers the composed text, so an assignment rename between preview and confirm voids the
+  token rather than sending unshown text.
+- **#302:** `get_student_analytics` at `admin_tools.py:170`, hitting
+  `/courses/{id}/analytics/student_summaries` at `:197`, emitting engagement score, page views,
+  participations, and on-time/late/missing from `tardiness_breakdown` — every field named in the
+  draft reply is real. Both skills the draft reply offers by name exist on disk
+  (`skills/canvas-morning-check`, `skills/canvas-course-qc`).
+- **#301:** grep for `assignment_groups` / `group_weights` / `weighting_scheme` across
+  `src/canvas_mcp/tools/` returns **zero** hits. The brief's "no tool creates assignment groups or
+  sets weights" is exact.
+
+**Unmeasured-behavior audit of the draft replies:** all three are clean. The #303 reply is the only
+one that touches live Canvas behavior, and it hedges correctly in both places — "I need to confirm
+whether that's actually letting a student-scoped token reach it in practice" and "Canvas may not
+expose that endpoint for third-party access — need to check". Nothing is asserted as measured that
+was not measured. Neither the brief's author nor this pass can exercise a live Canvas instance.
+
+### New findings — mine, not in the brief
+
+1. **The #303 role concern is stronger at the code level than the brief states.** `recipient_ids` is
+   a **caller-supplied** parameter (`messaging.py:628`), and `_compose_reminder` (`:273-307`) reads
+   only `GET /courses/{id}/assignments/{id}` — a student-readable endpoint. There is **no
+   instructor-only Canvas call anywhere in the path**: the tool never fetches the peer-review
+   assignments or the roster, so Canvas has no natural permission chokepoint to fail on. Whether the
+   `/conversations` POST itself succeeds for a student-scoped token is still unmeasured, but nothing
+   *upstream* of it would stop a student-scoped token from reaching that POST. This matters for
+   jonespm's claim and for scoping the fix: a role-string tightening in `server.py` would be the
+   only gate, since there is no permission-derived one. (Compare #291, where the fix was a live
+   `include[]=permissions` pre-check — the same pattern applies here.)
+2. **Latent, separate defect in the same tool: `course_identifier` is never resolved.** The
+   docstring says "Course code or Canvas ID" (`messaging.py:643`), but `_compose_reminder`
+   interpolates the raw value straight into the URL (`:283`) with no `get_course_id()` call. The
+   only `get_course_id` import in `messaging.py` is at `:933`, inside a different tool. So passing a
+   course *code* — which the docstring invites — would 404 against Canvas. Read-only observation;
+   worth folding into whatever change #303 produces rather than filing separately.
+3. **Cosmetic, unchanged from the last two briefs:** `Dockerfile:1` still reads "Use Python 3.12
+   slim image" over a `python:3.14-slim@sha256:…` pin. #295 only moves the digest.
+
+### Needs Vishal
+
+Everything below is outside this routine's action boundary (no public posting, no touching any PR
+but this one).
+
+1. **Reply to #303** (`jonespm`, high-sensitivity: messaging / student-to-student contact). The
+   draft in this brief is verified sound and safe to send as written. Consider folding in finding 1
+   above — the absence of any instructor-only call in the path is the concrete reason a role-string
+   gate is the only available fix — and finding 2 as a "while we're in here" note.
+2. **Reply to #302 and #301** (`rpsimon-ai`, first-time contributor, both opened 2026-08-18). Both
+   drafts verified against the code and safe to send. #301 in particular needs the "there is no base
+   tool for this yet" framing the draft already carries.
+3. **Reply to #299** (`turner-moore`, first-time contributor, now waiting since 2026-08-17T16:23Z —
+   carried from the 2026-08-18 brief, still unsent). That brief's correction still applies:
+   `src/canvas_mcp/code_api/client.ts:90` is a second, independent auth path, so the issue's
+   "roughly two files" scope does not hold.
+4. **Merge decision on #295, #296, #297, #298.** Independently verified green here (table above);
+   nothing found that needs investigation first. Merging #296 and #297 in either order will make the
+   other conflict until dependabot rebases.
+5. **#191, unchanged asks (seventh cycle):** reword the trailing auto-close line so a merge cannot
+   close [issue 172]; resolve the one-file conflict in `assignments.py`; then approve the fresh CI.
+   The correctness blocker (New Quizzes detection) still needs zqian's sandbox, so it should stay
+   draft regardless.
+6. **The flaky FERPA test** (`tests/security/test_ferpa_compliance.py:103`, ~0.60%/run) — carried
+   from 2026-08-18, did not fire in any of the five suite runs this pass. Still a one-line repair
+   outside `internal/issue-triage/`, so not mine to make.
+7. **Carried from #293, re-verified still open:** neither `tools/README.md` nor `AGENTS.md` mentions
+   `schema_version` (#281's breaking response shape) or the `include[]=permissions` pre-check
+   (#291).


### PR DESCRIPTION
## Triage brief — 2026-08-19

Cutoff: 2026-08-18. Three new issues opened since the last sweep, no PR state changes.

**Needs your reply / worth a response** — draft replies included in the brief:
- #303 — `send_peer_review_reminders` sends a real Inbox message instead of Canvas's native silent reminder; also flags that the tool's educator-only registration doesn't stop a student-scoped token from reaching it under the default `CANVAS_ROLE=all`. High-sensitivity (messaging / student contact).
- #302 — skill request for a per-student "falling through the cracks" analysis; `get_student_analytics` already covers most of it.
- #301 — skill request for department-based assignment-group weight templates; no underlying tool creates/weights assignment groups today, so this needs new tool work first.

**PRs** — no change since 2026-08-18: #191 still draft/dirty/zero-CI (targets #172, still blocked on the New Quizzes sandbox); #295–#298 (dependabot) still green on every required check, safe to merge at your discretion.

**Going stale** (unchanged, flagged for awareness): #170, #172, #142.

Full brief with draft replies: `internal/issue-triage/2026-08-19.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LdUDr3rXaLmEyxHWi8C7eg)_