### PR TITLE
chore: triage fixes 2026-09-08

### DIFF
--- a/tests/security/test_ferpa_compliance.py
+++ b/tests/security/test_ferpa_compliance.py
@@ -12,6 +12,7 @@ Test Coverage:
 - TC-1.4: Data Retention
 """
 
+import json
 import os
 from unittest.mock import patch
 
@@ -123,12 +124,15 @@ class TestAuditLogging:
             cfg_mod._config = None
             try:
                 init_audit_logging()
-                log_data_access("GET", "/courses/123/users/456", "success")
+                with patch("canvas_mcp.core.audit.datetime") as audit_datetime:
+                    audit_datetime.now.return_value.isoformat.return_value = (
+                        "2026-09-08T04:38:06.123456+00:00"
+                    )
+                    log_data_access("GET", "/courses/123/users/456", "success")
                 captured = capsys.readouterr()
-                assert "data_access" in captured.err
-                # Verify endpoint is sanitized (no raw IDs)
-                assert "123" not in captured.err
-                assert "456" not in captured.err
+                event = json.loads(captured.err)
+                assert event["event_type"] == "data_access"
+                assert event["endpoint"] == "/courses/***/users/***"
             finally:
                 cfg_mod._config = old
                 reset_audit_state()


### PR DESCRIPTION
## Summary

- Make the audit-log redaction test inspect the structured endpoint field and pin a timestamp containing the same digit sequences as the test IDs, eliminating timestamp-driven false failures without changing application behavior.

## Verification

- Red-first reproduction: the old assertion fails deterministically with the pinned timestamp.
- `uv run pytest -q tests/security/test_ferpa_compliance.py::TestAuditLogging::test_pii_access_logged` — 1 passed.
- `uv run pytest -q -rf` — 1,471 passed, 21 skipped.
- `uv run ruff check src/ tests/` — passed.
