### PR TITLE
docs: redact vulnerability-class detail from merged triage brief

### DIFF
--- a/internal/issue-triage/2026-09-08.md
+++ b/internal/issue-triage/2026-09-08.md
@@ -10,21 +10,21 @@ None. No open issue received a comment from anyone after the 2026-09-05 cutoff �
 ## PRs
 
 ### #360 — Protect shared-server exports and redact logged URL credentials
-*Author: vishalsachdev (from `codex/review-2026-09-06`), ready for review, not draft.*
+*Author: vishalsachdev, ready for review, not draft.*
 
 - CI: all 16 checks green — `test (3.11/3.12/3.13)`, `lint`, `claude-review`, CodeQL, SAST, secret scan, dependency scan, Cursor agents (neutral). Mergeable state is `blocked` — there's no approving review yet, so this is **green but unreviewed**.
-- ⚠️ **High-sensitivity — read before merging.** Both automated PR reviews (Codex and Claude) independently flagged the same thing: the PR's own commit history added `REVIEW-2026-09-06.md`, a security-review report documenting five **still-unpatched** findings with file:line detail and exploit scenarios — S2 (unbounded pipe buffering / host memory exhaustion in `code_execution.py`), S4 (no request-body size cap on the authenticated HTTP path in `server.py`), S5 (ReDoS via caller-controlled regex in `discussions.py`), S6 (timing side-channel in the access-key comparison in `server.py`), S7 (unbounded anonymization-cache growth). The file was removed before the PR's current head, but the content is real git history reachable through the PR's own commits, which cuts against `SECURITY.md`'s own instruction not to publicly disclose unpatched vulnerabilities. This is independent of the actual code change, which both reviewers verified as sound (HTTP export guards for `generate_peer_review_report` / `extract_peer_review_dataset` / `create_student_anonymization_map` fire before any Canvas fetch or file write; `sanitize_url()` correctly strips credentials from logged URLs; tests cover the refusal paths).
+- ⚠️ **High-sensitivity — read before merging.** Both automated PR reviews (Codex and Claude) independently flagged the same thing: the PR's own commit history added a security-review report documenting several **still-unpatched** findings with file:line detail and exploit scenarios (specifics deliberately withheld from this tracked, public file — see the executor note below for how to get them privately). The file was removed before the PR's current head, but the content is real git history reachable through the PR's own commits, which cuts against `SECURITY.md`'s own instruction not to publicly disclose unpatched vulnerabilities. This is independent of the actual code change, which both reviewers verified as sound (HTTP export guards for `generate_peer_review_report` / `extract_peer_review_dataset` / `create_student_anonymization_map` fire before any Canvas fetch or file write; `sanitize_url()` correctly strips credentials from logged URLs; tests cover the refusal paths).
 - This PR is itself student-data-adjacent (peer-review reports, anonymization maps) — treat with the usual FERPA caution, though the change here is a restriction, not a new exposure.
 - **Next action:** decide whether the exposed history needs remediation (advisory, or accept it's already shared via PR history) before approving; then get an approving review and merge.
 
 **Draft note for yourself (not sent anywhere):**
 ```
-Before merging #360: both automated reviews flagged that this branch's history carries
-REVIEW-2026-09-06.md, documenting 5 still-unpatched findings (S2 pipe buffering, S4 no
-body-size cap, S5 ReDoS, S6 timing side-channel, S7 unbounded cache) with exploit detail.
-It's off the final tree but still reachable via PR history, which conflicts with our own
-SECURITY.md disclosure policy. Want to open private advisories for those five (or fix them)
-before this merges — the export/redaction change itself looks clean on both reviews.
+Before merging #360: both automated reviews flagged that this branch's history carries a
+security-review doc documenting several still-unpatched findings with exploit detail
+(specifics withheld here, ask me directly). It's off the final tree but still reachable via
+PR history, which conflicts with our own SECURITY.md disclosure policy. Want to open private
+advisories for those (or fix them) before this merges — the export/redaction change itself
+looks clean on both reviews.
 ```
 
 ### #359 — chore: remove unused code and dependencies
@@ -136,10 +136,10 @@ hypothetical: it is the reason a hard build error has been sitting on `main` unn
 
 **3. #360 — the security-review history claim is CONFIRMED.**
 
-Verified against the actual commit range, not the PR description. `REVIEW-2026-09-06.md` is
-added in `bffebbf` and deleted in `309f00a`, both inside `origin/main..8d87d4f` — so the blob
-is reachable from PR #360's own commits on the public repo. The file is 152 lines and
-enumerates findings S1–S7; S1 and S3 are the two this PR patches, leaving S2, S4, S5, S6, S7
+Verified against the actual commit range, not the PR description (specific commit identifiers
+and finding IDs deliberately not restated in this tracked, public file — ask directly for
+those). The removed report is reachable from PR #360's own commits on the public repo; two of
+its findings are the ones this PR patches, and the remaining several stay
 documented-but-unpatched. The brief characterized this accurately.
 
 Not repeating the finding descriptions here — see `### Needs Vishal` below for why that no
@@ -189,16 +189,18 @@ stalled. No fork branches are open, so no awaiting-approval cases to note.
 
 ### Needs Vishal
 
-1. **#360 — decide the disclosure question, and note that redaction has already stopped
-   helping.** The five unpatched findings (S2, S4, S5, S6, S7) are now publicly readable in at
-   least four places: PR #360's commit history, the two automated review comments on #360, the
-   PR #361 body, and this brief. Deleting them from any one of those does not undo the others,
-   and a merge commit keeps this brief's own history reachable regardless — which is the same
-   trap #360 fell into. I deliberately did **not** redact this file: it would have been
-   theater, and it would have cost you the working record. The real fork is *patch the five*
-   or *accept the disclosure and say so*; "remove the file" is no longer on the menu.
-   Security-sensitive, so I took no action beyond reading — no advisories opened, no comments
-   posted, no history rewritten.
+1. **#360 — decide the disclosure question.** Several unpatched findings from the removed
+   review doc are readable in at least four places: PR #360's commit history, the two
+   automated review comments on #360, the PR #361 body, and (at the time this note was
+   originally written) this brief. I can't touch the first three — those are GitHub-hosted
+   comments/PR text outside this routine's write access. **Update from a later day (see the
+   redaction note added after this line):** this file's own copy has since been redacted, on
+   the reasoning that reducing the number of tracked, public copies still narrows exposure
+   even though the git-history and GitHub-comment copies remain outside anyone's reach to fix
+   except by rewriting history or contacting GitHub — which is your call, not mine. The real
+   fork is still *patch the remaining findings* or *accept the disclosure and say so*; "remove
+   every copy" was never fully on the menu given the comment/PR-body copies. Security-sensitive,
+   so beyond that redaction, no advisories opened, no comments posted, no history rewritten.
 2. **#360 — approve and merge if you're satisfied on point 1.** Code is verified clean
    independently by me (1477 passed, ruff, mypy) and by both automated reviewers. It only
    needs your approving review; `mergeable_state: blocked` is that and nothing more.

