### PR TITLE
feat(accessibility): ACCESSIBILITY_CHECKERS gate for the UFIXIT pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,8 @@ Course design, quality assurance, and WCAG-oriented accessibility review.
 | `parse_ufixit_violations` | Extract structured violations from report |
 | `format_accessibility_summary` | Format violations into readable report |
 
+> `fetch_ufixit_report` / `parse_ufixit_violations` / `format_accessibility_summary` need the UDOIT/UFIXIT add-on and are absent when the operator sets `ACCESSIBILITY_CHECKERS=none`. The built-in scanner is always registered.
+
 ### Developer Tools
 Advanced tools for bulk operations and custom logic.
 

--- a/env.template
+++ b/env.template
@@ -35,6 +35,13 @@ LOG_ACCESS_EVENTS=false
 LOG_EXECUTION_EVENTS=false
 AUDIT_LOG_DIR=
 
+# Accessibility checkers installed on your Canvas instance (#325).
+# "ufixit" (alias "udoit") registers the UFIXIT report pipeline
+# (fetch_ufixit_report / parse_ufixit_violations / format_accessibility_summary).
+# Set to "none" if your institution does not have UDOIT/UFIXIT; the built-in
+# scanner (scan_course_content_accessibility / fix_accessibility_issues) stays on.
+ACCESSIBILITY_CHECKERS=ufixit
+
 # Code Execution Sandbox (secure defaults, override to disable)
 ENABLE_TS_SANDBOX=true
 TS_SANDBOX_MODE=auto

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
       "args": ["run", "--directory", "${__dirname}", "canvas-mcp-server"],
       "env": {
         "CANVAS_API_URL": "${user_config.canvas_api_url}",
-        "CANVAS_API_TOKEN": "${user_config.canvas_api_token}"
+        "CANVAS_API_TOKEN": "${user_config.canvas_api_token}",
+        "ACCESSIBILITY_CHECKERS": "${user_config.accessibility_checkers}"
       }
     }
   },
@@ -39,6 +40,13 @@
       "description": "A Canvas personal access token (Account → Settings → New Access Token). Stored securely in your OS keychain.",
       "sensitive": true,
       "required": true
+    },
+    "accessibility_checkers": {
+      "type": "string",
+      "title": "Accessibility checkers",
+      "description": "Checkers installed on your Canvas instance: \"ufixit\" (alias \"udoit\") registers the UFIXIT report tools; \"none\" leaves them out if your institution does not have the add-on. The built-in scanner is always available.",
+      "default": "ufixit",
+      "required": false
     }
   },
   "compatibility": {

--- a/server.json
+++ b/server.json
@@ -60,6 +60,11 @@
         "description": "Enable anonymization debugging output",
         "required": false,
         "default": "false"
+      },
+      "ACCESSIBILITY_CHECKERS": {
+        "description": "Accessibility checkers installed on your Canvas instance. \"ufixit\" (alias \"udoit\") registers the UFIXIT report tools; \"none\" leaves them out if your institution lacks the add-on. The built-in scanner is always available.",
+        "required": false,
+        "default": "ufixit"
       }
     }
   }

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -100,6 +100,40 @@ def _is_loopback(hostname: str | None) -> bool:
         return False
 
 
+# Canonical checker names accepted in ACCESSIBILITY_CHECKERS, with aliases.
+ACCESSIBILITY_CHECKER_ALIASES: dict[str, str] = {
+    "ufixit": "ufixit",
+    "udoit": "ufixit",
+}
+
+
+def _parse_accessibility_checkers(raw: str) -> frozenset[str]:
+    """Normalise ACCESSIBILITY_CHECKERS to canonical checker names.
+
+    "none" (or an empty value) yields an empty set. Unknown names are dropped
+    with a warning at parse time — validate_config() only runs on the stdio
+    startup path, so deferring the warning there would lose it in HTTP mode.
+    """
+    names = [n.strip().lower() for n in raw.replace(",", " ").split() if n.strip()]
+    known: set[str] = set()
+    unknown: set[str] = set()
+    for name in names:
+        if name == "none":
+            continue
+        canonical = ACCESSIBILITY_CHECKER_ALIASES.get(name)
+        if canonical is None:
+            unknown.add(name)
+        else:
+            known.add(canonical)
+    if unknown:
+        log_warning(
+            "ACCESSIBILITY_CHECKERS names unknown checkers; they will be ignored "
+            f"(known: {', '.join(sorted(ACCESSIBILITY_CHECKER_ALIASES))}, none): "
+            f"{', '.join(sorted(unknown))}"
+        )
+    return frozenset(known)
+
+
 def _bool_env(name: str, default: bool) -> bool:
     value = os.getenv(name)
     if value is None:
