### PR TITLE
fix(security): validate configurable sandbox uid:gid numerically

### DIFF
--- a/env.template
+++ b/env.template
@@ -52,6 +52,12 @@ TS_SANDBOX_CPU_LIMIT=30
 TS_SANDBOX_MEMORY_LIMIT_MB=512
 TS_SANDBOX_TIMEOUT_SEC=120
 TS_SANDBOX_CONTAINER_IMAGE=node:20-alpine
+# TS_SANDBOX_UID_GID is the numeric uid:gid the sandbox container runs as
+# instead of the image-default root. Numeric, not a named user, because the
+# operator-configured image is not guaranteed to define one. Use this to match
+# a custom image's non-root user (e.g. "1000:1000") or to satisfy umask 077
+# checkouts where the host user's uid differs from the default.
+# TS_SANDBOX_UID_GID=65532:65532
 
 # Tool Profile (Optional)
 # Controls which tools are registered: student (~37), educator (~88), all (default)

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -207,6 +207,30 @@ def _float_env(name: str, default: float) -> float:
     return parsed
 
 
+_DEFAULT_TS_SANDBOX_UID_GID = "65532:65532"
+_TS_SANDBOX_UID_GID_PATTERN = re.compile(r"^\d+:\d+$")
+
+
+def _parse_ts_sandbox_uid_gid(value: str) -> str:
+    """Return a safe numeric uid:gid for every transport startup path."""
+    if not _TS_SANDBOX_UID_GID_PATTERN.fullmatch(value):
+        log_warning(
+            "TS_SANDBOX_UID_GID should be in <uid>:<gid> numeric form; "
+            f"defaulting to '{_DEFAULT_TS_SANDBOX_UID_GID}' (got '{value}')"
+        )
+        return _DEFAULT_TS_SANDBOX_UID_GID
+
+    uid, gid = (int(part) for part in value.split(":"))
+    if uid == 0 or gid == 0:
+        log_warning(
+            "TS_SANDBOX_UID_GID must use a non-zero uid and non-zero gid; "
+            f"defaulting to '{_DEFAULT_TS_SANDBOX_UID_GID}' (got '{value}')"
+        )
+        return _DEFAULT_TS_SANDBOX_UID_GID
+
+    return value
+
+
 class Config:
     """Configuration class for Canvas MCP server."""
 
@@ -250,7 +274,9 @@ class Config:
         self.ts_sandbox_memory_limit_mb = _int_env("TS_SANDBOX_MEMORY_LIMIT_MB", 512)
         self.ts_sandbox_timeout_sec = _int_env("TS_SANDBOX_TIMEOUT_SEC", 120)
         self.ts_sandbox_container_image = os.getenv("TS_SANDBOX_CONTAINER_IMAGE", "node:20-alpine")
-        self.ts_sandbox_uid_gid = os.getenv("TS_SANDBOX_UID_GID", "65532:65532")
+        self.ts_sandbox_uid_gid = _parse_ts_sandbox_uid_gid(
+            os.getenv("TS_SANDBOX_UID_GID", _DEFAULT_TS_SANDBOX_UID_GID)
+        )
 
         # Code execution is opt-in — set EXECUTE_TYPESCRIPT_ENABLED=true to
         # enable the execute_typescript tool (independent of CANVAS_ROLE).
@@ -444,22 +470,6 @@ def validate_config() -> bool:
             "TS_SANDBOX_MODE should be one of auto, local, container; "
             f"defaulting to 'auto' (got '{config.ts_sandbox_mode}')"
         )
-
-    uid_gid_pattern = re.compile(r"^\d+:\d+$")
-    if not uid_gid_pattern.match(config.ts_sandbox_uid_gid):
-        log_warning(
-            "TS_SANDBOX_UID_GID should be in <uid>:<gid> numeric form; "
-            f"defaulting to '65532:65532' (got '{config.ts_sandbox_uid_gid}')"
-        )
-        config.ts_sandbox_uid_gid = "65532:65532"
-
-    uid, gid = (int(part) for part in config.ts_sandbox_uid_gid.split(":"))
-    if uid == 0 or gid == 0:
-        log_warning(
-            "TS_SANDBOX_UID_GID must use non-zero uid and gid; "
-            f"defaulting to '65532:65532' (got '{config.ts_sandbox_uid_gid}')"
-        )
-        config.ts_sandbox_uid_gid = "65532:65532"
 
     valid_roles = ("student", "educator", "all")
     if config.canvas_role not in valid_roles:

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -250,6 +250,7 @@ class Config:
         self.ts_sandbox_memory_limit_mb = _int_env("TS_SANDBOX_MEMORY_LIMIT_MB", 512)
         self.ts_sandbox_timeout_sec = _int_env("TS_SANDBOX_TIMEOUT_SEC", 120)
         self.ts_sandbox_container_image = os.getenv("TS_SANDBOX_CONTAINER_IMAGE", "node:20-alpine")
