### PR TITLE
chore: migrate to FastMCP 4 and MCP SDK 2

### DIFF
--- a/.github/workflows/canvas-mcp-testing.yml
+++ b/.github/workflows/canvas-mcp-testing.yml
@@ -56,6 +56,10 @@ jobs:
   # break on the oldest one is invisible on a newer-only runner.
   test:
     runs-on: ubuntu-latest
+    env:
+      # FastMCP 4 temporarily bridges MCP SDK v1 camelCase attribute reads.
+      # Keep the bridge off in CI so new code must use the v2 snake_case API.
+      FASTMCP_MCP_CAMELCASE_COMPAT: "false"
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrated to FastMCP 4 and MCP SDK 2. Protocol-model attribute reads now use
+  the SDK's native snake_case API, and CI disables FastMCP's temporary
+  camelCase compatibility bridge to prevent regressions. Canvas API clients
+  continue to use `httpx`; they are independent of FastMCP's `httpx2` transport
+  stack ([issue 142](https://github.com/vishalsachdev/canvas-mcp/issues/142)).
+
 ## [1.12.0] — 2026-08-30
 
 ### Breaking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,9 @@ See: [Issue #56](https://github.com/vishalsachdev/canvas-mcp/issues/56) for comp
   patched 2026-07-31**: merging a brief closed #172, because it described another PR as `fixes #172`
   and GitHub parses closing keywords anywhere in a merged PR body. Routine now forbids them *and*
   greps its own output before opening the PR (#172 reopened)
-- [ ] Issue #142 → **watch item, unassigned** (`blocked-upstream`): `fastmcp-slim` 3.4.5 still pins `mcp<2.0`, so relaxing our pin cannot resolve; `mcp` 2.0.0 stable has shipped. Scope collapsed since #167 removed the FastMCP→MCPServer rename — hours, not a day. Trigger: a fastmcp release lifting `mcp<2.0`
+- [x] Issue #142 → FastMCP 4 / MCP SDK 2 migration complete: dependency
+  constraints and lockfile upgraded, protocol-model reads use native snake_case,
+  and CI runs with the temporary camelCase compatibility bridge disabled
 - [x] Issue #145 / PR #167: fastmcp 3.4.4 migration — **DONE 2026-07-21** (CVEs PYSEC-2026-2475/2476 resolved; dep-scan green; staging-validated then prod-deployed + live-verified; #145 closed)
 - [ ] Issue #157: `execute_typescript` sandbox hardening backlog (container-level egress, non-root user, prebuilt tsx image) — **self-hosted-only now**: tool is DISABLED on both hosted slots (`EXECUTE_TYPESCRIPT_ENABLED=false`, verified 2026-07-10); gate on re-enabling hosted code-exec
 - [ ] **Agent Plugins ([agent-plugins.org](https://agent-plugins.org)) → watch item, no owner.** Spec 1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
 ]
 keywords = ["canvas", "lms", "mcp", "claude", "education", "api"]
 dependencies = [
-    "fastmcp>=3.4.7,<4",
-    "mcp>=1.26.0,<2",
+    "fastmcp>=4,<5",
+    "mcp>=2,<3",
     "httpx>=0.28.1,<1",
     "python-dotenv>=1.2.2,<2",
     "pydantic>=2.13.1,<3",

--- a/src/canvas_mcp/tools/accessibility.py
+++ b/src/canvas_mcp/tools/accessibility.py
@@ -39,7 +39,7 @@ def register_accessibility_tools(mcp: FastMCP) -> None:
 def _register_ufixit_tools(mcp: FastMCP) -> None:
     """UFIXIT/UDOIT report pipeline — requires the add-on on the instance."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def fetch_ufixit_report(
         course_identifier: str | int,
@@ -100,7 +100,7 @@ def _register_ufixit_tools(mcp: FastMCP) -> None:
             "course_id": course_id
         })
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def parse_ufixit_violations(report_json: str) -> str:
         """Parse UFIXIT report content to extract accessibility violations.
@@ -145,7 +145,7 @@ def _register_ufixit_tools(mcp: FastMCP) -> None:
             }
         })
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def format_accessibility_summary(violations_json: str) -> str:
         """Format parsed violations into a human-readable summary.
@@ -224,7 +224,7 @@ def _register_ufixit_tools(mcp: FastMCP) -> None:
 def _register_builtin_scanner_tools(mcp: FastMCP) -> None:
     """Add-on-free scanner over Canvas page/assignment HTML."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def scan_course_content_accessibility(
         course_identifier: str | int,
@@ -292,7 +292,7 @@ def _register_builtin_scanner_tools(mcp: FastMCP) -> None:
             "scanned_types": types
         })
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def fix_accessibility_issues(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/admin_tools.py
+++ b/src/canvas_mcp/tools/admin_tools.py
@@ -14,7 +14,7 @@ from ..core.validation import validate_params
 def register_admin_tools(mcp: FastMCP) -> None:
     """Register admin/developer MCP tools."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     async def get_anonymization_status() -> str:
         """Get current data anonymization status and statistics."""
         from ..core.anonymization import get_anonymization_stats
@@ -52,7 +52,7 @@ def register_admin_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_groups(course_identifier: str | int) -> str:
         """List all groups and their members for a specific course.
@@ -118,7 +118,7 @@ def register_admin_tools(mcp: FastMCP) -> None:
 
         return output
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_users(course_identifier: str) -> str:
         """List users enrolled in a specific course.
@@ -165,7 +165,7 @@ def register_admin_tools(mcp: FastMCP) -> None:
         course_display = await get_course_code(course_id) or course_identifier
         return f"Users in Course {course_display}:\n\n" + "\n".join(users_info)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_student_analytics(course_identifier: str,
                                   include_participation: bool = True,
@@ -295,7 +295,7 @@ def register_admin_tools(mcp: FastMCP) -> None:
 
         return "\n".join(lines)
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def create_student_anonymization_map(course_identifier: str | int) -> str:
         """Create a local CSV file mapping real student data to anonymous IDs for a course.

--- a/src/canvas_mcp/tools/assignments.py
+++ b/src/canvas_mcp/tools/assignments.py
@@ -31,7 +31,7 @@ _DELETE_ASSIGNMENT_GUARD = ConfirmationGuard(nothing_done="Nothing was deleted."
 def register_shared_assignment_tools(mcp: FastMCP) -> None:
     """Register assignment tools accessible to both students and educators."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_assignments(course_identifier: str | int) -> str:
         """List assignments for a specific course.
@@ -72,7 +72,7 @@ def register_shared_assignment_tools(mcp: FastMCP) -> None:
         course_display = await get_course_code(course_id) or course_identifier
         return f"Assignments for Course {course_display}:\n\n" + "\n".join(assignments_info)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_assignment_details(course_identifier: str | int, assignment_id: str | int) -> str:
         """Get detailed information about a specific assignment.
@@ -114,7 +114,7 @@ def register_shared_assignment_tools(mcp: FastMCP) -> None:
 def register_educator_assignment_tools(mcp: FastMCP) -> None:
     """Register educator-only assignment tools (grading, analytics, management)."""
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def assign_peer_review(course_identifier: str, assignment_id: str, reviewer_id: str, reviewee_id: str) -> str:
         """Manually assign a peer review to a student for a specific assignment.
@@ -191,7 +191,7 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
                f"Reviewee ID: {reviewee_id}\n" + \
                f"Submission ID: {submission_id}"
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_peer_reviews(course_identifier: str, assignment_id: str) -> str:
         """List all peer review assignments for a specific assignment.
@@ -299,7 +299,7 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
 
         return output
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_submissions(course_identifier: str | int, assignment_id: str | int) -> str:
         """List submissions for a specific assignment.
@@ -345,7 +345,7 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
         course_display = await get_course_code(course_id) or course_identifier
         return f"Submissions for Assignment {assignment_id} in course {course_display}:\n\n" + "\n".join(submissions_info)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_assignment_analytics(course_identifier: str | int, assignment_id: str | int) -> str:
         """Get detailed analytics about student performance on a specific assignment.
@@ -610,7 +610,7 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
 
         return output
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def create_assignment(
         course_identifier: str | int,
@@ -768,7 +768,7 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def update_assignment(
         course_identifier: str | int,
@@ -933,7 +933,7 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def delete_assignment_with_confirmation(
         course_identifier: str | int,
@@ -1011,7 +1011,7 @@ def register_educator_assignment_tools(mcp: FastMCP) -> None:
             f"  Status: deleted (submissions and grades removed with it)"
         )
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False))
     @validate_params
     async def bulk_grade_submissions(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/code_execution.py
+++ b/src/canvas_mcp/tools/code_execution.py
@@ -354,7 +354,7 @@ def register_code_execution_tools(mcp: FastMCP) -> None:
     # endpoint the token reaches. Nothing here can be inspected ahead of time,
     # so both hints take their most conservative value: assume it replaces data
     # and assume repeating it does more (issue #204).
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False))
     @validate_params
     async def execute_typescript(
         code: str,
@@ -771,7 +771,7 @@ def register_code_execution_tools(mcp: FastMCP) -> None:
             except Exception:
                 pass  # Ignore cleanup errors
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_code_api_modules() -> str:
         """List all available TypeScript modules in the code execution API.

--- a/src/canvas_mcp/tools/content_migrations.py
+++ b/src/canvas_mcp/tools/content_migrations.py
@@ -252,7 +252,7 @@ def register_content_migration_tools(mcp: FastMCP) -> None:
     """Register educator-only content migration tools."""
 
     @mcp.tool(
-        annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False)
+        annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False)
     )
     @validate_params
     async def create_content_migration(
@@ -381,7 +381,7 @@ def register_content_migration_tools(mcp: FastMCP) -> None:
             "next_action": _next_status_action(target_id, migration_id),
         }
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_content_migration_status(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/courses.py
+++ b/src/canvas_mcp/tools/courses.py
@@ -147,7 +147,7 @@ def strip_html_tags(html_content: str) -> str:
 def register_course_tools(mcp: FastMCP) -> None:
     """Register all course-related MCP tools."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_courses(
         include_concluded: bool = False, include_all: bool = False
@@ -218,7 +218,7 @@ def register_course_tools(mcp: FastMCP) -> None:
 
         return "Courses:\n\n" + "\n".join(courses_info)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_course_details(course_identifier: str | int) -> str:
         """Get detailed information about a specific course.
@@ -262,7 +262,7 @@ def register_course_tools(mcp: FastMCP) -> None:
         course_display = response.get("course_code", course_identifier)
         return f"Course Details for {course_display}:\n\n" + "\n".join(details)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_syllabus(course_identifier: str | int,
                            output_format: str = "text",
@@ -335,7 +335,7 @@ def register_course_tools(mcp: FastMCP) -> None:
 
         return "\n".join(sections)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_course_content_overview(course_identifier: str | int,
                                         include_pages: bool = True,
@@ -482,7 +482,7 @@ def register_course_tools(mcp: FastMCP) -> None:
 def register_shared_content_tools(mcp: FastMCP) -> None:
     """Register shared content tools (pages, module items) for both students and educators."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_pages(course_identifier: str | int,
                         sort: str | None = "title",
@@ -540,7 +540,7 @@ def register_shared_content_tools(mcp: FastMCP) -> None:
         course_display = await get_course_code(course_id) or course_identifier
         return f"Pages for Course {course_display}:\n\n" + "\n".join(pages_info)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_page_content(course_identifier: str | int, page_url_or_id: str) -> str:
         """Get the full content body of a specific page.
@@ -587,7 +587,7 @@ def register_shared_content_tools(mcp: FastMCP) -> None:
             + fence_untrusted(untrusted, "page title, body, and media inventory")
         )
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_page_details(course_identifier: str | int, page_url_or_id: str) -> str:
         """Get a specific page's metadata plus a short text preview.
@@ -681,7 +681,7 @@ def register_shared_content_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_front_page(course_identifier: str | int) -> str:
         """Get the front page content for a course.
@@ -713,7 +713,7 @@ def register_shared_content_tools(mcp: FastMCP) -> None:
             + fence_untrusted(f"Title: {title}\n\n{body}", "front page title and body")
         )
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_module_items(course_identifier: str | int,
                                module_id: str | int,

--- a/src/canvas_mcp/tools/discovery.py
+++ b/src/canvas_mcp/tools/discovery.py
@@ -86,7 +86,7 @@ async def _search_mcp_tools(
 def register_discovery_tools(mcp: FastMCP) -> None:
     """Register tool discovery tools."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def search_canvas_tools(
         query: str = "",

--- a/src/canvas_mcp/tools/discussions.py
+++ b/src/canvas_mcp/tools/discussions.py
@@ -64,7 +64,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
 
     # ===== DISCUSSION TOOLS =====
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_discussion_topics(course_identifier: str | int,
                                    include_announcements: bool = False) -> str:
@@ -140,7 +140,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
         course_display = await get_course_code(course_id) or course_identifier
         return f"Discussion Topics for Course {course_display}:\n\n" + "\n".join(topics_info)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_announcements(course_identifier: str) -> str:
         """List a course's announcements, and nothing else.
@@ -185,7 +185,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
         course_display = await get_course_code(course_id) or course_identifier
         return f"Announcements for Course {course_display}:\n\n" + "\n".join(announcements_info)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_discussion_topic_details(course_identifier: str | int,
                                          topic_id: str | int) -> str:
@@ -258,7 +258,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_discussion_entries(course_identifier: str | int,
                                     topic_id: str | int,
@@ -482,7 +482,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
             + footer
         )
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_discussion_entry_details(course_identifier: str | int,
                                          topic_id: str | int,
@@ -660,7 +660,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_discussion_with_replies(course_identifier: str | int,
                                         topic_id: str | int,
@@ -797,7 +797,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def post_discussion_entry(course_identifier: str | int,
                                   topic_id: str | int,
@@ -860,7 +860,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def reply_to_discussion_entry(course_identifier: str | int,
                                       topic_id: str | int,
@@ -910,7 +910,7 @@ def register_shared_discussion_tools(mcp: FastMCP) -> None:
 def register_educator_discussion_tools(mcp: FastMCP) -> None:
     """Register educator-only discussion and announcement tools."""
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def create_discussion_topic(course_identifier: str | int,
                                     title: str,
@@ -972,7 +972,7 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
                f"Title: {topic_title}\n" + \
                f"Created: {created_at}"
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def update_discussion_topic(
         course_identifier: str | int,
@@ -1081,7 +1081,7 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
 
     # ===== ANNOUNCEMENT TOOLS =====
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def create_announcement(course_identifier: str | int,
                                 title: str,
@@ -1216,7 +1216,7 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
     # matching and nothing is deleted. The un-tokened delete_announcement was
     # retired in the same pass.
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def delete_announcement_with_confirmation(
         course_identifier: str | int,
@@ -1285,7 +1285,7 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
             result += "Title matched: True\n"
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def bulk_delete_announcements(
         course_identifier: str | int,
@@ -1411,7 +1411,7 @@ def register_educator_discussion_tools(mcp: FastMCP) -> None:
     # Idempotent since #318: the token is bound to the exact matched id set and
     # is single-use, so an identical retry either previews (no token) or is
     # refused (spent token) — it can no longer delete the NEXT batch.
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def delete_announcements_by_criteria(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/enrollment.py
+++ b/src/canvas_mcp/tools/enrollment.py
@@ -26,7 +26,7 @@ from ..core.validation import validate_params
 def register_enrollment_tools(mcp: FastMCP) -> None:
     """Register the enrollment-check MCP tool."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def check_enrollment(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/files.py
+++ b/src/canvas_mcp/tools/files.py
@@ -41,7 +41,7 @@ from ..core.validation import validate_params
 def register_shared_file_tools(mcp: FastMCP) -> None:
     """Register file tools accessible to both students and educators."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def download_course_file(
         course_identifier: str | int,
@@ -159,7 +159,7 @@ def register_shared_file_tools(mcp: FastMCP) -> None:
         result += f"  Course: {course_display}\n"
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def read_course_file(
         course_identifier: str | int,
@@ -250,7 +250,7 @@ def register_shared_file_tools(mcp: FastMCP) -> None:
         except Exception as e:
             return f"Error reading file: {str(e)}"
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_course_files(
         course_identifier: str | int,
@@ -315,7 +315,7 @@ def register_shared_file_tools(mcp: FastMCP) -> None:
 def register_educator_file_tools(mcp: FastMCP) -> None:
     """Register educator-only file tools (upload)."""
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False))
     @validate_params
     async def upload_course_file(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/messaging.py
+++ b/src/canvas_mcp/tools/messaging.py
@@ -312,7 +312,7 @@ Please complete your peer reviews as soon as possible to receive full participat
 def register_shared_messaging_tools(mcp: FastMCP) -> None:
     """Register messaging tools accessible to both students and educators."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_conversations(
         scope: str = "unread",
@@ -370,7 +370,7 @@ def register_shared_messaging_tools(mcp: FastMCP) -> None:
             print(f"Error listing conversations: {str(e)}", file=sys.stderr)
             return {"error": f"Failed to list conversations: {str(e)}"}
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_conversation_details(
         conversation_id: str | int,
@@ -418,7 +418,7 @@ def register_shared_messaging_tools(mcp: FastMCP) -> None:
             print(f"Error getting conversation details: {str(e)}", file=sys.stderr)
             return {"error": f"Failed to get conversation details: {str(e)}"}
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     async def get_unread_count() -> dict[str, Any]:
         """Get number of unread conversations."""
 
@@ -438,7 +438,7 @@ def register_shared_messaging_tools(mcp: FastMCP) -> None:
             print(f"Error getting unread count: {str(e)}", file=sys.stderr)
             return {"error": f"Failed to get unread count: {str(e)}"}
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=True))
     @validate_params
     async def mark_conversations_read(conversation_ids: list[str]) -> dict[str, Any]:
         """
@@ -481,7 +481,7 @@ def register_shared_messaging_tools(mcp: FastMCP) -> None:
 def register_educator_messaging_tools(mcp: FastMCP) -> None:
     """Register educator-only messaging tools (send, bulk, campaigns)."""
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def send_conversation(
         course_identifier: str | int,
@@ -620,7 +620,7 @@ def register_educator_messaging_tools(mcp: FastMCP) -> None:
             print(f"Error sending conversation: {str(e)}", file=sys.stderr)
             return {"error": f"Failed to send conversation: {str(e)}"}
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def send_peer_review_inbox_messages(
         course_identifier: str | int,
@@ -785,7 +785,7 @@ def register_educator_messaging_tools(mcp: FastMCP) -> None:
                 "nothing_sent": True,
             }
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def send_bulk_messages_from_list(
         course_identifier: str | int,
@@ -949,7 +949,7 @@ def register_educator_messaging_tools(mcp: FastMCP) -> None:
             print(f"Error sending bulk messages: {str(e)}", file=sys.stderr)
             return {"error": f"Failed to send bulk messages: {str(e)}"}
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def send_peer_review_followup_campaign(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/modules.py
+++ b/src/canvas_mcp/tools/modules.py
@@ -32,7 +32,7 @@ _DELETE_MODULE_ITEM_GUARD = ConfirmationGuard(nothing_done="Nothing was deleted.
 def register_shared_module_tools(mcp: FastMCP) -> None:
     """Register module tools accessible to both students and educators."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_modules(
         course_identifier: str | int,
@@ -108,7 +108,7 @@ def register_shared_module_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_course_structure(
         course_identifier: str | int,
@@ -217,7 +217,7 @@ def register_shared_module_tools(mcp: FastMCP) -> None:
 def register_educator_module_tools(mcp: FastMCP) -> None:
     """Register educator-only module management tools."""
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def create_module(
         course_identifier: str | int,
@@ -303,7 +303,7 @@ def register_educator_module_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def update_module(
         course_identifier: str | int,
@@ -401,7 +401,7 @@ def register_educator_module_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def delete_module(
         course_identifier: str | int,
@@ -456,7 +456,7 @@ def register_educator_module_tools(mcp: FastMCP) -> None:
         result += f"  Items affected: {items_count} (items unlinked, content preserved)\n"
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def add_module_item(
         course_identifier: str | int,
@@ -605,7 +605,7 @@ def register_educator_module_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def update_module_item(
         course_identifier: str | int,
@@ -721,7 +721,7 @@ def register_educator_module_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def delete_module_item(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/pages.py
+++ b/src/canvas_mcp/tools/pages.py
@@ -81,7 +81,7 @@ def _notify_of_update_warning(response: dict[str, Any]) -> str:
 def register_page_tools(mcp: FastMCP) -> None:
     """Register page settings MCP tools."""
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False))
     @validate_params
     async def update_page_settings(
         course_identifier: str | int,
@@ -166,7 +166,7 @@ def register_page_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False))
     @validate_params
     async def bulk_update_pages(
         course_identifier: str | int,
@@ -288,7 +288,7 @@ def register_educator_page_crud_tools(mcp: FastMCP) -> None:
 
     # front_page=True displaces the course's CURRENT front page -- Canvas
     # allows only one -- so the whole effect is not additive (#204).
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False))
     @validate_params
     async def create_page(course_identifier: str | int,
                          title: str,
@@ -347,7 +347,7 @@ def register_educator_page_crud_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def edit_page_content(course_identifier: str | int,
                                page_url_or_id: str,
@@ -397,7 +397,7 @@ def register_educator_page_crud_tools(mcp: FastMCP) -> None:
 
         return f"Successfully updated page '{page_title}' in course {course_display}. Last updated: {updated_at}"
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=True))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
     @validate_params
     async def delete_page(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/peer_review_comments.py
+++ b/src/canvas_mcp/tools/peer_review_comments.py
@@ -67,7 +67,7 @@ def _peer_review_csv_row(review: dict[str, Any]) -> list[Any]:
 def register_peer_review_comment_tools(mcp: FastMCP) -> None:
     """Register all peer review comment analysis MCP tools."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_peer_review_comments(
         course_identifier: str | int,
@@ -109,7 +109,7 @@ def register_peer_review_comment_tools(mcp: FastMCP) -> None:
         except Exception as e:
             return f"Error in get_peer_review_comments: {str(e)}"
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def analyze_peer_review_quality(
         course_identifier: str | int,
@@ -153,7 +153,7 @@ def register_peer_review_comment_tools(mcp: FastMCP) -> None:
         except Exception as e:
             return f"Error in analyze_peer_review_quality: {str(e)}"
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def identify_problematic_peer_reviews(
         course_identifier: str | int,
@@ -194,7 +194,7 @@ def register_peer_review_comment_tools(mcp: FastMCP) -> None:
         except Exception as e:
             return f"Error in identify_problematic_peer_reviews: {str(e)}"
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def extract_peer_review_dataset(
         course_identifier: str | int,
@@ -313,7 +313,7 @@ def register_peer_review_comment_tools(mcp: FastMCP) -> None:
         except Exception as e:
             return f"Error in extract_peer_review_dataset: {str(e)}"
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def generate_peer_review_feedback_report(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/peer_reviews.py
+++ b/src/canvas_mcp/tools/peer_reviews.py
@@ -36,7 +36,7 @@ def _fence_peer_review_names(result: object) -> None:
 def register_peer_review_tools(mcp: FastMCP) -> None:
     """Register all peer review analytics MCP tools."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_peer_review_assignments(
         course_identifier: str | int,
@@ -72,7 +72,7 @@ def register_peer_review_tools(mcp: FastMCP) -> None:
         except Exception as e:
             return f"Error in get_peer_review_assignments: {str(e)}"
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_peer_review_completion_analytics(
         course_identifier: str | int,
@@ -108,7 +108,7 @@ def register_peer_review_tools(mcp: FastMCP) -> None:
         except Exception as e:
             return f"Error in get_peer_review_completion_analytics: {str(e)}"
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def generate_peer_review_report(
         course_identifier: str | int,
@@ -195,7 +195,7 @@ def register_peer_review_tools(mcp: FastMCP) -> None:
         except Exception as e:
             return f"Error in generate_peer_review_report: {str(e)}"
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_peer_review_followup_list(
         course_identifier: str | int,

--- a/src/canvas_mcp/tools/rubrics.py
+++ b/src/canvas_mcp/tools/rubrics.py
@@ -515,7 +515,7 @@ async def _ensure_course_bookmark(response: Any, course_id: str | int) -> str:
 def register_rubric_tools(mcp: FastMCP) -> None:
     """Register all rubric-related MCP tools."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_rubric(course_identifier: str | int,
                          rubric_id: str | int | None = None,
@@ -682,7 +682,7 @@ def register_rubric_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_rubric_assessment(course_identifier: str | int,
                                              assignment_id: str | int,
@@ -796,7 +796,7 @@ def register_rubric_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False))
     @validate_params
     async def grade_with_rubric(course_identifier: str | int,
                               assignment_id: str | int,
@@ -910,7 +910,7 @@ def register_rubric_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def list_rubrics(course_identifier: str | int,
                               include_criteria: bool = True) -> str:
@@ -1004,7 +1004,7 @@ def register_rubric_tools(mcp: FastMCP) -> None:
 
         return result
 
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
     @validate_params
     async def create_rubric_from_csv(
         course_identifier: str | int,
@@ -1126,7 +1126,7 @@ def register_rubric_tools(mcp: FastMCP) -> None:
 
     # With assignment_id, this creates a rubric_association on that
     # assignment, REPLACING any rubric already attached to it (#204).
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False))
     @validate_params
     async def create_rubric(
         course_identifier: str | int,
@@ -1244,7 +1244,7 @@ def register_rubric_tools(mcp: FastMCP) -> None:
 
     # Replaces the assignment's existing rubric association, and overwrites
     # use_for_grading / purpose even when re-associating the same rubric (#204).
-    @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False))
     @validate_params
     async def associate_rubric(course_identifier: str | int,
                                              rubric_id: str | int,

--- a/src/canvas_mcp/tools/self_identity.py
+++ b/src/canvas_mcp/tools/self_identity.py
@@ -43,7 +43,7 @@ def _own_roles(course: dict) -> list[str]:
 def register_self_identity_tools(mcp: FastMCP) -> None:
     """Register the caller-scoped identity tools (all role profiles)."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_my_enrollments(include_concluded: bool = False) -> str:
         """List the courses YOU are enrolled in, with your role in each.
@@ -112,7 +112,7 @@ def register_self_identity_tools(mcp: FastMCP) -> None:
         )
         return header + "\n".join(lines) + footer
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_my_profile() -> str:
         """Get YOUR own Canvas identity (user ID, name, login ID).

--- a/src/canvas_mcp/tools/student_tools.py
+++ b/src/canvas_mcp/tools/student_tools.py
@@ -127,7 +127,7 @@ async def _fetch_planner_peer_reviews(
 def register_student_tools(mcp: FastMCP) -> None:
     """Register student-specific MCP tools."""
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_my_upcoming_assignments(days: int = 7) -> str:
         """Get your upcoming assignments across all courses.
@@ -215,7 +215,7 @@ def register_student_tools(mcp: FastMCP) -> None:
 
         return "\n".join(output_lines)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_my_submission_status(course_identifier: str | int | None = None) -> str:
         """Get your submission status for assignments.
@@ -323,7 +323,7 @@ def register_student_tools(mcp: FastMCP) -> None:
 
         return "\n".join(output_lines)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     async def get_my_course_grades() -> str:
         """Get your current grades across all enrolled courses."""
         courses = await fetch_all_paginated_results(
@@ -377,7 +377,7 @@ def register_student_tools(mcp: FastMCP) -> None:
 
         return "\n".join(output_lines)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     async def get_my_todo_items() -> str:
         """Get your Canvas TODO list."""
         todos = await fetch_all_paginated_results(
@@ -412,7 +412,7 @@ def register_student_tools(mcp: FastMCP) -> None:
 
         return "\n".join(output_lines)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_my_peer_reviews_todo(
         course_identifier: str | int | None = None,

--- a/src/canvas_mcp/tools/student_write.py
+++ b/src/canvas_mcp/tools/student_write.py
@@ -639,7 +639,7 @@ def register_student_write_tools(mcp: FastMCP) -> None:
     """
     enabled = get_config().student_write_tools
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     @validate_params
     async def get_my_submission(
         course_identifier: str | int,
@@ -709,7 +709,7 @@ def register_student_write_tools(mcp: FastMCP) -> None:
 
     if "submit_assignment" in enabled:
 
-        @mcp.tool(annotations=ToolAnnotations(destructiveHint=True, idempotentHint=False))
+        @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=False))
         @validate_params
         async def submit_assignment(
             course_identifier: str | int,
@@ -963,7 +963,7 @@ def register_student_write_tools(mcp: FastMCP) -> None:
 
     if "comment_on_my_submission" in enabled:
 
-        @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=False))
+        @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=False))
         @validate_params
         async def comment_on_my_submission(
             course_identifier: str | int,
@@ -1015,7 +1015,7 @@ def register_student_write_tools(mcp: FastMCP) -> None:
 
     if "mark_module_item_done" in enabled:
 
-        @mcp.tool(annotations=ToolAnnotations(destructiveHint=False, idempotentHint=True))
+        @mcp.tool(annotations=ToolAnnotations(destructive_hint=False, idempotent_hint=True))
         @validate_params
         async def mark_module_item_done(
             course_identifier: str | int,

--- a/tests/core/test_tool_results.py
+++ b/tests/core/test_tool_results.py
@@ -19,11 +19,11 @@ def _result_server() -> FastMCP:
     mcp = FastMCP("tool-result-contract")
     install_tool_result_contract(mcp)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     async def text_result(value: str) -> str:
         return value
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     async def dict_result(fail: bool) -> dict[str, Any]:
         if fail:
             return {"error": "boom", "nothing_sent": True}
@@ -31,7 +31,7 @@ def _result_server() -> FastMCP:
 
     @mcp.tool(
         output_schema=_EXPLICIT_TEXT_SCHEMA,
-        annotations=ToolAnnotations(readOnlyHint=True),
+        annotations=ToolAnnotations(read_only_hint=True),
     )
     async def explicit_text(value: str) -> str:
         return value
@@ -92,7 +92,7 @@ async def test_string_result_has_one_text_surface_and_no_structured_duplicate():
             "text_result", {"value": "single copy"}, raise_on_error=False
         )
 
-    assert tools["text_result"].outputSchema is None
+    assert tools["text_result"].output_schema is None
     assert result.structured_content is None
     assert len(result.content) == 1
     assert getattr(result.content[0], "text", None) == "single copy"
@@ -106,7 +106,7 @@ async def test_dictionary_tool_retains_schema_and_structured_content():
             "dict_result", {"fail": False}, raise_on_error=False
         )
 
-    assert tools["dict_result"].outputSchema is not None
+    assert tools["dict_result"].output_schema is not None
     assert result.structured_content == {
         "success": True,
         "detail": {"error": "quoted example"},
@@ -121,7 +121,7 @@ async def test_installing_contract_twice_does_not_double_wrap_registration():
     install_tool_result_contract(mcp)
     install_tool_result_contract(mcp)
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     async def once() -> str:
         return "one"
 
@@ -142,7 +142,7 @@ async def test_explicit_string_schema_is_respected_and_legacy_wrapper_errors():
             raise_on_error=False,
         )
 
-    assert tools["explicit_text"].outputSchema["x-fastmcp-wrap-result"] is True
+    assert tools["explicit_text"].output_schema["x-fastmcp-wrap-result"] is True
     assert result.structured_content == {"result": "Error: explicit schema failure"}
     assert result.is_error is True
 

--- a/tests/security/test_untrusted_content_registry.py
+++ b/tests/security/test_untrusted_content_registry.py
@@ -31,7 +31,7 @@ async def test_every_read_tool_declares_and_keeps_its_untrusted_content_policy()
     read_tools = {
         tool.name: tool
         for tool in await mcp.list_tools(run_middleware=False)
-        if tool.annotations and tool.annotations.readOnlyHint
+        if tool.annotations and tool.annotations.read_only_hint
     }
     policies = getattr(untrusted_content, "READ_TOOL_CONTENT_POLICIES", {})
 

--- a/tests/test_fastmcp_compat.py
+++ b/tests/test_fastmcp_compat.py
@@ -1,7 +1,7 @@
 """Characterization tests for the fastmcp APIs this codebase relies on.
 
-These pin the exact upstream behaviors the migration (issue #145) assumes,
-originally written against fastmcp 2.x and revalidated on 3.x. If a fastmcp
+These pin the exact upstream behaviors the migration (issue #142) assumes,
+originally written against fastmcp 2.x and revalidated on 3.x and 4.x. If a fastmcp
 upgrade breaks one of these, it breaks the server the same way.
 """
 
@@ -13,7 +13,7 @@ from mcp.types import ToolAnnotations
 def _make_server() -> FastMCP:
     mcp = FastMCP(name="compat-test")
 
-    @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+    @mcp.tool(annotations=ToolAnnotations(read_only_hint=True))
     async def sample_tool(course_identifier: str) -> str:
         """A sample tool."""
         return f"ok:{course_identifier}"
@@ -40,7 +40,7 @@ async def test_tool_registration_and_annotations():
         tools = await client.list_tools()
         tool = next(t for t in tools if t.name == "sample_tool")
         assert tool.annotations is not None
-        assert tool.annotations.readOnlyHint is True
+        assert tool.annotations.read_only_hint is True
         result = await client.call_tool(
             "sample_tool", {"course_identifier": "badm_350"}
         )
@@ -52,7 +52,7 @@ async def test_resource_template_with_keyword_uri():
     mcp = _make_server()
     async with Client(mcp) as client:
         templates = await client.list_resource_templates()
-        assert any("canvas://course/" in t.uriTemplate for t in templates)
+        assert any("canvas://course/" in t.uri_template for t in templates)
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_metadata.py
+++ b/tests/test_tool_metadata.py
@@ -1,16 +1,16 @@
 """Tool-annotation contract (issues #200, #204).
 
 Every registered tool must declare what it does to the world. A read tool says
-``readOnlyHint=True``; a write tool must answer both remaining questions —
-whether it replaces existing data (``destructiveHint``) and whether repeating it
-changes anything (``idempotentHint``).
+``read_only_hint=True``; a write tool must answer both remaining questions —
+whether it replaces existing data (``destructive_hint``) and whether repeating it
+changes anything (``idempotent_hint``).
 
 The point of the first test is that a NEW tool cannot land without making those
 declarations: an unannotated tool fails CI rather than shipping bare, which is
 how #200 happened in the first place. Enumerating the live registry rather than
 a hand-maintained list is what makes that work.
 
-Semantics follow the MCP spec, not a local convention: ``destructiveHint=False``
+Semantics follow the MCP spec, not a local convention: ``destructive_hint=False``
 asserts the tool performs ONLY ADDITIVE updates, so a tool that overwrites grades
 or replaces a page body is destructive even though it deletes nothing.
 """
@@ -174,28 +174,28 @@ async def test_every_tool_declares_its_effect_on_the_world():
         if annotations is None:
             undeclared.append(f"{tool.name}: no annotations at all")
             continue
-        if annotations.readOnlyHint:
+        if annotations.read_only_hint:
             continue
-        if annotations.destructiveHint is None:
-            undeclared.append(f"{tool.name}: write tool missing destructiveHint")
-        if annotations.idempotentHint is None:
-            undeclared.append(f"{tool.name}: write tool missing idempotentHint")
+        if annotations.destructive_hint is None:
+            undeclared.append(f"{tool.name}: write tool missing destructive_hint")
+        if annotations.idempotent_hint is None:
+            undeclared.append(f"{tool.name}: write tool missing idempotent_hint")
 
     assert not undeclared, (
-        "every tool must declare readOnlyHint, or both destructiveHint and "
-        "idempotentHint (see issue #204):\n  " + "\n  ".join(sorted(undeclared))
+        "every tool must declare read_only_hint, or both destructive_hint and "
+        "idempotent_hint (see issue #204):\n  " + "\n  ".join(sorted(undeclared))
     )
 
 
 @pytest.mark.asyncio
 async def test_tools_that_replace_data_are_marked_destructive():
-    """destructiveHint=False claims 'additive only' — grades say otherwise."""
+    """destructive_hint=False claims 'additive only' — grades say otherwise."""
     tools = {tool.name: tool for tool in await _registry().list_tools()}
 
     for name in DESTRUCTIVE:
         assert name in tools, f"{name} is no longer registered — update this list"
-        assert tools[name].annotations.destructiveHint is True, (
-            f"{name} replaces existing data, so destructiveHint must be True; "
+        assert tools[name].annotations.destructive_hint is True, (
+            f"{name} replaces existing data, so destructive_hint must be True; "
             "False asserts the tool performs only additive updates"
         )
 
@@ -206,7 +206,7 @@ async def test_additive_tools_are_not_marked_destructive():
 
     for name in ADDITIVE:
         assert name in tools, f"{name} is no longer registered — update this list"
-        assert tools[name].annotations.destructiveHint is False, (
+        assert tools[name].annotations.destructive_hint is False, (
             f"{name} only adds; marking it destructive costs users an "
             "unnecessary confirmation"
         )
@@ -217,8 +217,8 @@ async def test_repeatable_tools_declare_idempotency_honestly():
     tools = {tool.name: tool for tool in await _registry().list_tools()}
 
     for name in NOT_IDEMPOTENT:
-        assert tools[name].annotations.idempotentHint is False, (
-            f"{name} produces a duplicate when repeated, so idempotentHint "
+        assert tools[name].annotations.idempotent_hint is False, (
+            f"{name} produces a duplicate when repeated, so idempotent_hint "
             "must be False — a host may otherwise retry it safely"
         )
 
@@ -232,7 +232,7 @@ async def test_repeatable_tools_declare_idempotency_honestly():
     for name in ("update_assignment", "update_module", "update_discussion_topic",
                  "edit_page_content", "delete_page", "bulk_delete_announcements",
                  "delete_announcements_by_criteria", "delete_assignment_with_confirmation"):
-        assert tools[name].annotations.idempotentHint is True, (
+        assert tools[name].annotations.idempotent_hint is True, (
             f"{name} converges on the same end state when repeated"
         )
 
@@ -244,7 +244,7 @@ async def test_read_tools_are_marked_read_only():
 
     for name in ("list_courses", "get_course_details", "check_enrollment",
                  "list_submissions", "get_syllabus", "read_course_file"):
-        assert tools[name].annotations.readOnlyHint is True, (
+        assert tools[name].annotations.read_only_hint is True, (
             f"{name} does not write and should say so"
         )
 
@@ -288,7 +288,7 @@ async def test_list_courses_boolean_parameters_have_descriptions():
     async with Client(_registry()) as client:
         tools = {tool.name: tool for tool in await client.list_tools()}
 
-    properties = tools["list_courses"].inputSchema["properties"]
+    properties = tools["list_courses"].input_schema["properties"]
 
     assert "concluded" in properties["include_concluded"]["description"].lower()
     assert "active" in properties["include_all"]["description"].lower()

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,8 @@ resolution-markers = [
     "python_full_version >= '3.15' and sys_platform != 'win32'",
     "python_full_version == '3.14.*' and sys_platform != 'win32'",
     "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "(python_full_version < '3.12' and sys_platform == 'emscripten') or (python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32')",
 ]
 
 [[package]]
@@ -249,9 +250,9 @@ requires-dist = [
     { name = "azure-communication-email", marker = "extra == 'hosted'", specifier = ">=1.0.0" },
     { name = "azure-data-tables", marker = "extra == 'hosted'", specifier = ">=12.5.0" },
     { name = "azure-identity", marker = "extra == 'hosted'", specifier = ">=1.17.0" },
-    { name = "fastmcp", specifier = ">=3.4.7,<4" },
+    { name = "fastmcp", specifier = ">=4,<5" },
     { name = "httpx", specifier = ">=0.28.1,<1" },
-    { name = "mcp", specifier = ">=1.26.0,<2" },
+    { name = "mcp", specifier = ">=2,<3" },
     { name = "pydantic", specifier = ">=2.13.1,<3" },
     { name = "python-dateutil", specifier = ">=2.9.0,<3" },
     { name = "python-dotenv", specifier = ">=1.2.2,<2" },
@@ -574,21 +575,22 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.4.7"
+version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastmcp-slim", extra = ["client", "server"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/dd/fd444d94ae7afdaf5b6dd168799d34023f576b405872d6a27d5686a9d1f4/fastmcp-3.4.7.tar.gz", hash = "sha256:43117aca886f5ee2f6a569bba91cef02b59c339aad04ba29950ff18d251c822a", size = 28808982, upload-time = "2026-08-10T21:17:55.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5d/1a/bee10aff530338f3b8982a3dd1c377c3ba5d0bc724615bf358422c4e9ecf/fastmcp-4.0.3.tar.gz", hash = "sha256:0dd50baf070105ee4436c245f087ac3c047e655c32d9e783de16d0bf15783a98", size = 42311418, upload-time = "2026-09-05T00:31:36.932Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ac/14/6d950459cc831fa17fe2d1797926b6eb2d2f2af50f830e62d0c098cc1ec8/fastmcp-3.4.7-py3-none-any.whl", hash = "sha256:e4e7698cb4af5bc667b1901685261fa2f3526dc73d243a461fca42500c8dbe56", size = 8016, upload-time = "2026-08-10T21:17:51.391Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/66600db497b3be21cf141f01296308169859d48ed9b1bc8ba7c9d83279b7/fastmcp-4.0.3-py3-none-any.whl", hash = "sha256:f743f43193e1daf606e6497a9dddba5bbaad7df7957a98fd093716ecf4458b99", size = 8076, upload-time = "2026-09-05T00:31:33.957Z" },
 ]
 
 [[package]]
 name = "fastmcp-slim"
-version = "3.4.7"
+version = "4.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "mcp-types" },
     { name = "platformdirs" },
     { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
@@ -596,16 +598,16 @@ dependencies = [
     { name = "rich" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/ac/7924e803368d0758ee4d6b1259066550df78f58f0f9f8bfebd5a123e957d/fastmcp_slim-3.4.7.tar.gz", hash = "sha256:06b32a358320a7dc2b2ee040ba89ea55ddc20763dff2949f384f7974b13b5d8f", size = 594357, upload-time = "2026-08-10T21:17:28.723Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/a9/b7b796b0d4a5e095dadef233833c82ac1136f5c110dd9947b2e9a4988518/fastmcp_slim-4.0.3.tar.gz", hash = "sha256:3ce04a82b82cc41ccb12bb3bb366cfd65b52bc797b8fee332a75da9d480f9b74", size = 685704, upload-time = "2026-09-05T00:31:12.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b4/97/e0e53642cd029a9a7635ae9c548f9f2cc995af5914e487b3df795664e4be/fastmcp_slim-3.4.7-py3-none-any.whl", hash = "sha256:6c931a0089705f3f2935428ef9b2bc74ad94140adc64aab84d116d103e694b3a", size = 769370, upload-time = "2026-08-10T21:17:27.227Z" },
+    { url = "https://files.pythonhosted.org/packages/43/4b/6b31820d87f56d5773538860878c8634b618cd1e9044b3bfbd8a78380a0f/fastmcp_slim-4.0.3-py3-none-any.whl", hash = "sha256:3756ed4bd9f82f40adaf51974b7cdd1463ab6b9f479cf69b69b2692969312b87", size = 859717, upload-time = "2026-09-05T00:31:10.93Z" },
 ]
 
 [package.optional-dependencies]
 client = [
     { name = "authlib" },
     { name = "exceptiongroup" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
@@ -616,7 +618,7 @@ server = [
     { name = "cyclopts" },
     { name = "exceptiongroup" },
     { name = "griffelib" },
-    { name = "httpx" },
+    { name = "httpx2" },
     { name = "joserfc" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -667,6 +669,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -682,12 +697,29 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "python_full_version >= '3.12' and sys_platform == 'emscripten'" },
+    { name = "idna" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -704,7 +736,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.14'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -944,15 +976,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -962,9 +994,22 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/6e/21fb8e5d579dbe21d96ea4d5034200d46d8bdf2261053b5bd041f3c2f612/mcp-2.1.1.tar.gz", hash = "sha256:50b7ba1ebbe117008ea7bdd288234043e69c20b403d6851d19661e6d431a75ef", size = 3984589, upload-time = "2026-08-25T16:14:02.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/50/af/8644cc5fa26a59afd2df2e98eeb19e72926887fa4b7441aba4ff661140db/mcp-2.1.1-py3-none-any.whl", hash = "sha256:1c6c31c5d6471c58db76af3af8af67f46d11d01f0a59077d0a308cbdb3d3e915", size = 357912, upload-time = "2026-08-25T16:13:59.024Z" },
+]
+
+[[package]]
+name = "mcp-types"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/dd/1c4417dc0b722c23a1669032d5f044e41170fe5d4773b488a50fcce98c32/mcp_types-2.1.1.tar.gz", hash = "sha256:77dcbe48fba73cca71a673f2646a5f037a017b7a0a07ac89cec1113028890eda", size = 66674, upload-time = "2026-08-25T16:14:03.861Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/d0/242e63c510f4a17381f55b1549a3f94f5687a0595984febd2b6f87a687a0/mcp_types-2.1.1-py3-none-any.whl", hash = "sha256:26f9f7f03f2a5730717a5b98e2ab7eb640ac352d05a00cdc725c311864778295", size = 69656, upload-time = "2026-08-25T16:14:00.667Z" },
 ]
 
 [[package]]
@@ -1956,8 +2001,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -2000,6 +2045,15 @@ wheels = [
 ]
 
 [[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2022,11 +2076,11 @@ wheels = [
 
 [[package]]
 name = "uncalled-for"
-version = "0.3.2"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5a/92ce0b3ea5481915f55da994c2c2c5f7a3c09949afde196ee89f8ab961aa/uncalled_for-0.4.0.tar.gz", hash = "sha256:335b95bd2422332ec210d518f314a16e4c640921c39fc8bf2ad095bd3538f4af", size = 56979, upload-time = "2026-08-10T14:51:46.247Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/40/97cec87c077eb3291fc7905e6633e08b7ca593c57d30238444bcb6bb3d53/uncalled_for-0.4.0-py3-none-any.whl", hash = "sha256:16c4bb3337532e4bd5569adc192285976f3ad5305402256d34c67a12b5c968bd", size = 15502, upload-time = "2026-08-10T14:51:45.068Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- raise the supported dependency ranges to `fastmcp>=4,<5` and `mcp>=2,<3`, with a regenerated lockfile resolving FastMCP 4.0.3 and MCP SDK 2.1.1
- migrate protocol-model construction and attribute access to MCP SDK 2's native snake_case API
- disable FastMCP's temporary camelCase compatibility bridge in the Python-version CI matrix
- retain `httpx` for Canvas API calls, which are independent from FastMCP's `httpx2` transport stack
- update the changelog and maintainer status notes

## Verification

- `FASTMCP_MCP_CAMELCASE_COMPAT=false uv run python -m pytest tests/ -q` (1,471 passed, 21 skipped)
- `uv run ruff check src/ tests/`
- `uv run mypy src/`
- real subprocess stdio handshake and tool listing (37 student tools)
- real authenticated stateless streamable-HTTP handshake and tool listing (37 student tools)
- `uv lock --check`

Closes #142