--- a/internal/issue-triage/2026-09-09.md
+++ b/internal/issue-triage/2026-09-09.md
@@ -10,11 +10,11 @@ None. All five currently-open issues (#157, #172, #236, #301, #302) had their mo
 ## PRs
 
 ### #360 — Protect shared-server exports and redact logged URL credentials
-*Author: vishalsachdev (from `codex/review-2026-09-06`), ready for review, not draft.*
+*Author: vishalsachdev, ready for review, not draft.*
 
 - CI: all 16 checks green on head `8d87d4f` (test 3.11/3.12/3.13, lint, claude-review, CodeQL x2, SAST, secret scan, dependency scan, security test suite, PR-body check, Cursor agents neutral).
 - `mergeable_state: behind` — main has advanced (the two dependabot batches plus PR #362) since this PR's base (`337b8ea`); no conflict reported, but the branch should be brought up to date before merging.
-- No formal GitHub review has been submitted (`get_reviews` is empty) — only automated PR comments from Codex and Claude, both "no blocking issues" but both independently flagging the same thing carried over from the prior brief: this PR's own commit history contains `REVIEW-2026-09-06.md`, documenting five **still-unpatched** security findings (S2 unbounded pipe buffering, S4 no HTTP body-size cap, S5 ReDoS, S6 timing side-channel, S7 unbounded anonymization-cache growth) with file:line and exploit detail — in tension with `SECURITY.md`'s instruction not to publicly disclose unpatched vulnerabilities. No comment from you on this PR addresses that question yet, so it's still open.
+- No formal GitHub review has been submitted (`get_reviews` is empty) — only automated PR comments from Codex and Claude, both "no blocking issues" but both independently flagging the same thing carried over from the prior brief: this PR's own commit history contains a security-review report documenting several **still-unpatched** findings with file:line and exploit detail (specifics deliberately withheld from this tracked, public file — ask directly) — in tension with `SECURITY.md`'s instruction not to publicly disclose unpatched vulnerabilities. No comment from you on this PR addresses that question yet, so it's still open.
 - ⚠️ High-sensitivity (FERPA-adjacent: peer-review reports, anonymization maps) — the code change itself is a restriction, not a new exposure, and both reviewers verified the guards fire before any Canvas fetch or file write.
 - **Next action:** decide the disclosure question (patch the five findings, or formally accept and record the disclosure — "delete the file" is not a real fix once it's in PR/comment history); sync the branch with main; then get an approving review and merge.
 
@@ -54,7 +54,7 @@ PR #363 body (`scripts/check_closing_keywords.py --strict`, exit 0 on each) — 
 
 Both runs are on throwaway worktrees; nothing was pushed to either PR branch.
 
-**PR #360 branch as-is (`8d87d4f`, `codex/review-2026-09-06`):**
+**PR #360 branch as-is (`8d87d4f`):**
 
 ```
 1477 passed, 22 skipped, 1 warning in 30.43s     (uv run python -m pytest tests/ -q -rf, exit 0)
@@ -97,7 +97,7 @@ evidence the flake is gone — it was intermittent to begin with — it just did
    lists do not appear among this branch's workflow runs. Nothing here contradicts "green," but
    treat the 16-item list as unverified in its detail.
 3. **#360 "behind, no conflict" — confirmed by measurement, not just by GitHub's label.**
-   `git merge-tree --write-tree origin/main origin/codex/review-2026-09-06` exits 0 with no
+   `git merge-tree --write-tree origin/main` against the PR's branch head exits 0 with no
    conflicts. `main` is 24 commits ahead of the PR's recorded base `337b8ea`.
 4. **#359 "dirty" — the conflict is now localized.** `git merge-tree` against `origin/main` reports
    content conflicts in exactly two files: `package.json` and `package-lock.json`. That is #359's
@@ -107,13 +107,13 @@ evidence the flake is gone — it was intermittent to begin with — it just did
 5. **#299 — the brief inferred it "looks to have been resolved/closed"; here is the measured fact.**
    Closed 2026-09-08T15:34:16Z by `vishalsachdev` with `state_reason: not_planned` and a `wontfix`
    label. It was declined, not resolved — the distinction matters if the reporter follows up.
-6. **The #360 disclosure concern is real and I verified it directly.** `REVIEW-2026-09-06.md` is
-   absent from the head tree (removed in `309f00a`) but `git show bffebbf:REVIEW-2026-09-06.md`
-   still resolves on the pushed branch, so it remains publicly fetchable and visible in the PR's
-   commit view. Its status lines confirm the brief's count exactly: **S1 fixed** (`735ca36`),
-   **S3 fixed** (`afb4cc0`), and **S2, S4, S5, S6, S7 all carrying "recommendation; not
-   implemented" or "not implemented"** — five unpatched findings published with file:line detail on
-   a public repo. The brief's framing that deleting the file is not a fix is correct as measured.
+6. **The #360 disclosure concern is real and I verified it directly.** The removed report is
+   absent from the head tree but still resolves via a specific commit on the pushed branch (identifier
+   deliberately not restated here), so it remains publicly fetchable and visible in the PR's
+   commit view. Its status lines confirm the brief's count exactly: two findings fixed, and the
+   remaining several **all carrying "recommendation; not implemented" or "not implemented"** —
+   several unpatched findings published with file:line detail on a public repo. The brief's
+   framing that deleting the file is not a fix is correct as measured.
 7. **Open-issue set confirmed:** exactly #157, #172, #236, #301, #302 open; every one last updated
    2026-09-08 between 15:33 and 15:35 UTC by `vishalsachdev`. "No open issue needs a reply" holds.
 8. **Merges confirmed:** #362, #358, #357, #356, #355 are all present in `main`'s history.
@@ -136,13 +136,13 @@ evidence the flake is gone — it was intermittent to begin with — it just did
 ### Needs Vishal
 
 1. **#360 — decide the security-disclosure question. This is the only real blocker and it is now
-   two days old.** Five unpatched findings (S2 unbounded pipe buffering, S4 no HTTP body-size cap,
-   S5 ReDoS, S6 access-key timing side-channel, S7 unbounded anonymization-cache growth) are
-   publicly readable at `bffebbf` with file:line and exploit detail, against `SECURITY.md`'s own
-   instruction not to publicly disclose unpatched vulnerabilities. Three routes: patch the five,
-   formally accept and record the disclosure, or rewrite the branch history — and history rewriting
-   is yours alone to do, both because it is a force-push and because the content is FERPA-adjacent.
-   Note S6 and S7 are themselves in the read-only territory, so I cannot patch them either.
+   two days old.** Several unpatched findings (specifics withheld from this tracked, public file —
+   ask directly for detail) are publicly readable at a specific commit on the pushed branch, with
+   file:line and exploit detail, against `SECURITY.md`'s own instruction not to publicly disclose
+   unpatched vulnerabilities. Three routes: patch the remaining findings, formally accept and
+   record the disclosure, or rewrite the branch history — and history rewriting is yours alone to
+   do, both because it is a force-push and because the content is FERPA-adjacent. Some of the
+   remaining findings are themselves in the read-only territory, so I cannot patch them either.
 2. **#360 — needs an approving review and a merge decision.** No formal review has ever been
    submitted (the reviews list is empty; the Codex and Claude comments are automated). Merge is
    yours; I may only merge the triage brief PR. Tests and lint are green on the merged tree.

--- a/internal/issue-triage/2026-09-10.md
+++ b/internal/issue-triage/2026-09-10.md
@@ -21,7 +21,7 @@ Both open PRs are your own (`vishalsachdev`), same-repo branches, all CI green. 
 - CI: all green (same matrix as above, plus a Codex review with no findings and two Cursor bot checks reporting `neutral`).
 - `mergeable_state: behind` — base has moved on; needs a branch update (merge/rebase `main` in) before merging.
 - Substance looks solid: three new HTTP-transport guards stop a shared/hosted server from writing student peer-review reports, exports, or the identity-anonymization map to its own disk, plus a `sanitize_url()` fix so presigned-upload credentials (`X-Amz-Signature` etc.) never hit logs, and a peer-review roster de-dup. Reviewers found no correctness bugs; two Low/Medium doc nits (`tools/README.md` HTTP-restriction callouts partially added but `CHANGELOG.md [Unreleased]` not touched; `tests/test_tool_metadata.py`'s sampled destructive/idempotent sets not updated for the two tools that flipped `read_only_hint`).
-- ⚠️ **High-sensitivity flag, worth your attention before merging:** one commit on this branch (`bffebbf`, "docs: record 2026-09-06 security review") added `REVIEW-2026-09-06.md` at the repo root, documenting **five still-unpatched** findings with file:line evidence and exploit scenarios (details deliberately not restated in this brief — see the executor note below). A later commit (`309f00a`) removed the file from the tip, and your PR description notes it's "retained in a private location" — but because both commits are already pushed to this public repo, the full report is still reachable right now via the PR's Commits tab (commit `bffebbf`), regardless of what merge strategy is used later. `SECURITY.md` asks that vulnerability details not be posted publicly. This isn't something I can fix (no write access under my constraints), but you may want to decide whether to rewrite this branch's history before merging, or treat the exposure as already-happened and move the follow-up work into private GitHub Security Advisories instead. Flagging because it touches the access-key/anonymization security surface, not because the fix itself looks wrong — the fix is fine.
+- ⚠️ **High-sensitivity flag, worth your attention before merging:** an earlier commit on this branch added a security-review document at the repo root, documenting **five still-unpatched** findings with file:line evidence and exploit scenarios (details, and the specific commit identifiers, deliberately not restated in this brief — see the executor note below). A later commit removed the file from the tip, and your PR description notes it's "retained in a private location" — but because both commits are already pushed to this public repo, the full report is still reachable right now via the PR's Commits tab, regardless of what merge strategy is used later. `SECURITY.md` asks that vulnerability details not be posted publicly. This isn't something I can fix (no write access under my constraints), but you may want to decide whether to rewrite this branch's history before merging, or treat the exposure as already-happened and move the follow-up work into private GitHub Security Advisories instead. Flagging because it touches the access-key/anonymization security surface, not because the fix itself looks wrong — the fix is fine.
 - **Next action:** update the branch against `main`, then decide on the history question above before merging.
 
 ## New since 2026-09-09
@@ -84,11 +84,12 @@ were pushed.
 
 The brief's finding is correct and I verified it independently — but its suggested remedy is not.
 
-Verified: commit `bffebbf` is still an ancestor of the PR #360 branch tip, it added
-`REVIEW-2026-09-06.md` (152 lines) at the repo root, and that report documents five findings whose
-status lines read "recommendation; not implemented" / "not implemented". I checked each of the five
-against current `main` and **all five code paths are still exactly as the report describes them** —
-so this is a public description of live, unpatched weaknesses, not of already-fixed ones.
+Verified: a specific commit (identifier deliberately not restated here) is still an ancestor of the
+PR #360 branch tip; it added a 152-line security-review document at the repo root, and that report
+documents five findings whose status lines read "recommendation; not implemented" / "not
+implemented". I checked each of the five against current `main` and **all five code paths are
+still exactly as the report describes them** — so this is a public description of live, unpatched
+weaknesses, not of already-fixed ones.
 
 The correction: the brief offers "rewrite this branch's history before merging" as one of two
 options. That will not work. Once a commit has been pushed to a public repo and associated with a
@@ -119,9 +120,9 @@ here is read-only observation.
 The brief's own high-sensitivity bullet enumerated all five unpatched findings by weakness class
 and source file. This file lands on `main` when PR #364 merges, which would have republished a
 compact version of the same information the bullet was flagging. I replaced that parenthetical with
-a pointer to this section; the finding, the evidence trail (`bffebbf`, `309f00a`), and the
-recommended action are all untouched. Nothing was softened — only the enumeration was dropped, and
-it remains available to you in the report itself.
+a pointer to this section; the finding, the evidence trail (specific commit identifiers, deliberately
+not restated here either), and the recommended action are all untouched. Nothing was softened —
+only the enumeration was dropped, and it remains available to you in the report itself.
 
 ### Not done, and why
 

--- a/internal/issue-triage/2026-09-10.md
+++ b/internal/issue-triage/2026-09-10.md
@@ -101,9 +101,9 @@ on the real fix. Treat the content as disclosed as of 2026-09-07.
 
 What actually closes this, in priority order:
 
-1. **Prioritize the five fixes**, since the exploit steps are public. The two with the clearest
-   shared-server impact are the availability pair (the code-execution one is moot wherever
-   `execute_typescript` stays disabled, which includes both hosted slots).
+1. **Prioritize the five fixes**, since the exploit steps are public. Two of the five have the
+   clearest shared-server impact; one of those is moot wherever the relevant opt-in tool stays
+   disabled, which includes both hosted slots (specifics deliberately withheld here, ask directly).
 2. **Move the remaining tracking into a private GitHub Security Advisory**, per `SECURITY.md`,
    rather than any tracked file.
 3. **Optionally ask GitHub Support to purge** the cached commit view — that is the only mechanism

--- a/internal/issue-triage/2026-09-11.md
+++ b/internal/issue-triage/2026-09-11.md
@@ -28,12 +28,13 @@ Both PRs are unchanged from yesterday — same heads, same problems, still waiti
 - Head `8d87d4f`, still `mergeable_state: behind` (confirmed 0-conflict merge against `main`,
   clean update available in one click). CI green, no formal review submitted (reviews list is
   still empty — only bot/Codex comments, both "no blocking issues").
-- ⚠️ **High-sensitivity, still open, now 4 days old:** the branch's history still contains commit
-  `bffebbf` (`REVIEW-2026-09-06.md`), which publicly documents five still-unpatched security
-  findings (file:line + exploit detail) in tension with `SECURITY.md`. Nothing about this has
-  changed since 2026-09-10 — the file is still fetchable at that SHA, the five findings are still
-  unpatched on `main`, and a history rewrite still would not retract it (already explained in
-  detail in the 2026-09-10 brief's executor section — worth a re-read if it's been a few days).
+- ⚠️ **High-sensitivity, still open, now 4 days old:** the branch's history still contains a
+  security-review document (specific commit identifier deliberately not restated here), which
+  publicly documents five still-unpatched security findings (file:line + exploit detail) in
+  tension with `SECURITY.md`. Nothing about this has changed since 2026-09-10 — the file is still
+  fetchable, the five findings are still unpatched on `main`, and a history rewrite still would not
+  retract it (already explained in detail in the 2026-09-10 brief's executor section — worth a
+  re-read if it's been a few days).
 - **Next action:** unchanged — this is the one item on your desk with a clock on it. Decide the
   disclosure question (recommended: treat as disclosed, open a private GitHub Security Advisory,
   schedule the five fixes, add a root-level ignore rule for future `REVIEW-*.md` files), then
@@ -112,8 +113,9 @@ commits were pushed.
 
 ### Addition to yesterday's disclosure finding
 
-Yesterday's section treated the #360 exposure as the commit blob at `bffebbf`. That is still true —
-the file is gone from the branch tip but reachable at that SHA — but it is not the whole surface:
+Yesterday's section treated the #360 exposure as the commit blob at a specific pushed commit. That
+is still true — the file is gone from the branch tip but reachable at that commit — but it is not
+the whole surface:
 the automated review bot's **public PR comment** on #360 (posted 2026-09-07, still visible on the
 PR) independently restates the same five items, by weakness class and source file, as its own
 top finding. So the content is public in two places, one of which no git operation touches at all.

--- a/internal/issue-triage/2026-09-12.md
+++ b/internal/issue-triage/2026-09-12.md
@@ -26,13 +26,13 @@ Touches anonymization/PII export boundaries and credential redaction in logs —
 
 - **State:** ready for review (not draft), `mergeable_state: behind` (needs `main` merged in — no conflict, just stale), CI all green (16/16 checks, including two Cursor agent checks reporting `neutral`).
 - **Reviews:** No formal APPROVE/REQUEST_CHANGES submitted — only PR comments (2x `claude[bot]`, 1x `codex` summary). All three describe it as a solid, well-scoped fix with no blocking issues.
-- **One finding worth confirming, not blocking:** the first `claude[bot]` pass (2026-09-07 23:20) flagged a High-severity process concern — that the PR added `REVIEW-2026-09-06.md` at the repo root, publicly disclosing 5 still-unpatched vulnerability findings with exploit detail, which reads as in tension with `SECURITY.md`'s private-disclosure policy. I checked the PR's **current** file list directly: `REVIEW-2026-09-06.md` is **not** in it, matching the PR body's own claim that the file "has been removed from the final public tree." So this appears already resolved — worth a quick look at whether that file (or its content) shows up anywhere else in the repo's tracked history before merge, since the bot's own comment notes removal doesn't erase git history.
+- **One finding worth confirming, not blocking:** the first `claude[bot]` pass (2026-09-07 23:20) flagged a High-severity process concern — that the PR added a security-review document at the repo root, publicly disclosing 5 still-unpatched vulnerability findings with exploit detail, which reads as in tension with `SECURITY.md`'s private-disclosure policy. I checked the PR's **current** file list directly: that document is **not** in it, matching the PR body's own claim that the file "has been removed from the final public tree." So this appears already resolved — worth a quick look at whether that content shows up anywhere else in the repo's tracked history before merge, since the bot's own comment notes removal doesn't erase git history.
 - Remaining bot comments are low-severity docs/changelog nits (CHANGELOG `[Unreleased]` entry, a narrowed test invariant) — non-blocking per the reviewers, and `tools/README.md` already got the relevant callouts per the current diff.
 - **Next action:** Update the branch against `main` (it's `behind`, not conflicted), then either merge given three green bot reviews with no blockers, or request one human/formal review first given the PII-export surface it changes (HTTP behavior change: `generate_peer_review_report`, `extract_peer_review_dataset`, `create_student_anonymization_map` now refuse over HTTP).
 
 **Draft reply** *(superseded — see "Draft replies — flags" below before posting)*:
 ```
-This looks clean across three independent bot passes — the one High flag (REVIEW-2026-09-06.md being public) is already handled, it's not in the current diff. Updating the branch against main and merging; the HTTP-export refusals are the intended breaking behavior change here.
+This looks clean across three independent bot passes — the one High flag (the removed security-review document being public) is already handled, it's not in the current diff. Updating the branch against main and merging; the HTTP-export refusals are the intended breaking behavior change here.
 ```
 
 ## New since 2026-09-11
@@ -87,7 +87,7 @@ Both runs in read-only `git worktree` checkouts of the PR head refs, on this con
 
 ### Corrections to the brief
 
-**1. #360 / `REVIEW-2026-09-06.md` — "appears already resolved" is only half right. The disclosure
+**1. #360 / the removed security-review document — "appears already resolved" is only half right. The disclosure
 is still public right now.** Measured, not inferred:
 
 - Absent from the current PR tree and absent from `origin/main` — the brief is correct on that.
@@ -166,7 +166,7 @@ Neither draft reply was posted. Both need an edit before they are:
 
 ### Needs Vishal
 
-1. **#360 — decide on the still-reachable `REVIEW-2026-09-06.md` history in this PR's own earlier
+1. **#360 — decide on the still-reachable removed security-review document's history in this PR's own earlier
    commits.** Several of its findings were marked not-yet-implemented in their own status lines.
    Specifics (which findings, exact commit/branch) are deliberately not written into this tracked
    file — ping me directly for the detail rather than asking for it in a public thread. Options:

--- a/internal/issue-triage/2026-09-12.md
+++ b/internal/issue-triage/2026-09-12.md
@@ -173,6 +173,16 @@ Neither draft reply was posted. Both need an edit before they are:
    accept the exposure and file the remaining findings as normal tracked issues (making the
    disclosure moot), or remove the branch history before/after merge. Irreversible and public
    either way, so untouched.
+   - **Update, same day:** a first version of this brief (with the specifics named in the open,
+     including which commit/branch to look at) was itself merged to `main` before a redaction PR
+     reached it in time. Redacting the file's current snapshot in that follow-up PR does **not**
+     remove the earlier version from `main`'s own reachable git history — a review comment on the
+     redaction PR caught this correctly; anyone can still read it from that merge commit or its
+     parent. Only rewriting/force-pushing `main`'s history would actually remove it, which is
+     disruptive to every clone of this repo and not something to attempt without your explicit
+     say-so. Bundled with the decision above: whatever you decide about the #360 branch history,
+     the same call (and the same GitHub-caching caveat) now also applies to `main`'s own history
+     from today.
 2. **#360 — merge decision.** It is green, cleanly mergeable after a branch update, and passes the
    full suite merged with main locally. Three bot passes, no formal human review, and it carries a
    breaking HTTP behavior change on three export tools. Worth a CHANGELOG `[Unreleased]` entry if the

--- a/internal/issue-triage/2026-09-12.md
+++ b/internal/issue-triage/2026-09-12.md
@@ -16,7 +16,7 @@ None. All 5 open issues (#157, #172, #236, #301, #302) were last commented on by
 - **Reviews:** No formal GitHub review submitted. Two `claude[bot]` deep-dive comments (2026-09-07) verified every deletion is dead/unreferenced and flagged only one item as unverified-by-them: the `tsconfig.json` swap of `moduleResolution: "node"` → `types: ["node"]`, since neither bot could run `tsc` in their sandbox. You posted your own comment (2026-09-08) confirming `npm run build` passed locally and stating the PR should stay draft until you advance it — so the draft state itself is intentional, not stalled.
 - **Next action:** The merge conflict is the only thing not already addressed. Rebase onto current `main` and resolve it before this can move out of draft. No content concerns raised by any reviewer.
 
-**Draft reply:**
+**Draft reply** *(superseded — see "Draft replies — flags" below before posting)*:
 ```
 Rebasing this onto main to clear the conflict — content-wise it's already checked out from three independent passes (two bot reviews + my own local build), so once it's conflict-free I'll flip it to ready.
 ```
@@ -30,7 +30,7 @@ Touches anonymization/PII export boundaries and credential redaction in logs —
 - Remaining bot comments are low-severity docs/changelog nits (CHANGELOG `[Unreleased]` entry, a narrowed test invariant) — non-blocking per the reviewers, and `tools/README.md` already got the relevant callouts per the current diff.
 - **Next action:** Update the branch against `main` (it's `behind`, not conflicted), then either merge given three green bot reviews with no blockers, or request one human/formal review first given the PII-export surface it changes (HTTP behavior change: `generate_peer_review_report`, `extract_peer_review_dataset`, `create_student_anonymization_map` now refuse over HTTP).
 
-**Draft reply:**
+**Draft reply** *(superseded — see "Draft replies — flags" below before posting)*:
 ```
 This looks clean across three independent bot passes — the one High flag (REVIEW-2026-09-06.md being public) is already handled, it's not in the current diff. Updating the branch against main and merging; the HTTP-export refusals are the intended breaking behavior change here.
 ```
@@ -91,19 +91,21 @@ Both runs in read-only `git worktree` checkouts of the PR head refs, on this con
 is still public right now.** Measured, not inferred:
 
 - Absent from the current PR tree and absent from `origin/main` — the brief is correct on that.
-- **But present in the pushed public branch history**: added in `bffebbf` ("docs: record 2026-09-06
-  security review", 152 lines), removed in `309f00a`. `codex/review-2026-09-06` is a branch of this
-  public repo, so that commit and its full contents are retrievable today by anyone.
-- Content read: the file names five findings with exploit scenarios and file:line evidence. Three of
-  them — **S2** (code-execution output memory exhaustion), **S4** (no MCP HTTP body size limit),
-  **S5** (announcement-title ReDoS) — carry the status line *"recommendation; not implemented in this
-  time box"*, i.e. **unpatched as of that document**. S1 and S3 are the ones this PR fixes.
-- So the `claude[bot]` High-severity process flag has **not** actually been discharged; it was
-  addressed in the tree only. The PR body itself says as much ("Its previously pushed feature-branch
-  revision remains retrievable through PR history"), which the brief did not pick up.
+- **But it was pushed at an earlier point in this PR's own branch history**, and per the PR body's
+  own admission ("Its previously pushed feature-branch revision remains retrievable through PR
+  history"), an earlier revision may still be reachable to someone who knows where to look, even
+  though it is gone from every current branch tip. Commit identifiers and the exact branch/file
+  location are deliberately **not repeated here** — this brief is itself a tracked, public file, and
+  restating them would recreate the disclosure this note is trying to flag.
+- Content read (off the record, not reproduced here): several of the five original findings carry a
+  status line indicating they were **not yet implemented** at the time that document was written —
+  i.e. still open as far as this brief can verify. Specific vulnerability classes and locations are
+  withheld from this file; see "Needs Vishal" below for how to get the detail privately.
+- So the `claude[bot]` High-severity process flag has **not** actually been fully discharged; it was
+  addressed in the tree only. The PR body itself says as much, which the brief did not pick up.
 - Note for whoever acts: merging #360 does not remove that history, and neither does deleting the
-  file again. Only removing/rewriting the remote branch would, and GitHub may still serve the
-  orphaned commit by SHA for some time.
+  file again. Only removing/rewriting the remote branch would, and GitHub may still serve an orphaned
+  commit for some time.
 - **No action taken.** This is security-disclosure territory adjacent to the FERPA read-only rule, and
   any remedy (force-push, branch deletion, contacting GitHub support) is irreversible and public.
   Routed to Vishal below.
@@ -164,10 +166,12 @@ Neither draft reply was posted. Both need an edit before they are:
 
 ### Needs Vishal
 
-1. **#360 — decide on the still-public `REVIEW-2026-09-06.md` history** (commit `bffebbf` on
-   `codex/review-2026-09-06`). It describes S2/S4/S5 with exploit detail and those are still
-   unimplemented. Options: accept the exposure and file the three findings as normal issues (making
-   the disclosure moot), or remove the branch history before/after merge. Irreversible and public
+1. **#360 — decide on the still-reachable `REVIEW-2026-09-06.md` history in this PR's own earlier
+   commits.** Several of its findings were marked not-yet-implemented in their own status lines.
+   Specifics (which findings, exact commit/branch) are deliberately not written into this tracked
+   file — ping me directly for the detail rather than asking for it in a public thread. Options:
+   accept the exposure and file the remaining findings as normal tracked issues (making the
+   disclosure moot), or remove the branch history before/after merge. Irreversible and public
    either way, so untouched.
 2. **#360 — merge decision.** It is green, cleanly mergeable after a branch update, and passes the
    full suite merged with main locally. Three bot passes, no formal human review, and it carries a


### PR DESCRIPTION
## Urgent: redact vulnerability-class detail from merged/tracked briefs

**Scope grew after this PR was opened** — a `claude-review` comment on the first commit correctly pointed out that `2026-09-08.md` through `2026-09-11.md` are already-tracked, un-redacted copies of the same disclosure, in most cases with *more* detail than `2026-09-12.md` (six finding IDs instead of three, plus the specific vulnerable source files). This PR now redacts all five files.

**Original problem:** an automated executor addendum on today's brief named specific unpatched-vulnerability classes, plus the commit identifiers and branch name where a removed security-review document is still reachable in git history. That content landed on `main` — a stronger disclosure than the #360 process concern it was describing, and in tension with `SECURITY.md`'s private-disclosure policy.

**What this PR does:** drops finding IDs/descriptions, vulnerable file names, commit identifiers, the branch name, and the report's own filename from all five brief files, while keeping the fact that some findings remain unpatched and need an owner decision.

**What this PR does NOT do — please read before treating this as resolved:**
- It does not purge the content from git history. Editing a file's latest snapshot doesn't remove earlier commits from `main`'s own reachable history (a review comment on an earlier commit here caught this directly).
- A history rewrite likely wouldn't fully work either: per the 2026-09-10 brief's own analysis (still in this PR, redacted of specifics but not of the conclusion), GitHub keeps a PR's head commit reachable via `refs/pull/<N>/head` indefinitely, even after merge, close, or a branch force-push/deletion.
- A bot's own public PR comment on #360 (posted 2026-09-07) independently restates the same findings in the open — that's a GitHub comment, not a repo file, and nothing here touches it.

**Net effect:** this narrows what's visible in the default branch view and stops daily re-broadcasting of the specifics — worth doing — but the underlying disclosure is best treated as already-happened. The real remedies (patch the remaining findings, move tracking to a private GitHub Security Advisory, ask GitHub Support about the cached view, add a root-level ignore rule for future security-review docs at the repo root) are Vishal's to decide and action.

Confirmed by @vishalsachdev directly on this PR: scope and limitations as described above are agreed, resolved as addressed-by-description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHH5N3NfBcpXxhgemyjD59