+        self.ts_sandbox_uid_gid = os.getenv("TS_SANDBOX_UID_GID", "65532:65532")
 
         # Code execution is opt-in — set EXECUTE_TYPESCRIPT_ENABLED=true to
         # enable the execute_typescript tool (independent of CANVAS_ROLE).
@@ -443,6 +444,22 @@ def validate_config() -> bool:
             "TS_SANDBOX_MODE should be one of auto, local, container; "
             f"defaulting to 'auto' (got '{config.ts_sandbox_mode}')"
         )
+
+    uid_gid_pattern = re.compile(r"^\d+:\d+$")
+    if not uid_gid_pattern.match(config.ts_sandbox_uid_gid):
+        log_warning(
+            "TS_SANDBOX_UID_GID should be in <uid>:<gid> numeric form; "
+            f"defaulting to '65532:65532' (got '{config.ts_sandbox_uid_gid}')"
+        )
+        config.ts_sandbox_uid_gid = "65532:65532"
+
+    uid, gid = (int(part) for part in config.ts_sandbox_uid_gid.split(":"))
+    if uid == 0 or gid == 0:
+        log_warning(
+            "TS_SANDBOX_UID_GID must use non-zero uid and gid; "
+            f"defaulting to '65532:65532' (got '{config.ts_sandbox_uid_gid}')"
+        )
+        config.ts_sandbox_uid_gid = "65532:65532"
 
     valid_roles = ("student", "educator", "all")
     if config.canvas_role not in valid_roles:

--- a/src/canvas_mcp/core/config.py
+++ b/src/canvas_mcp/core/config.py
@@ -208,7 +208,7 @@ def _float_env(name: str, default: float) -> float:
 
 
 _DEFAULT_TS_SANDBOX_UID_GID = "65532:65532"
-_TS_SANDBOX_UID_GID_PATTERN = re.compile(r"^\d+:\d+$")
+_TS_SANDBOX_UID_GID_PATTERN = re.compile(r"^[0-9]{1,10}:[0-9]{1,10}$")
 
 
 def _parse_ts_sandbox_uid_gid(value: str) -> str:

--- a/src/canvas_mcp/tools/code_execution.py
+++ b/src/canvas_mcp/tools/code_execution.py
@@ -33,7 +33,6 @@ _SAFE_ENV_KEYS = frozenset({
 })
 
 
-
 def _container_run_script(container_code_api_dir: str) -> str:
     """Return the `sh -c` body that runs stdin-delivered code inside the container.
 

--- a/src/canvas_mcp/tools/code_execution.py
+++ b/src/canvas_mcp/tools/code_execution.py
@@ -32,10 +32,6 @@ _SAFE_ENV_KEYS = frozenset({
     "CONTAINER_HOST",
 })
 
-# Numeric uid:gid the sandbox container runs as instead of image-default root
-# (the distroless "nonroot" convention). Numeric, not a named user, because
-# the operator-configured image is not guaranteed to define one.
-_SANDBOX_UID_GID = "65532:65532"
 
 
 def _container_run_script(container_code_api_dir: str) -> str:
@@ -581,7 +577,7 @@ def register_code_execution_tools(mcp: FastMCP) -> None:
                     # (root for node:*-alpine and most images), so a container
                     # escape does not hand back root.
                     "--user",
-                    _SANDBOX_UID_GID,
+                    config.ts_sandbox_uid_gid,
                     # Drop all Linux capabilities and block privilege escalation;
                     # the tsx runtime needs none of them.
                     "--cap-drop=ALL",

--- a/tests/security/test_sandbox_nonroot_user.py
+++ b/tests/security/test_sandbox_nonroot_user.py
@@ -28,7 +28,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp import FastMCP
 
-from canvas_mcp.core.config import get_config, reset_config, validate_config
+from canvas_mcp.core.config import get_config, reset_config
 from canvas_mcp.tools.code_execution import register_code_execution_tools
 
 
@@ -387,8 +387,8 @@ class TestSandboxUidGidConfigurable:
     async def test_malformed_uid_gid_rejected_with_default(self):
         """A malformed TS_SANDBOX_UID_GID falls back to the default.
 
