### PR TITLE
fix(security): mount the execute_typescript container rootfs read-only

### DIFF
--- a/src/canvas_mcp/tools/code_execution.py
+++ b/src/canvas_mcp/tools/code_execution.py
@@ -588,6 +588,13 @@ def register_code_execution_tools(mcp: FastMCP) -> None:
                     "--security-opt=no-new-privileges",
                     # Cap process count to contain fork bombs.
                     "--pids-limit=256",
+                    # Nothing needs a writable root filesystem: the workspace
+                    # is a :ro bind mount, the script arrives over stdin into
+                    # the $HOME tmpfs, npm's cache lives under $HOME and /tmp
+                    # is its own tmpfs. So the image's own filesystem is
+                    # read-only, leaving the two tmpfs mounts as the only
+                    # writable paths (and $HOME the only writable+exec one).
+                    "--read-only",
                 ]
                 # Egress: the in-process JS guard only patches net/tls/http/https
                 # and fetch, so executed code can reach the network through

--- a/tests/security/test_sandbox_nonroot_user.py
+++ b/tests/security/test_sandbox_nonroot_user.py
@@ -99,6 +99,44 @@ class TestContainerRunsAsNonRoot:
         assert uid_gid != "0:0" and not uid_gid.startswith("root")
 
     @pytest.mark.asyncio
+    async def test_root_filesystem_is_read_only(self):
+        """The image's own filesystem must be mounted read-only (issue 336).
+
+        With the workspace on a :ro bind mount, the script delivered over
+        stdin into $HOME, and /tmp on its own tmpfs, no path outside the two
+        tmpfs mounts needs to be writable. Without --read-only the image
+        rootfs is writable and executable by the sandbox uid, which is a
+        free persistence and staging surface for executed code.
+        """
+        tool = get_execute_typescript(TS_SANDBOX_MODE="container")
+        if tool is None:
+            pytest.skip("execute_typescript not registered in this configuration")
+
+        with patch(
+            "canvas_mcp.tools.code_execution._detect_container_runtime",
+            return_value="docker",
+        ), patch(
+            "canvas_mcp.tools.code_execution._runtime_available",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "canvas_mcp.tools.code_execution.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=_mock_process(),
+        ) as spawn:
+            await tool(code="console.log(1)")
+
+        cmd = list(spawn.call_args.args)
+        assert "--read-only" in cmd, "container rootfs is not mounted read-only"
+        # The flag must sit on the `run` line, before the image name, or the
+        # runtime passes it to the container command instead.
+        image_index = cmd.index(cmd[-4])
+        assert cmd.index("--read-only") < image_index
+        # And the two tmpfs mounts still exist, otherwise npx has nowhere to write.
+        tmpfs_targets = [cmd[i + 1] for i, a in enumerate(cmd) if a == "--tmpfs"]
+        assert any(t.startswith("/tmp:") for t in tmpfs_targets)
+        assert any(t.startswith("/home/sandbox:") for t in tmpfs_targets)
+
+    @pytest.mark.asyncio
     async def test_home_is_writable_and_exec_allowed_not_the_noexec_scratch_tmpfs(self):
         """$HOME must land on its own exec-allowed mount, never on /tmp.
 


### PR DESCRIPTION
Follow-up to #317 (merged as b4f21b4).

Adds `--read-only` to the `execute_typescript` container run line. After #317 the container has no reason to write outside its two tmpfs mounts: the workspace is a `:ro` bind mount, the script is delivered over stdin into `$HOME`, npm's cache is under `$HOME`, and `/tmp` is a separate noexec tmpfs. With the flag, the image's own filesystem stops being a writable, executable surface for whatever the caller's code does.

- `src/canvas_mcp/tools/code_execution.py`: one flag, with the reasoning inline.
- `tests/security/test_sandbox_nonroot_user.py`: new `test_root_filesystem_is_read_only` (flag present, placed before the image name so the runtime consumes it, both tmpfs mounts still present).

Suite 1457 passed / 21 skipped; ruff and mypy clean.

**Not measured here:** this machine has no Docker or podman, so `npx tsx` starting under `--read-only` on a Linux host is verified by construction (every write path is enumerated above), not by a run. If anyone has a Linux Docker host handy, one `execute_typescript` call in container mode with `block_outbound=true` would close that gap. If npm turns out to write somewhere unexpected, the failure is loud (EROFS), not silent.

Closes #336