@@ -222,6 +256,17 @@ class Config:
         # Off by default: arbitrary code execution should be a deliberate
         # operator choice, not something a default install exposes (#157).
         self.execute_typescript_enabled = _bool_env("EXECUTE_TYPESCRIPT_ENABLED", False)
+
+        # Accessibility checkers available on this Canvas instance (#325).
+        # The UFIXIT/UDOIT report pipeline (fetch_ufixit_report ->
+        # parse_ufixit_violations -> format_accessibility_summary) only works
+        # where that add-on is installed; institutions without it get three
+        # tools that can never return anything. Comma- or space-separated
+        # names; "ufixit" and "udoit" are aliases. Empty or "none" registers
+        # only the add-on-free built-in scanner. Default keeps today's set.
+        self.accessibility_checkers = _parse_accessibility_checkers(
+            os.getenv("ACCESSIBILITY_CHECKERS", "ufixit")
+        )
 
         # HTTP access-key gate (v1, multi-user). Comma- or whitespace-separated
         # list of accepted keys; an HTTP caller must present a matching

--- a/src/canvas_mcp/tools/accessibility.py
+++ b/src/canvas_mcp/tools/accessibility.py
@@ -14,6 +14,7 @@ from mcp.types import ToolAnnotations
 
 from ..core.cache import get_course_id
 from ..core.client import fetch_all_paginated_results, make_canvas_request
