### PR TITLE
chore: update FastMCP to 3.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Raised the FastMCP 3.x dependency floor from 3.4.4 to 3.4.7, picking up
+  upstream fixes for Azure scope fallback, deterministic transformed-tool
+  schemas, trusted OAuth metadata/JWKS proxies, and `private_key_jwt` audience
+  validation
+  ([issue 293](https://github.com/vishalsachdev/canvas-mcp/issues/293)).
 - **Breaking:** `send_peer_review_reminders` is now
   `send_peer_review_inbox_messages` to accurately describe that it sends
   ordinary Canvas Inbox messages rather than invoking Canvas's native reminder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 keywords = ["canvas", "lms", "mcp", "claude", "education", "api"]
 dependencies = [
-    "fastmcp>=3.4.4,<4",
+    "fastmcp>=3.4.7,<4",
     "mcp>=1.26.0,<2",
     "httpx>=0.28.1,<1",
     "python-dotenv>=1.2.2,<2",

--- a/uv.lock
+++ b/uv.lock
@@ -296,7 +296,7 @@ requires-dist = [
     { name = "azure-communication-email", marker = "extra == 'hosted'", specifier = ">=1.0.0" },
     { name = "azure-data-tables", marker = "extra == 'hosted'", specifier = ">=12.5.0" },
     { name = "azure-identity", marker = "extra == 'hosted'", specifier = ">=1.17.0" },
-    { name = "fastmcp", specifier = ">=3.4.4,<4" },
+    { name = "fastmcp", specifier = ">=3.4.7,<4" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "mcp", specifier = ">=1.26.0,<2" },
     { name = "pydantic", specifier = ">=2.13.1,<3" },
@@ -652,19 +652,19 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.4"
+version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/f7/5188565d1b93ad611cbd80bf473e7ad669d1f3b689c4bedcd304e1ec3472/fastmcp-3.4.4.tar.gz", hash = "sha256:378202e26ec15b23819d9a1c0d1b0ebda096bc712720532010a0b82a45c2b1df", size = 28796458, upload-time = "2026-07-09T00:32:41.352Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/dd/fd444d94ae7afdaf5b6dd168799d34023f576b405872d6a27d5686a9d1f4/fastmcp-3.4.7.tar.gz", hash = "sha256:43117aca886f5ee2f6a569bba91cef02b59c339aad04ba29950ff18d251c822a", size = 28808982, upload-time = "2026-08-10T21:17:55.045Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/67/3cef84ba38a23dca1e1e776bfda8a35ab3c7a6c94a8ca81d0715de6dd3c5/fastmcp-3.4.4-py3-none-any.whl", hash = "sha256:f86f208713212260068cf55c32936839eee856fefc7808e18a032f31eb0f718e", size = 8019, upload-time = "2026-07-09T00:32:39.411Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/14/6d950459cc831fa17fe2d1797926b6eb2d2f2af50f830e62d0c098cc1ec8/fastmcp-3.4.7-py3-none-any.whl", hash = "sha256:e4e7698cb4af5bc667b1901685261fa2f3526dc73d243a461fca42500c8dbe56", size = 8016, upload-time = "2026-08-10T21:17:51.391Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.4"
+version = "3.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "platformdirs" },
@@ -674,9 +674,9 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/79/f35661c6a1d76dfbe17a079f912d96fffcfdd40fad5a9144bb9e7dfb1fdf/fastmcp_slim-3.4.4.tar.gz", hash = "sha256:dcaa3e0be2127d7eacdce592c2ef0039204923dc0ec396454615cb4a3275b078", size = 590203, upload-time = "2026-07-09T00:32:20.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/ac/7924e803368d0758ee4d6b1259066550df78f58f0f9f8bfebd5a123e957d/fastmcp_slim-3.4.7.tar.gz", hash = "sha256:06b32a358320a7dc2b2ee040ba89ea55ddc20763dff2949f384f7974b13b5d8f", size = 594357, upload-time = "2026-08-10T21:17:28.723Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/91/321e0b2e9ed70d0628b17ddaec76fc7b09f3e1d5d290f70bf101a2890142/fastmcp_slim-3.4.4-py3-none-any.whl", hash = "sha256:9d3a6327b9ee835188eb7323fc3b5d4cd061631b48da8ece56794bb538972505", size = 765158, upload-time = "2026-07-09T00:32:19.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/97/e0e53642cd029a9a7635ae9c548f9f2cc995af5914e487b3df795664e4be/fastmcp_slim-3.4.7-py3-none-any.whl", hash = "sha256:6c931a0089705f3f2935428ef9b2bc74ad94140adc64aab84d116d103e694b3a", size = 769370, upload-time = "2026-08-10T21:17:27.227Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- raise the FastMCP 3.x dependency floor from 3.4.4 to 3.4.7
- refresh only the FastMCP and fastmcp-slim lock entries
- record the upstream 3.4.5–3.4.7 fixes in the Unreleased changelog

## Why
FastMCP 3.4.7 is the current stable 3.x release. It includes fixes for Azure scope fallback, deterministic transformed-tool schemas, trusted OAuth metadata/JWKS proxies, and private_key_jwt audience validation. FastMCP 4 remains prerelease, and the direct mcp<2 compatibility guard remains unchanged.

## Verification
- uv run python -m pytest tests/ -q — 1374 passed, 21 skipped
- uv run ruff check .
- uv run mypy src
- git diff --check

Addresses #293.