-        validate_config() warns and resets to 65532:65532 when the value
-        does not match the <uid>:<gid> numeric pattern.
+        Configuration construction resets the value without relying on
+        validate_config(), which the HTTP startup path intentionally skips.
         """
         tool = get_execute_typescript(
             TS_SANDBOX_MODE="container", TS_SANDBOX_UID_GID="not-a-number"
@@ -396,9 +396,7 @@ class TestSandboxUidGidConfigurable:
         if tool is None:
             pytest.skip("execute_typescript not registered in this configuration")
 
-        # Trigger the startup validation that resets malformed values
-        validate_config()
-
+        # Config construction must clamp this for both stdio and HTTP startup.
         with patch(
             "canvas_mcp.tools.code_execution._detect_container_runtime",
             return_value="docker",
@@ -427,9 +425,8 @@ class TestSandboxUidGidConfigurable:
     async def test_root_uid_gid_rejected_with_default(self, root_uid_gid):
         """Any numeric representation of a zero uid or gid falls back safely.
 
-        validate_config() warns and resets to 65532:65532 when the value
-        would run the sandbox as root, undoing the non-root protection
-        from PR #317.
+        Configuration construction resets the value without relying on
+        validate_config(), which the HTTP startup path intentionally skips.
         """
         tool = get_execute_typescript(
             TS_SANDBOX_MODE="container", TS_SANDBOX_UID_GID=root_uid_gid
@@ -437,9 +434,7 @@ class TestSandboxUidGidConfigurable:
         if tool is None:
             pytest.skip("execute_typescript not registered in this configuration")
 
-        # Trigger the startup validation that resets root uid:gid values
-        validate_config()
-
+        # Config construction must clamp this for both stdio and HTTP startup.
         with patch(
             "canvas_mcp.tools.code_execution._detect_container_runtime",
             return_value="docker",

--- a/tests/security/test_sandbox_nonroot_user.py
+++ b/tests/security/test_sandbox_nonroot_user.py
@@ -383,15 +383,23 @@ class TestSandboxUidGidConfigurable:
             f"expected configured {configured_uid_gid}, got {uid_gid}"
         )
 
+    @pytest.mark.parametrize(
+        "malformed_uid_gid",
+        [
+            pytest.param("not-a-number", id="non-numeric"),
+            pytest.param(f"{'0' * 4301}:1000", id="pathologically-long"),
+            pytest.param("١٠٠٠:١٠٠٠", id="unicode-digits"),
+        ],
+    )
     @pytest.mark.asyncio
-    async def test_malformed_uid_gid_rejected_with_default(self):
+    async def test_malformed_uid_gid_rejected_with_default(self, malformed_uid_gid):
         """A malformed TS_SANDBOX_UID_GID falls back to the default.
 
         Configuration construction resets the value without relying on
         validate_config(), which the HTTP startup path intentionally skips.
         """
         tool = get_execute_typescript(
-            TS_SANDBOX_MODE="container", TS_SANDBOX_UID_GID="not-a-number"
+            TS_SANDBOX_MODE="container", TS_SANDBOX_UID_GID=malformed_uid_gid
         )
         if tool is None:
             pytest.skip("execute_typescript not registered in this configuration")
@@ -414,7 +422,7 @@ class TestSandboxUidGidConfigurable:
         assert "--user" in cmd
         uid_gid = cmd[cmd.index("--user") + 1]
         assert uid_gid == "65532:65532", (
-            f"malformed value should fall back to default 65532:65532, got {uid_gid}"
+            f"{malformed_uid_gid!r} should fall back to 65532:65532, got {uid_gid}"
         )
 
     @pytest.mark.parametrize(

--- a/tests/security/test_sandbox_nonroot_user.py
+++ b/tests/security/test_sandbox_nonroot_user.py
@@ -28,7 +28,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from fastmcp import FastMCP
 
-from canvas_mcp.core.config import get_config, reset_config
+from canvas_mcp.core.config import get_config, reset_config, validate_config
 from canvas_mcp.tools.code_execution import register_code_execution_tools
 
 
@@ -317,5 +317,146 @@ class TestContainerRunsAsNonRoot:
         process_mock.communicate.assert_awaited_once()
         assert process_mock.communicate.await_args.kwargs.get("input") == (
             b"import { x } from './canvas/x.js';"
+        )
+
+
+class TestSandboxUidGidConfigurable:
+    """TS_SANDBOX_UID_GID makes the hardcoded uid:gid from PR #317 overridable.
+
+    Two environments break the default (65532:65532):
+    - umask 077 checkouts where the host user's uid differs from the default
+    - custom container images with a mismatched non-root user
+    """
+
+    @pytest.mark.asyncio
+    async def test_default_uid_gid_when_unset(self):
+        """Without TS_SANDBOX_UID_GID set, the container runs as 65532:65532."""
+        tool = get_execute_typescript(TS_SANDBOX_MODE="container")
+        if tool is None:
+            pytest.skip("execute_typescript not registered in this configuration")
+
+        with patch(
+            "canvas_mcp.tools.code_execution._detect_container_runtime",
+            return_value="docker",
+        ), patch(
+            "canvas_mcp.tools.code_execution._runtime_available",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "canvas_mcp.tools.code_execution.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=_mock_process(),
+        ) as spawn:
+            await tool(code="console.log(1)")
+
+        cmd = list(spawn.call_args.args)
+        assert "--user" in cmd
+        uid_gid = cmd[cmd.index("--user") + 1]
+        assert uid_gid == "65532:65532", f"expected default 65532:65532, got {uid_gid}"
+
+    @pytest.mark.parametrize("configured_uid_gid", ["1000:1000", "010:010"])
+    @pytest.mark.asyncio
+    async def test_configured_uid_gid_is_used(self, configured_uid_gid):
+        """Setting TS_SANDBOX_UID_GID overrides the default uid:gid."""
+        tool = get_execute_typescript(
+            TS_SANDBOX_MODE="container", TS_SANDBOX_UID_GID=configured_uid_gid
+        )
+        if tool is None:
+            pytest.skip("execute_typescript not registered in this configuration")
+
+        with patch(
+            "canvas_mcp.tools.code_execution._detect_container_runtime",
+            return_value="docker",
+        ), patch(
+            "canvas_mcp.tools.code_execution._runtime_available",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "canvas_mcp.tools.code_execution.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=_mock_process(),
+        ) as spawn:
+            await tool(code="console.log(1)")
+
+        cmd = list(spawn.call_args.args)
+        assert "--user" in cmd
+        uid_gid = cmd[cmd.index("--user") + 1]
+        assert uid_gid == configured_uid_gid, (
+            f"expected configured {configured_uid_gid}, got {uid_gid}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_uid_gid_rejected_with_default(self):
+        """A malformed TS_SANDBOX_UID_GID falls back to the default.
+
+        validate_config() warns and resets to 65532:65532 when the value
+        does not match the <uid>:<gid> numeric pattern.
+        """
+        tool = get_execute_typescript(
+            TS_SANDBOX_MODE="container", TS_SANDBOX_UID_GID="not-a-number"
+        )
+        if tool is None:
+            pytest.skip("execute_typescript not registered in this configuration")
+
+        # Trigger the startup validation that resets malformed values
+        validate_config()
+
+        with patch(
+            "canvas_mcp.tools.code_execution._detect_container_runtime",
+            return_value="docker",
+        ), patch(
+            "canvas_mcp.tools.code_execution._runtime_available",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "canvas_mcp.tools.code_execution.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=_mock_process(),
+        ) as spawn:
+            await tool(code="console.log(1)")
+
+        cmd = list(spawn.call_args.args)
+        assert "--user" in cmd
+        uid_gid = cmd[cmd.index("--user") + 1]
+        assert uid_gid == "65532:65532", (
+            f"malformed value should fall back to default 65532:65532, got {uid_gid}"
+        )
+
+    @pytest.mark.parametrize(
+        "root_uid_gid",
+        ["0:0", "0:65532", "65532:0", "00:00", "00:65532", "65532:00"],
+    )
+    @pytest.mark.asyncio
+    async def test_root_uid_gid_rejected_with_default(self, root_uid_gid):
+        """Any numeric representation of a zero uid or gid falls back safely.
+
+        validate_config() warns and resets to 65532:65532 when the value
+        would run the sandbox as root, undoing the non-root protection
+        from PR #317.
+        """
+        tool = get_execute_typescript(
+            TS_SANDBOX_MODE="container", TS_SANDBOX_UID_GID=root_uid_gid
+        )
+        if tool is None:
+            pytest.skip("execute_typescript not registered in this configuration")
+
+        # Trigger the startup validation that resets root uid:gid values
+        validate_config()
+
+        with patch(
+            "canvas_mcp.tools.code_execution._detect_container_runtime",
+            return_value="docker",
+        ), patch(
+            "canvas_mcp.tools.code_execution._runtime_available",
+            new=AsyncMock(return_value=True),
+        ), patch(
+            "canvas_mcp.tools.code_execution.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=_mock_process(),
+        ) as spawn:
+            await tool(code="console.log(1)")
+
+        cmd = list(spawn.call_args.args)
+        assert "--user" in cmd
+        uid_gid = cmd[cmd.index("--user") + 1]
+        assert uid_gid == "65532:65532", (
+            f"{root_uid_gid} should fall back to default 65532:65532, got {uid_gid}"
         )
 


### PR DESCRIPTION
## Summary

Recreates #340 on the base repository because the GitHub integration cannot push to the contributor's fork.

- add `TS_SANDBOX_UID_GID` with the secure `65532:65532` default
- validate the `uid:gid` format
- reject numeric zero in either component, including leading-zero forms such as `00:00` and `00:65532`
- preserve valid nonzero leading-zero values such as `010:010`
- pass the validated value to the container runtime
- document the setting and add regression coverage

This carries forward the work by @k0shir0 in #340; the commit retains co-author attribution.

Closes #338
Supersedes #340