### PR TITLE
fix: decode code_api TypeScript files as UTF-8 in search_canvas_tools

### DIFF
--- a/src/canvas_mcp/tools/discovery.py
+++ b/src/canvas_mcp/tools/discovery.py
@@ -130,7 +130,7 @@ def register_discovery_tools(mcp: FastMCP) -> None:
                     if not file_match:
                         # Also check file contents for query
                         try:
-                            content = ts_file.read_text()
+                            content = ts_file.read_text(encoding="utf-8")
                             if query_lower not in content.lower():
                                 continue
                         except Exception as e:
@@ -145,7 +145,7 @@ def register_discovery_tools(mcp: FastMCP) -> None:
                     elif detail_level == "signatures":
                         # Extract function signature from file
                         try:
-                            content = ts_file.read_text()
+                            content = ts_file.read_text(encoding="utf-8")
                             signature = extract_function_signature(content)
                             doc_comment = extract_doc_comment(content)
 
@@ -162,7 +162,7 @@ def register_discovery_tools(mcp: FastMCP) -> None:
 
                     else:  # full
                         try:
-                            content = ts_file.read_text()
+                            content = ts_file.read_text(encoding="utf-8")
                             code_api_matches.append({
                                 "file": relative_path,
                                 "content": _cap(content, _CODE_API_FULL_CONTENT_CHARS)

--- a/tests/tools/test_discovery.py
+++ b/tests/tools/test_discovery.py
@@ -14,6 +14,7 @@ fixture standing in for it.
 """
 
 import json
+from pathlib import Path
 
 import pytest
 from fastmcp import Client, FastMCP
@@ -235,3 +236,63 @@ async def test_registry_is_queried_live_not_at_registration_time():
     mcp = _registry()
     data = await _search(mcp, "execute_typescript", detail_level="names")
     assert "execute_typescript" in data["mcp_tools"]["tools"]
+
+
+# --- Locale-independent decoding of the TypeScript code-API files ----------
+#
+# The code_api/**/*.ts files are UTF-8 and two of them contain U+2713/U+2717
+# ("✓"/"✗") in console output strings. Path.read_text() without an explicit
+# encoding resolves to locale.getpreferredencoding(), so on a Windows install
+# whose code page is not cp1252 (cp932 Japanese, cp936 Simplified Chinese,
+# cp1253 Greek, ...) those two files raise UnicodeDecodeError. The read sits
+# under `except Exception: continue`, so they are silently dropped from the
+# search results with no error reported to the caller.
+#
+# CI runs on UTF-8, where the bug is invisible — hence the explicit shim
+# below rather than relying on the ambient locale.
+
+@pytest.fixture
+def _non_utf8_default_locale(monkeypatch):
+    """Make encoding-less text reads behave as they do on a cp932 host."""
+    real_read_text = Path.read_text
+
+    def shim(self, encoding=None, errors=None, *args, **kwargs):
+        return real_read_text(self, encoding=encoding or "cp932", errors=errors)
+
+    monkeypatch.setattr(Path, "read_text", shim)
+
+
+def _code_api_files(data: dict) -> set[str]:
+    return {
+        entry["file"].replace("\\", "/")
+        for entry in data["code_execution_api"]["tools"]
+        if isinstance(entry, dict)
+    }
+
+
+@pytest.mark.asyncio
+async def test_code_api_search_does_not_drop_files_on_non_utf8_locale(
+    _non_utf8_default_locale,
+):
+    """Content search must find UTF-8 modules whatever the host code page."""
+    mcp = _registry()
+    data = await _search(mcp, "submission", detail_level="signatures")
+
+    found = _code_api_files(data)
+    # Both of these match "submission" only in their body, so they are
+    # reached through the content-search path that does the decoding.
+    assert "grading/bulkGrade.ts" in found
+    assert "discussions/bulkGradeDiscussion.ts" in found
+
+
+@pytest.mark.asyncio
+async def test_code_api_signatures_readable_on_non_utf8_locale(
+    _non_utf8_default_locale,
+):
+    """Signature extraction must not degrade to an error entry."""
+    mcp = _registry()
+    data = await _search(mcp, "bulkGrade", detail_level="signatures")
+
+    entries = data["code_execution_api"]["tools"]
+    assert entries, "expected bulkGrade modules to be found"
+    assert not [e for e in entries if isinstance(e, dict) and "error" in e]


### PR DESCRIPTION
## What

`search_canvas_tools` reads the bundled `code_api/**/*.ts` modules with
`Path.read_text()` and no explicit encoding, so the decoding depends on the
host's locale. Two of those modules contain `U+2713`/`U+2717` (`✓`/`✗`) in
console output strings, which fails to decode on a Windows host whose code
page is not cp1252.

The read in the content-search branch sits under `except Exception: continue`,
so on those hosts the affected modules are **silently dropped** from the
results — no error reaches the caller, the model just never learns those
modules exist. The `signatures` and `full` branches are noisier but also
degraded: they return `{"file": ..., "error": "Could not parse signature:
'cp932' codec can't decode byte 0x93 ..."}` instead of a signature.

## Repro

Calling `search_canvas_tools(query="submission", detail_level="signatures")`
and varying only the default encoding used for encoding-less text reads:

| default encoding | typical host | code-API modules returned |
| --- | --- | --- |
| utf-8 | Linux/macOS, CI | 4 |
| cp1252 | Windows (Western) | 4 |
| cp1251 | Windows (Cyrillic) | 4 |
| cp932 | Windows (Japanese) | **2** |
| cp936 | Windows (Simplified Chinese) | **2** |
| cp1253 | Windows (Greek) | **2** |

The two that disappear are `grading/bulkGrade.ts` and
`discussions/bulkGradeDiscussion.ts` — exactly the two files containing the
non-ASCII characters. `entries_with_error` is `0` in the dropped case, which
is what makes it silent.

Under cp1252 the same bytes decode to mojibake (`✓` → `âœ“`) rather than
raising. That is currently invisible in output because both occurrences sit
past the 2000-char `_CODE_API_FULL_CONTENT_CHARS` cap, so I have not treated
it as a separate defect.

## Fix

`encoding="utf-8"` on the three reads. The files are UTF-8 on disk, so the
encoding is pinned rather than made configurable.

`execute_typescript` is **not** affected — it runs these files through Node,
which reads them as UTF-8 directly, so no Python-side decoding is involved.

## Tests

Two tests added to `tests/tools/test_discovery.py`, using your existing
`_registry()` / `_search()` harness.

Since CI runs on UTF-8, a plain content assertion would pass with or without
the fix, so the tests install a fixture that makes encoding-less reads resolve
to cp932. That makes them fail on Linux CI before the change and pass after —
verified in both directions:

- before: `2 failed, 13 passed`
- after: `15 passed`

I normalised the path separator in the assertions (`\` → `/`) so they behave
the same on Windows and Linux.

## Checks run

- `ruff check src/ tests/` — clean
- `pytest tests/` — `1450 passed, 22 skipped` (the 8 failures I see locally are
  pre-existing POSIX-only/encoding assumptions in `tests/security/` and
  `test_closing_keyword_guard.py`, unrelated to this change and unchanged by
  it; your CI is green on `main`)
- `mypy src/` — the 3 errors I see are pre-existing Windows-only
  `resource.setrlimit`/`RLIMIT_CPU` attribute errors in `code_execution.py`,
  untouched here

## Where this came from

I maintain a different Canvas LMS MCP server and was reading your code-API
discovery path out of interest in how you'd approached it. I found this by
running your test suite on Windows. Offering the fix as-is — no expectation
attached, and happy for you to close it and apply the one-word change yourself
if that's easier.