+from ..core.config import get_config
 from ..core.untrusted_content import (
     fence_untrusted,
     fence_untrusted_fields,
@@ -23,7 +24,20 @@ from ..core.validation import validate_params
 
 
 def register_accessibility_tools(mcp: FastMCP) -> None:
-    """Register all accessibility-related MCP tools."""
+    """Register accessibility MCP tools.
+
+    The built-in scanner (scan_course_content_accessibility /
+    fix_accessibility_issues) needs no Canvas add-on and is always registered.
+    The UFIXIT/UDOIT report pipeline is registered only when
+    ACCESSIBILITY_CHECKERS includes ``ufixit`` (the default) — see #325.
+    """
+    if "ufixit" in get_config().accessibility_checkers:
+        _register_ufixit_tools(mcp)
+    _register_builtin_scanner_tools(mcp)
+
+
+def _register_ufixit_tools(mcp: FastMCP) -> None:
+    """UFIXIT/UDOIT report pipeline — requires the add-on on the instance."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     @validate_params
@@ -204,6 +218,11 @@ def register_accessibility_tools(mcp: FastMCP) -> None:
                 lines.append(f"*...and {len(violations) - 20} more violations*")
 
         return "\n".join(lines)
+
+
+
+def _register_builtin_scanner_tools(mcp: FastMCP) -> None:
+    """Add-on-free scanner over Canvas page/assignment HTML."""
 
     @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
     @validate_params

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,13 +8,19 @@ from canvas_mcp.core.config import reset_config
 
 
 @pytest.fixture(autouse=True)
-def reset_config_between_tests():
+def reset_config_between_tests(monkeypatch):
     """Discard the cached config singleton before and after each test.
 
     Without this, the first test to call get_config() freezes the singleton
     from its environment; later tests that patch env vars (e.g. anonymization
     toggles) would silently read stale config.
+
+    Also pins ACCESSIBILITY_CHECKERS to its default so a developer's .env or
+    shell (e.g. ``ACCESSIBILITY_CHECKERS=none``, a supported setting since
+    #325) cannot shrink the registry under the suite. Tests of the gate itself
+    override this through their own fixture.
     """
+    monkeypatch.setenv("ACCESSIBILITY_CHECKERS", "ufixit")
     reset_config()
     yield
     reset_config()

--- a/tests/tools/test_accessibility.py
+++ b/tests/tools/test_accessibility.py
@@ -18,6 +18,22 @@ import pytest
 # Helpers
 # ---------------------------------------------------------------------------
 
+@pytest.fixture(autouse=True)
+def _ufixit_pipeline_enabled(monkeypatch):
+    """Pin the operator setting so these tests do not depend on the contributor's .env.
+
+    The UFIXIT tests below exercise the tools' behaviour and must see them
+    registered even when the developer runs with ACCESSIBILITY_CHECKERS=none.
+    The gate tests at the bottom override this through their own fixture.
+    """
+    from canvas_mcp.core import config as config_module
+
+    monkeypatch.setenv("ACCESSIBILITY_CHECKERS", "ufixit")
+    monkeypatch.setattr(config_module, "_config", None, raising=False)
+    yield
+    monkeypatch.setattr(config_module, "_config", None, raising=False)
+
+
 @pytest.fixture
 def mock_canvas_api():
     """Fixture to mock Canvas API calls for accessibility tools."""

--- a/tests/tools/test_accessibility.py
+++ b/tests/tools/test_accessibility.py
@@ -18,22 +18,6 @@ import pytest
 # Helpers
 # ---------------------------------------------------------------------------
 
-@pytest.fixture(autouse=True)
-def _ufixit_pipeline_enabled(monkeypatch):
-    """Pin the operator setting so these tests do not depend on the contributor's .env.
-
-    The UFIXIT tests below exercise the tools' behaviour and must see them
-    registered even when the developer runs with ACCESSIBILITY_CHECKERS=none.
-    The gate tests at the bottom override this through their own fixture.
-    """
-    from canvas_mcp.core import config as config_module
-
-    monkeypatch.setenv("ACCESSIBILITY_CHECKERS", "ufixit")
-    monkeypatch.setattr(config_module, "_config", None, raising=False)
-    yield
-    monkeypatch.setattr(config_module, "_config", None, raising=False)
-
-
 @pytest.fixture
 def mock_canvas_api():
     """Fixture to mock Canvas API calls for accessibility tools."""

--- a/tests/tools/test_accessibility.py
+++ b/tests/tools/test_accessibility.py
@@ -320,3 +320,87 @@ class TestFixAccessibilityIssues:
 
         # Should complete without error
         assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# ACCESSIBILITY_CHECKERS gate (#325)
+# ---------------------------------------------------------------------------
+
+UFIXIT_TOOLS = {"fetch_ufixit_report", "parse_ufixit_violations", "format_accessibility_summary"}
+BUILTIN_TOOLS = {"scan_course_content_accessibility", "fix_accessibility_issues"}
+
+
+def _registered_accessibility_tools() -> set[str]:
+    from fastmcp import FastMCP
+
+    from canvas_mcp.tools.accessibility import register_accessibility_tools
+
+    mcp = FastMCP("test")
+    captured: set[str] = set()
+    original_tool = mcp.tool
+
+    def capturing_tool(*args, **kwargs):
+        decorator = original_tool(*args, **kwargs)
+
+        def wrapper(fn):
+            captured.add(fn.__name__)
+            return decorator(fn)
+
+        return wrapper
+
+    mcp.tool = capturing_tool
+    register_accessibility_tools(mcp)
+    return captured
+
+
+@pytest.fixture
+def checkers_env(monkeypatch):
+    """Set ACCESSIBILITY_CHECKERS and reset the config singleton around the test."""
+    from canvas_mcp.core import config as config_module
+
+    def _set(value: str | None) -> None:
+        if value is None:
+            monkeypatch.delenv("ACCESSIBILITY_CHECKERS", raising=False)
+        else:
+            monkeypatch.setenv("ACCESSIBILITY_CHECKERS", value)
+        monkeypatch.setattr(config_module, "_config", None, raising=False)
+
+    yield _set
+    monkeypatch.setattr(config_module, "_config", None, raising=False)
+
+
+class TestAccessibilityCheckerGate:
+    """The UFIXIT pipeline only registers when a UFIXIT checker is declared.
+
+    The built-in scanner needs no Canvas add-on, so it is always registered.
+    """
+
+    def test_default_registers_everything(self, checkers_env):
+        checkers_env(None)
+        assert _registered_accessibility_tools() == UFIXIT_TOOLS | BUILTIN_TOOLS
+
+    @pytest.mark.parametrize("value", ["none", "", "  "])
+    def test_none_hides_ufixit_pipeline_keeps_builtin_scanner(self, checkers_env, value):
+        checkers_env(value)
+        assert _registered_accessibility_tools() == BUILTIN_TOOLS
+
+    @pytest.mark.parametrize("value", ["ufixit", "UDOIT", " udoit , ufixit "])
+    def test_ufixit_and_udoit_aliases_enable_pipeline(self, checkers_env, value):
+        checkers_env(value)
+        assert _registered_accessibility_tools() == UFIXIT_TOOLS | BUILTIN_TOOLS
+
+    def test_unknown_checker_is_ignored_with_warning(self, checkers_env):
+        checkers_env("ally")
+        with patch("canvas_mcp.core.config.log_warning") as warn:
+            from canvas_mcp.core.config import get_config
+
+            config = get_config()
+        assert config.accessibility_checkers == frozenset()
+        assert any("ACCESSIBILITY_CHECKERS" in str(c.args[0]) for c in warn.call_args_list)
+        assert _registered_accessibility_tools() == BUILTIN_TOOLS
+
+    def test_config_exposes_normalised_set(self, checkers_env):
+        checkers_env("UDOIT")
+        from canvas_mcp.core.config import get_config
+
+        assert get_config().accessibility_checkers == frozenset({"ufixit"})

--- a/tools/README.md
+++ b/tools/README.md
@@ -1271,6 +1271,8 @@ Upload a local file to Canvas course storage.
 
 Two workflows: a built-in scanner (`scan_course_content_accessibility` → `fix_accessibility_issues`), and a UFIXIT-report pipeline (`fetch_ufixit_report` → `parse_ufixit_violations` → `format_accessibility_summary`).
 
+The UFIXIT pipeline requires the UDOIT/UFIXIT add-on on your Canvas instance. Set `ACCESSIBILITY_CHECKERS=none` to leave those three tools unregistered (default: `ufixit`; `udoit` is an alias). The built-in scanner needs no add-on and is always available.
+
 #### `scan_course_content_accessibility`
 Scan course content for basic accessibility issues.
 


### PR DESCRIPTION
## Summary

Institutions without the UDOIT/UFIXIT add-on currently get three tools in the list that can never return anything: `fetch_ufixit_report`, `parse_ufixit_violations`, `format_accessibility_summary`.

This adds an `ACCESSIBILITY_CHECKERS` setting:

- default `ufixit` keeps today's tool set (no behaviour change for existing installs); `udoit` is accepted as an alias
- `none` (or empty) leaves the three UFIXIT tools unregistered
- unknown names warn at parse time and are ignored
- the built-in scanner (`scan_course_content_accessibility`, `fix_accessibility_issues`) needs no add-on and is always registered

One correction to the issue as filed: only three of the four listed tools depend on UFIXIT. `scan_course_content_accessibility` reads page and assignment HTML directly and works on any instance, so it stays on. Its checks are fairly basic (missing alt text, table headers, a couple of Illinois-specific DesignPlus patterns), which may be why it looked empty on a course that had none of those.

Exposed in `env.template`, the `.mcpb` `user_config`, and `server.json` so packaged installs can set it too.

## Tests

9 new tests: default registers everything; `none`/empty/whitespace hide the UFIXIT trio and keep the scanner; `ufixit`/`UDOIT`/mixed lists enable it; unknown names warn and are ignored; the config exposes the normalised set. The existing UFIXIT tests pin `ufixit` via an autouse fixture so a developer's `.env` cannot break them.

Full suite: 1407 passed, 21 skipped. `ruff` and `mypy` clean.

Refs #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3xugtvm98HhHEJRVpqcbZ
