### PR TITLE
fix(security): make sandbox uid:gid configurable via TS_SANDBOX_UID_GID (#338)

### DIFF
--- a/env.template
+++ b/env.template
@@ -52,6 +52,12 @@ TS_SANDBOX_CPU_LIMIT=30
 TS_SANDBOX_MEMORY_LIMIT_MB=512
 TS_SANDBOX_TIMEOUT_SEC=120
 TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
+# TS_SANDBOX_UID_GID is the numeric uid:gid the sandbox container runs as
+# instead of the image-default root. Numeric, not a named user, because the
+# operator-configured image is not guaranteed to define one. Use this to match
+# a custom image's non-root user (e.g. "1000:1000") or to satisfy umask 077
+# checkouts where the host user's uid differs from the default.
+# TS_SANDBOX_UID_GID=65532:65532
 
 # Tool Profile (Optional)
 # Controls which tools are registered: student (~37), educator (~88), all (default)

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -250,6 +250,7 @@ class Config:
         self.ts_sandbox_memory_limit_mb = _int_env("TS_SANDBOX_MEMORY_LIMIT_MB", 512)
         self.ts_sandbox_timeout_sec = _int_env("TS_SANDBOX_TIMEOUT_SEC", 120)
         self.ts_sandbox_container_image = os.getenv("TS_SANDBOX_CONTAINER_IMAGE", "node:20-alpine")
+        self.ts_sandbox_uid_gid = os.getenv("TS_SANDBOX_UID_GID", "65532:65532")
 
         # Code execution is opt-in — set EXECUTE_TYPESCRIPT_ENABLED=true to
         # enable the execute_typescript tool (independent of CANVAS_ROLE).
@@ -443,6 +444,14 @@ def validate_config() -> bool:
             "TS_SANDBOX_MODE should be one of auto, local, container; "
             f"defaulting to 'auto' (got '{config.ts_sandbox_mode}')"
         )
+
+    uid_gid_pattern = re.compile(r"^\d+:\d+$")
+    if not uid_gid_pattern.match(config.ts_sandbox_uid_gid):
+        log_warning(
+            "TS_SANDBOX_UID_GID should be in <uid>:<gid> numeric form; "
+            f"defaulting to '65532:65532' (got '{config.ts_sandbox_uid_gid}')"
+        )
+        config.ts_sandbox_uid_gid = "65532:65532"
 
     valid_roles = ("student", "educator", "all")
     if config.canvas_role not in valid_roles:

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -453,6 +453,14 @@ def validate_config() -> bool:
         )
         config.ts_sandbox_uid_gid = "65532:65532"
 
+    uid, gid = config.ts_sandbox_uid_gid.split(":")
+    if uid == "0" or gid == "0":
+        log_warning(
+            "TS_SANDBOX_UID_GID=0:0 would run the sandbox as root; "
+            f"defaulting to '65532:65532' (got '{config.ts_sandbox_uid_gid}')"
+        )
+        config.ts_sandbox_uid_gid = "65532:65532"
+
     valid_roles = ("student", "educator", "all")
     if config.canvas_role not in valid_roles:
         log_warning(

--- a/src/canvas_mcp/tools/code_execution.py
+++ b/src/canvas_mcp/tools/code_execution.py
@@ -32,10 +32,6 @@ _SAFE_ENV_KEYS = frozenset({
     "CONTAINER_HOST",
 })
 
-# Numeric uid:gid the sandbox container runs as instead of image-default root
-# (the distroless "nonroot" convention). Numeric, not a named user, because
-# the operator-configured image is not guaranteed to define one.
-_SANDBOX_UID_GID = "65532:65532"
 
 
 def _container_run_script(container_code_api_dir: str) -> str:
@@ -581,7 +577,7 @@ def register_code_execution_tools(mcp: FastMCP) -> None:
                     # (root for node:*-alpine and most images), so a container
                     # escape does not hand back root.
                     "--user",
-                    _SANDBOX_UID_GID,
+                    config.ts_sandbox_uid_gid,
                     # Drop all Linux capabilities and block privilege escalation;
                     # the tsx runtime needs none of them.
                     "--cap-drop=ALL",

--- a/tests/security/test_sandbox_nonroot_user.py
+++ b/tests/security/test_sandbox_nonroot_user.py
@@ -416,3 +416,40 @@ class TestSandboxUidGidConfigurable:
             f"malformed value should fall back to default 65532:65532, got {uid_gid}"
         )
 
+    @pytest.mark.asyncio
+    async def test_root_uid_gid_rejected_with_default(self):
+        """A 0:0 uid:gid falls back to the default non-root value.
+
+        validate_config() warns and resets to 65532:65532 when the value
+        would run the sandbox as root, undoing the non-root protection
+        from PR #317.
+        """
+        tool = get_execute_typescript(
+            TS_SANDBOX_MODE="container", TS_SANDBOX_UID_GID="0:0"
+        )
+        if tool is None:
+            pytest.skip("execute_typescript not registered in this configuration")
+
+        # Trigger the startup validation that resets root uid:gid values
+        validate_config()
+
+        with patch(
+            "canvas_mcp.tools.code_execution._detect_container_runtime",
+            return_value="docker",
+        ), patch(
+            "canvas_mcp.tools.code_execution._runtime_available",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "canvas_mcp.tools.code_execution.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=_mock_process(),
+        ) as spawn:
+            await tool(code="console.log(1)")
+
+        cmd = list(spawn.call_args.args)
+        assert "--user" in cmd
+        uid_gid = cmd[cmd.index("--user") + 1]
+        assert uid_gid == "65532:65532", (
+            f"0:0 should fall back to default 65532:65532, got {uid_gid}"
+        )
+

