### PR TITLE
docs(release): 1.12.0 notes lead with Breaking + migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,42 +9,66 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.12.0] — 2026-08-30
 
-### Changed
+### Breaking
 
-- **Breaking:** every `delete_*` tool is now two-step. The first call (no
-  `confirmation_token`) returns a preview of exactly what would be deleted plus
-  a single-use token bound to the tool, course, target ids, every displayed
-  detail and the behavioural arguments; only a second call carrying that token
-  deletes. `dry_run` is gone from `delete_announcement_with_confirmation`,
-  `bulk_delete_announcements` and `delete_announcements_by_criteria` (the
-  preview is the dry run); `delete_module`, `delete_module_item` and
-  `delete_page` gain `confirmation_token`. `delete_announcements_by_criteria`
-  is idempotent now that its token is bound to the exact match set
+Four changes need action when upgrading. Each has its migration inline.
+
+- **`delete_announcement` removed.** Call `delete_announcement_with_confirmation`
+  with the same `course_identifier` and `announcement_id`. It is two-step: the
+  first call returns a preview and a `Confirmation token: <token>` line, the
+  second call with `confirmation_token=<token>` and identical arguments deletes
   ([issue 318](https://github.com/vishalsachdev/canvas-mcp/issues/318)).
-- **Breaking:** Python 3.10 is no longer supported (`requires-python >= 3.11`)
-  ahead of its 2026-10-31 end of life
+- **`dry_run` removed** from `delete_announcement_with_confirmation`,
+  `bulk_delete_announcements` and `delete_announcements_by_criteria`. Migration:
+  drop the argument. A call without `confirmation_token` *is* the dry run: it
+  lists exactly what would be deleted and deletes nothing. Note that
+  `bulk_delete_announcements` previously defaulted to `dry_run=False` and
+  deleted on the first call; it now previews on the first call like the others
+  ([issue 318](https://github.com/vishalsachdev/canvas-mcp/issues/318)).
+- **`confirmation_token` required on all seven delete tools:**
+  `delete_announcement_with_confirmation`, `bulk_delete_announcements`,
+  `delete_announcements_by_criteria`, `delete_page`, `delete_module`,
+  `delete_module_item` and the new `delete_assignment_with_confirmation`.
+  Migration, per delete: (1) call the tool with your normal arguments and show
+  the returned preview to the user; (2) read the token from the
+  `Confirmation token:` line and call again with the *same* arguments plus
+  `confirmation_token`. Tokens are single-use, expire after 5 minutes, and are
+  bound to the tool, course, the ids as requested, every detail the preview
+  displayed (titles, due date, points, posting dates) and the behavioural
+  arguments (`stop_on_error`, `limit`). If anything changed in between, the
+  call refuses and you preview again. Two calls with different arguments never
+  share a token ([issue 318](https://github.com/vishalsachdev/canvas-mcp/issues/318)).
+- **Python 3.10 dropped:** `requires-python >= 3.11`, ahead of 3.10's
+  2026-10-31 end of life. Migration: upgrade the interpreter (3.11, 3.12 and
+  3.13 are tested in CI). `pip`/`uv` will refuse to install 1.12.0 on 3.10; pin
+  `canvas-mcp<1.12` if you cannot upgrade yet
   ([issue 315](https://github.com/vishalsachdev/canvas-mcp/issues/315)).
-
-### Removed
-
-- **Breaking:** `delete_announcement` (the un-tokened single delete) is gone;
-  use `delete_announcement_with_confirmation`
-  ([issue 318](https://github.com/vishalsachdev/canvas-mcp/issues/318)).
 
 ### Added
 
 - `delete_assignment_with_confirmation`: two-step assignment deletion whose
-  preview shows due date, points and whether submissions exist
+  preview shows due date, points, and whether submissions exist, and warns that
+  submissions and grades are deleted with the assignment
   ([issue 318](https://github.com/vishalsachdev/canvas-mcp/issues/318)).
 - `ACCESSIBILITY_CHECKERS` setting (default `ufixit`, alias `udoit`; `none`
   leaves the three UFIXIT report tools unregistered for institutions without
   the add-on). The built-in scanner is always available. Exposed in
   `env.template`, the Desktop Extension settings and `server.json`
   ([issue 325](https://github.com/vishalsachdev/canvas-mcp/issues/325)).
+- Educator-only content migration tools for previewing and confirming a full
+  course-copy request, then polling its progress and reviewing all terminal
+  migration issues ([issue 309](https://github.com/vishalsachdev/canvas-mcp/issues/309)).
+- Skill Request issue template, so a workflow can be requested in plain
+  language without a Canvas API endpoint
+  ([issue 302](https://github.com/vishalsachdev/canvas-mcp/issues/302)).
 
-- Added educator-only content migration tools for previewing and confirming a
-  full course-copy request, then polling its progress and reviewing all
-  terminal migration issues ([issue 309](https://github.com/vishalsachdev/canvas-mcp/issues/309)).
+### Changed
+
+- `delete_announcements_by_criteria` is idempotent now that its token is bound
+  to the exact match set; a retry can no longer delete the next batch
+  ([issue 318](https://github.com/vishalsachdev/canvas-mcp/issues/318)).
+- `datetime.timezone.utc` → `datetime.UTC` and `asyncio.TimeoutError` → the
+  builtin alias throughout, enabled by the 3.11 floor. No behaviour change.
 
 ## [1.11.0] — 2026-08-20
 

--- a/README.md
+++ b/README.md
@@ -129,13 +129,14 @@ The Canvas MCP Server bridges the gap between AI assistants and Canvas Learning 
 
 **Released:** August 2026 | **[Full Changelog](./CHANGELOG.md)** | **[All Releases](https://github.com/vishalsachdev/canvas-mcp/releases)**
 
-A safety release: every delete tool now asks first. **Three changes are breaking** — read them before upgrading.
+A safety release: every delete tool now asks first. **Four changes are breaking.** Each one's migration is a line long:
 
-- **Breaking: every `delete_*` tool is two-step** ([#318](https://github.com/vishalsachdev/canvas-mcp/issues/318)). Call it without `confirmation_token` and you get a preview of exactly what would be deleted plus a single-use token; call again with the token and identical arguments to delete. Tokens expire in 5 minutes and stop matching if the target changed in between. `dry_run` is gone from the three announcement deletes (the preview is the dry run); `delete_module`, `delete_module_item` and `delete_page` gain `confirmation_token`. Thanks [@zqian](https://github.com/zqian) for the request
-- **Breaking: `delete_announcement` removed** — use `delete_announcement_with_confirmation`. **New: `delete_assignment_with_confirmation`**, whose preview shows due date, points and whether submissions exist
-- **Breaking: Python 3.10 dropped** ([#315](https://github.com/vishalsachdev/canvas-mcp/issues/315)) ahead of its 2026-10-31 end of life; `requires-python >= 3.11`
-- **`ACCESSIBILITY_CHECKERS` setting** ([#325](https://github.com/vishalsachdev/canvas-mcp/issues/325)): institutions without the UDOIT/UFIXIT add-on can set it to `none` and the three UFIXIT report tools are not registered. The built-in scanner stays on. Thanks [@jonespm](https://github.com/jonespm)
-- **Skill Request issue template** for asking for new agent workflows in plain language ([#302](https://github.com/vishalsachdev/canvas-mcp/issues/302))
+- **`delete_announcement` removed** → call `delete_announcement_with_confirmation` with the same arguments; it previews first, then deletes on the second call with the token ([#318](https://github.com/vishalsachdev/canvas-mcp/issues/318))
+- **`dry_run` removed** from the three announcement delete tools → drop the argument; a call without `confirmation_token` is the dry run and deletes nothing. `bulk_delete_announcements` used to delete on the first call; it previews now ([#318](https://github.com/vishalsachdev/canvas-mcp/issues/318))
+- **`confirmation_token` required on all seven delete tools** (`delete_announcement_with_confirmation`, `bulk_delete_announcements`, `delete_announcements_by_criteria`, `delete_page`, `delete_module`, `delete_module_item`, `delete_assignment_with_confirmation`) → call once with your normal arguments, show the preview, then call again with identical arguments plus the token from the `Confirmation token:` line. Tokens are single-use, expire in 5 minutes, and stop matching if the target or the arguments changed ([#318](https://github.com/vishalsachdev/canvas-mcp/issues/318)). Thanks [@zqian](https://github.com/zqian) for the request
+- **Python 3.10 dropped** → `requires-python >= 3.11`; upgrade the interpreter, or pin `canvas-mcp<1.12` until you can ([#315](https://github.com/vishalsachdev/canvas-mcp/issues/315))
+
+Also new: **`delete_assignment_with_confirmation`** (preview shows due date, points and whether submissions exist); **`ACCESSIBILITY_CHECKERS`** so institutions without UDOIT/UFIXIT can set `none` and drop the three UFIXIT tools while keeping the built-in scanner ([#325](https://github.com/vishalsachdev/canvas-mcp/issues/325), thanks [@jonespm](https://github.com/jonespm)); the **content migration** tools ([#309](https://github.com/vishalsachdev/canvas-mcp/issues/309)); and a **Skill Request** issue template ([#302](https://github.com/vishalsachdev/canvas-mcp/issues/302))
 
 <details>
 <summary>Previous releases</summary>

--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -198,7 +198,7 @@ Placeholders: `<app-name>`, `<resource-group>`, `<registry-name>`, `<app-service
 
 ### 4.2 Container image
 
-The repo ships a `Dockerfile` (Python 3.12-slim, non-root `mcp` user). It sets network-facing
+The repo ships a `Dockerfile` (`python:3.14-slim`, pinned by digest, non-root `mcp` user). It sets network-facing
 defaults inside the image:
 
 ```


### PR DESCRIPTION
Release notes for v1.12.0, which is already stamped on `main` (#332) but not tagged.

- `CHANGELOG.md`: the 1.12.0 section now opens with a **Breaking** block listing `delete_announcement` removed, `dry_run` removed, `confirmation_token` required on all seven delete tools, and Python 3.10 dropped, each with its migration (which tool to call instead, how to get and reuse a token, what to pin if stuck on 3.10). Added/Changed follow. Date: 2026-08-30.
- `README.md`: Latest Release mirrors that, one migration line per breaking change.
- `deploy/azure/README.md`: "Python 3.12-slim" corrected to the Dockerfile's `python:3.14-slim` (pinned by digest).

Docs only. No tag, no publish, no site deploy in this PR.

## Tag and publish sequence (for tomorrow)

From `internal/release-checklist.md` plus the two known failure modes recorded there:

```
git checkout main && git pull --ff-only
git tag v1.12.0 && git push origin v1.12.0
# The tag triggers create-release.yml (GitHub Release + canvas-mcp.mcpb + SLSA) and
# publish-mcp.yml (PyPI job, then the MCP Registry job).

# If the Registry job fails, check PyPI FIRST:
curl -s -o /dev/null -w '%{http_code}' https://pypi.org/pypi/canvas-mcp/1.12.0/json
#   404 -> propagation race: wait until it returns 200, then
#   200 -> not the race (last time: unauthenticated api.github.com lookup rate-limited to null; a rerun fixed it)
gh run rerun <run-id> --failed

# Verify
gh attestation verify canvas-mcp.mcpb --owner vishalsachdev
curl -s https://pypi.org/pypi/canvas-mcp/json | python3 -c 'import json,sys; print(json.load(sys.stdin)["info"]["version"])'

# Site (only after the tag; the banner already says v1.12.0)
export CLOUDFLARE_API_TOKEN=$(grep '^CF_API_TOKEN=' ~/.env | cut -d= -f2- | tr -d '"')
npx wrangler pages deploy docs/ --project-name=canvas-mcp --branch=main --commit-dirty=true
```

If the tag lands on a day other than 2026-08-30, change the CHANGELOG date in the same commit as the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3xugtvm98HhHEJRVpqcbZ