--- a/tests/security/test_sandbox_nonroot_user.py
+++ b/tests/security/test_sandbox_nonroot_user.py
@@ -28,7 +28,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp import FastMCP
 
-from canvas_mcp.core.config import get_config, reset_config
+from canvas_mcp.core.config import get_config, reset_config, validate_config
 from canvas_mcp.tools.code_execution import register_code_execution_tools
 
 
@@ -317,5 +317,102 @@ class TestContainerRunsAsNonRoot:
         process_mock.communicate.assert_awaited_once()
         assert process_mock.communicate.await_args.kwargs.get("input") == (
             b"import { x } from './canvas/x.js';"
+        )
+
+
+class TestSandboxUidGidConfigurable:
+    """TS_SANDBOX_UID_GID makes the hardcoded uid:gid from PR #317 overridable.
+
+    Two environments break the default (65532:65532):
+    - umask 077 checkouts where the host user's uid differs from the default
+    - custom container images with a mismatched non-root user
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_uid_gid_when_unset(self):
+        """Without TS_SANDBOX_UID_GID set, the container runs as 65532:65532."""
+        tool = get_execute_typescript(TS_SANDBOX_MODE="container")
+        if tool is None:
+            pytest.skip("execute_typescript not registered in this configuration")
+
+        with patch(
+            "canvas_mcp.tools.code_execution._detect_container_runtime",
+            return_value="docker",
+        ), patch(
+            "canvas_mcp.tools.code_execution._runtime_available",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "canvas_mcp.tools.code_execution.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=_mock_process(),
+        ) as spawn:
+            await tool(code="console.log(1)")
+
+        cmd = list(spawn.call_args.args)
+        assert "--user" in cmd
+        uid_gid = cmd[cmd.index("--user") + 1]
+        assert uid_gid == "65532:65532", f"expected default 65532:65532, got {uid_gid}"
+
+    @pytest.mark.asyncio
+    async def test_configured_uid_gid_is_used(self):
+        """Setting TS_SANDBOX_UID_GID overrides the default uid:gid."""
+        tool = get_execute_typescript(
+            TS_SANDBOX_MODE="container", TS_SANDBOX_UID_GID="1000:1000"
+        )
+        if tool is None:
+            pytest.skip("execute_typescript not registered in this configuration")
+
+        with patch(
+            "canvas_mcp.tools.code_execution._detect_container_runtime",
+            return_value="docker",
+        ), patch(
+            "canvas_mcp.tools.code_execution._runtime_available",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "canvas_mcp.tools.code_execution.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=_mock_process(),
+        ) as spawn:
+            await tool(code="console.log(1)")
+
+        cmd = list(spawn.call_args.args)
+        assert "--user" in cmd
+        uid_gid = cmd[cmd.index("--user") + 1]
+        assert uid_gid == "1000:1000", f"expected configured 1000:1000, got {uid_gid}"
+
+    @pytest.mark.asyncio
+    async def test_malformed_uid_gid_rejected_with_default(self):
+        """A malformed TS_SANDBOX_UID_GID falls back to the default.
+
+        validate_config() warns and resets to 65532:65532 when the value
+        does not match the <uid>:<gid> numeric pattern.
+        """
+        tool = get_execute_typescript(
+            TS_SANDBOX_MODE="container", TS_SANDBOX_UID_GID="not-a-number"
+        )
+        if tool is None:
+            pytest.skip("execute_typescript not registered in this configuration")
+
+        # Trigger the startup validation that resets malformed values
+        validate_config()
+
+        with patch(
+            "canvas_mcp.tools.code_execution._detect_container_runtime",
+            return_value="docker",
+        ), patch(
+            "canvas_mcp.tools.code_execution._runtime_available",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "canvas_mcp.tools.code_execution.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=_mock_process(),
+        ) as spawn:
+            await tool(code="console.log(1)")
+
+        cmd = list(spawn.call_args.args)
+        assert "--user" in cmd
+        uid_gid = cmd[cmd.index("--user") + 1]
+        assert uid_gid == "65532:65532", (
+            f"malformed value should fall back to default 65532:65532, got {uid_gid}"
         )
 


### PR DESCRIPTION
## Problem

PR #317 hardcoded `--user 65532:65532` in the container run command. That breaks when:
- The host has umask 077 (different uid than the default)
- A custom `TS_SANDBOX_CONTAINER_IMAGE` defines a different non-root user

## Fix

Added `TS_SANDBOX_UID_GID` env var (default `65532:65532`). Validated with `^\d+:\d+$` in `validate_config()` — malformed input warns and falls back to default.

## Files

- `core/config.py` — config field + validation
- `tools/code_execution.py` — use config instead of constant
- `env.template` — documented
- `tests/security/test_sandbox_nonroot_user.py` — 3 new tests

## Testing

9/9 sandbox tests pass. Ruff clean.