### PR TITLE
feat: add update_syllabus, a write tool for the course Syllabus tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,8 @@ Reduce tool overhead by setting a role-based profile. Only tools relevant to the
 ```
 # In .env:
 CANVAS_ROLE=student    # ~37 tools (student + shared)
-CANVAS_ROLE=educator   # 90 tools (educator + shared)
-CANVAS_ROLE=all        # Default profile; 96 tools by default, 101 with all feature-gated tools enabled
+CANVAS_ROLE=educator   # 91 tools (educator + shared)
+CANVAS_ROLE=all        # Default profile; 97 tools by default, 102 with all feature-gated tools enabled
 ```
 
 Or via CLI flag: `canvas-mcp-server --role student` (CLI flag takes precedence over env var).
@@ -107,6 +107,7 @@ Course management, grading, and analytics. Requires instructor/TA role.
 | `send_peer_review_inbox_messages` | Send direct Canvas Inbox messages about incomplete peer reviews; this is not Canvas's native reminder action. Requires `manage_grades` permission and uses **two calls** (preview + confirm) |
 | `create_announcement` | Post course announcements. Pre-checks Canvas's announcement permission; if Canvas silently creates a discussion instead, the tool deletes that unintended topic and reports failure (or warns if cleanup cannot be confirmed) |
 | `update_discussion_topic` | Edit discussion or announcement title/body and settings |
+| `update_syllabus` | Write the course Syllabus tab (`replace`, `append`, or `prepend`). Canvas keeps no revision history for the syllabus, so **replacing a syllabus that already has content is two calls** — preview + token, then confirm. Writing into an empty syllabus, appending, or prepending is a single call. The write is verified by reading the syllabus back |
 
 ### Untrusted Canvas content is fenced
 
@@ -140,7 +141,7 @@ Content access tools available to all authenticated users.
 | `get_my_enrollments` | What am I enrolled in, and as what role? Needs no roster permission |
 | `list_courses` | Enrolled courses (includes your own role in each) |
 | `get_course_details` | Course info and syllabus (includes your own role) |
-| `get_syllabus` | Full Syllabus tab content, untruncated (text/html/both) |
+| `get_syllabus` | Full Syllabus tab content, untruncated (text/html/both). Educators write it with `update_syllabus` |
 | `list_pages` | Course pages |
 | `get_page_content` | Read page content |
 | `update_page_settings` | Publish/unpublish, set front page, editing roles |
@@ -280,6 +281,26 @@ delete_announcements_by_criteria, delete_page, delete_module, delete_module_item
 delete_assignment_with_confirmation. There is no un-tokened delete tool.
 ```
 
+### Educator: Write the Syllabus
+```
+1. Read what is there now
+   → get_syllabus(course_id)
+
+2a. Adding to a syllabus, or filling an empty one — single call
+   → update_syllabus(course_id, "<p>...</p>", mode="append")
+
+2b. Replacing a syllabus that already has content — two calls
+   → update_syllabus(course_id, "<p>...</p>")            # returns a preview + token
+   Show the preview to the educator, then
+   → update_syllabus(course_id, "<p>...</p>", confirmation_token=token)
+
+Canvas keeps no revision history for the syllabus, so a replace cannot be
+undone — that is why only the destructive case asks for a token. The tool reads
+the syllabus back after writing and reports a warning rather than success if
+Canvas stored something different (a token without manage_course_content is the
+usual cause).
+```
+
 ### Educator: Copy Course Content
 ```
 1. Preview the source, target, optional date shift, and target occupancy
@@ -310,7 +331,7 @@ delete_assignment_with_confirmation. There is no un-tokened delete tool.
 
 ### Cannot Do
 - Create or delete courses
-- Modify course settings or structure
+- Modify course settings other than the syllabus body (`update_syllabus`)
 - Access data outside user's Canvas permissions
 - Bypass Canvas API rate limits
 - Access other students' data (for student users)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   preview → token → confirm path as the delete tools; writing into an empty
   syllabus, appending, or prepending is a single call. The write is verified by
   reading the syllabus back, and reports `unconfirmed_write_warning` rather than
-  success when Canvas accepts the request but stores something else (a token
-  without `manage_course_content` is the usual cause). Registered for the
+  success when the syllabus does not contain what was sent (a token without
+  `manage_course_content` is the usual cause). That read-back compares visible
+  text rather than markup: Canvas rewrites the body server-side, and an
+  institutional theme injecting `<link>`/`<script>` tags into every syllabus
+  made byte equality report failure on writes that had succeeded. When Canvas
+  does rewrite the HTML the success message says so. Registered for the
   `educator` and `all` profiles only.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`update_syllabus`** — write the course Syllabus tab, which previously had a
+  read tool (`get_syllabus`) and no way to write. Supports `replace` (default),
+  `append` and `prepend`. Canvas keeps no revision history for `syllabus_body`,
+  so replacing a syllabus that already has content takes the same
+  preview → token → confirm path as the delete tools; writing into an empty
+  syllabus, appending, or prepending is a single call. The write is verified by
+  reading the syllabus back, and reports `unconfirmed_write_warning` rather than
+  success when Canvas accepts the request but stores something else (a token
+  without `manage_course_content` is the usual cause). Registered for the
+  `educator` and `all` profiles only.
+
 ### Changed
+
+- `preview_with_token` takes an optional `action` verb (default `"delete"`, so
+  every existing call site is unchanged). Delete tools were its only callers, so
+  its wording was hardcoded to deletion; `update_syllabus` is the first
+  irreversible write that is not a delete, and telling the user a replace would
+  "delete" something describes the wrong risk.
 
 - Migrated to FastMCP 4 and MCP SDK 2. Protocol-model attribute reads now use
   the SDK's native snake_case API, and CI disables FastMCP's temporary

--- a/src/canvas_mcp/core/write_confirmation.py
+++ b/src/canvas_mcp/core/write_confirmation.py
@@ -221,20 +221,31 @@ class ConfirmationGuard:
 
 
 def preview_with_token(
-    guard: ConfirmationGuard, fingerprint: str, tool_name: str, preview: str
+    guard: ConfirmationGuard,
+    fingerprint: str,
+    tool_name: str,
+    preview: str,
+    action: str = "delete",
 ) -> str:
     """Render a destructive-tool preview that ends with a fresh single-use token.
 
     Used by every delete tool (#318): the preview must show exactly what the
     token authorizes, and the fingerprint must be derived from that same
     content so a changed target stops matching.
+
+    ``action`` names the verb for tools whose irreversible write is not a
+    deletion -- ``update_syllabus`` replaces a body Canvas keeps no history
+    for. Telling the user a replace would "delete" something, or that nothing
+    was deleted when content was about to be overwritten, describes the wrong
+    risk. Defaults to "delete" so every existing call site reads unchanged.
     """
+    nothing_done = "Nothing deleted." if action == "delete" else guard.nothing_done
     return (
-        "PREVIEW — Nothing deleted.\n\n"
+        f"PREVIEW — {nothing_done}\n\n"
         f"{preview.rstrip()}\n\n"
         f"Confirmation token: {guard.issue(fingerprint)}\n"
-        f"Show this preview to the user. To delete, call {tool_name} again with "
-        "this confirmation_token and identical arguments. The token is "
+        f"Show this preview to the user. To {action}, call {tool_name} again "
+        "with this confirmation_token and identical arguments. The token is "
         "single-use, expires in 5 minutes, and stops matching if the target "
         "changes in the meantime."
     )

--- a/src/canvas_mcp/server.py
+++ b/src/canvas_mcp/server.py
@@ -43,6 +43,7 @@ from .tools import (
     register_course_tools,
     register_discovery_tools,
     register_educator_assignment_tools,
+    register_educator_course_tools,
     register_educator_discussion_tools,
     register_educator_file_tools,
     register_educator_messaging_tools,
@@ -454,6 +455,7 @@ def register_all_tools(mcp: FastMCP, role: str = "all") -> None:
     # Educator-specific tools
     if role in ("educator", "all"):
         register_educator_assignment_tools(mcp)
+        register_educator_course_tools(mcp)
         register_content_migration_tools(mcp)
         register_educator_discussion_tools(mcp)
         register_educator_module_tools(mcp)

--- a/src/canvas_mcp/tools/__init__.py
+++ b/src/canvas_mcp/tools/__init__.py
@@ -8,7 +8,11 @@ from .assignments import (
 )
 from .code_execution import register_code_execution_tools
 from .content_migrations import register_content_migration_tools
-from .courses import register_course_tools, register_shared_content_tools
+from .courses import (
+    register_course_tools,
+    register_educator_course_tools,
+    register_shared_content_tools,
+)
 from .discovery import register_discovery_tools
 from .discussions import (
     register_educator_discussion_tools,
@@ -38,6 +42,7 @@ __all__ = [
     'register_discovery_tools',
     'register_enrollment_tools',
     'register_educator_assignment_tools',
+    'register_educator_course_tools',
     'register_educator_discussion_tools',
     'register_educator_file_tools',
     'register_educator_messaging_tools',

--- a/src/canvas_mcp/tools/courses.py
+++ b/src/canvas_mcp/tools/courses.py
@@ -17,9 +17,29 @@ from ..core.cache import (
 from ..core.client import fetch_all_paginated_results, make_canvas_request
 from ..core.config import get_config
 from ..core.dates import format_date
-from ..core.untrusted_content import fence_untrusted, fence_untrusted_inline
+from ..core.untrusted_content import (
+    FENCE_LEAK_ERROR,
+    contains_fence_markers,
+    fence_untrusted,
+    fence_untrusted_inline,
+)
 from ..core.validation import validate_params
+from ..core.write_confirmation import (
+    ConfirmationGuard,
+    preview_with_token,
+    redeem_confirmation,
+    unconfirmed_write_warning,
+)
 from .self_identity import _own_roles
+
+# Replacing a syllabus that already has content destroys the only copy Canvas
+# keeps -- syllabus_body carries no revision history, unlike a wiki page. So
+# that one case takes the same preview->token->confirm path as the delete
+# tools; writing into an empty syllabus, or appending, has nothing to lose and
+# stays a single call.
+_UPDATE_SYLLABUS_GUARD = ConfirmationGuard(
+    nothing_done="The syllabus was not changed."
+)
 
 
 class _MediaCollector(HTMLParser):
@@ -778,3 +798,161 @@ def register_shared_content_tools(mcp: FastMCP) -> None:
             result += f"Published: {'Yes' if published else 'No'}\n\n"
 
         return result
+
+
+def register_educator_course_tools(mcp: FastMCP) -> None:
+    """Register course tools that write, so need an instructor-scoped token.
+
+    Kept out of ``register_course_tools`` on purpose: that group is shared with
+    the student profile, and a student token cannot write a syllabus. Offering
+    the tool there would only produce 401s and widen the student profile's
+    write surface for no gain.
+    """
+
+    @mcp.tool(annotations=ToolAnnotations(destructive_hint=True, idempotent_hint=True))
+    @validate_params
+    async def update_syllabus(course_identifier: str | int,
+                              syllabus_body: str,
+                              mode: str = "replace",
+                              confirmation_token: str | None = None) -> str:
+        """Set the Canvas Syllabus tab content for a course.
+
+        Canvas keeps no revision history for the syllabus, so replacing a
+        syllabus that already has content is a two-step call: call without
+        confirmation_token to get a preview plus a single-use token, show the
+        preview to the educator, then call again with the token and identical
+        arguments. Writing into an empty syllabus, or appending/prepending,
+        destroys nothing and takes a single call.
+
+        Args:
+            course_identifier: Course code or Canvas ID
+            syllabus_body: HTML for the syllabus. Canvas stores this as HTML;
+                plain text is accepted but renders without formatting.
+            mode: "replace" (default) swaps the whole body, "append" adds to
+                the end of the existing body, "prepend" adds to the start.
+            confirmation_token: Token from the preview call. Only needed when
+                replacing a syllabus that already has content.
+        """
+        normalized_mode = (mode or "replace").lower()
+        if normalized_mode not in ("replace", "append", "prepend"):
+            return (
+                f"Error: invalid mode '{mode}'. "
+                "Use 'replace', 'append', or 'prepend'."
+            )
+
+        # Backstop for issue 239: get_syllabus fences the body it returns, so a
+        # model round-tripping that output would otherwise write our own
+        # provenance markers into the course.
+        if contains_fence_markers(syllabus_body):
+            return FENCE_LEAK_ERROR
+
+        if normalized_mode == "replace" and not syllabus_body.strip():
+            return (
+                "Error: syllabus_body is empty. To clear a syllabus "
+                "deliberately, pass a body such as '<p></p>'."
+            )
+
+        course_id = await get_course_id(course_identifier)
+
+        current = await make_canvas_request(
+            "get",
+            f"/courses/{course_id}",
+            params={"include[]": "syllabus_body"},
+        )
+        if "error" in current:
+            return f"Error fetching current syllabus: {current['error']}"
+
+        existing_body = current.get("syllabus_body") or ""
+        course_display = current.get("course_code", course_identifier)
+        has_existing = bool(existing_body.strip())
+
+        if normalized_mode == "append":
+            new_body = f"{existing_body}\n{syllabus_body}" if has_existing else syllabus_body
+        elif normalized_mode == "prepend":
+            new_body = f"{syllabus_body}\n{existing_body}" if has_existing else syllabus_body
+        else:
+            new_body = syllabus_body
+
+        # Only a replace over existing content is unrecoverable, so only that
+        # path demands the token.
+        if normalized_mode == "replace" and has_existing:
+            fingerprint = _UPDATE_SYLLABUS_GUARD.fingerprint(
+                "update_syllabus", str(course_id), new_body
+            )
+            if not confirmation_token:
+                preview = (
+                    f"Would REPLACE the entire syllabus of course {course_display}.\n"
+                    f"  Replacing {len(existing_body)} characters of existing "
+                    f"content with {len(new_body)}.\n"
+                    f"  Canvas keeps no revision history for the syllabus, so "
+                    f"the current content cannot be recovered.\n\n"
+                    f"  Current syllabus (plain text):\n"
+                    f"{fence_untrusted(strip_html_tags(existing_body), 'course syllabus')}"
+                )
+                return preview_with_token(
+                    _UPDATE_SYLLABUS_GUARD,
+                    fingerprint,
+                    "update_syllabus",
+                    preview,
+                    action="replace the syllabus",
+                )
+            error = redeem_confirmation(
+                _UPDATE_SYLLABUS_GUARD, confirmation_token, fingerprint
+            )
+            if error:
+                return error
+
+        response = await make_canvas_request(
+            "put",
+            f"/courses/{course_id}",
+            data={"course": {"syllabus_body": new_body}},
+        )
+        if "error" in response:
+            return f"Error updating syllabus: {response['error']}"
+
+        # Canvas answers 200 on this PUT without echoing syllabus_body, and it
+        # drops the field entirely for a token lacking manage_course_content.
+        # Read it back rather than trusting the status code.
+        verify = await make_canvas_request(
+            "get",
+            f"/courses/{course_id}",
+            params={"include[]": "syllabus_body"},
+        )
+        saved_body = verify.get("syllabus_body") or "" if "error" not in verify else None
+
+        if saved_body is None:
+            return unconfirmed_write_warning(
+                "the syllabus update",
+                {
+                    "Course": course_display,
+                    "Mode": normalized_mode,
+                    "Canvas response": "accepted the write but the read-back failed",
+                },
+                "Open the course Syllabus tab in Canvas to check whether it saved.",
+            )
+
+        if saved_body.strip() != new_body.strip():
+            return unconfirmed_write_warning(
+                "the syllabus update",
+                {
+                    "Course": course_display,
+                    "Mode": normalized_mode,
+                    "Sent": f"{len(new_body)} characters",
+                    "Stored by Canvas": f"{len(saved_body)} characters",
+                },
+                "Canvas accepted the request but stored something different. This "
+                "usually means the token lacks permission to edit the syllabus, or "
+                "Canvas rewrote the HTML. Check the Syllabus tab.",
+            )
+
+        verb = {
+            "replace": "Replaced",
+            "append": "Appended to",
+            "prepend": "Prepended to",
+        }[normalized_mode]
+        return (
+            f"✅ {verb} the syllabus of course {course_display}.\n\n"
+            f"  Mode: {normalized_mode}\n"
+            f"  Syllabus is now {len(saved_body)} characters\n"
+            f"  Verified by reading the syllabus back from Canvas"
+        )

--- a/src/canvas_mcp/tools/courses.py
+++ b/src/canvas_mcp/tools/courses.py
@@ -42,6 +42,11 @@ _UPDATE_SYLLABUS_GUARD = ConfirmationGuard(
 )
 
 
+def _syllabus_text(body: str) -> str:
+    """Visible text of a syllabus body, whitespace-collapsed, for comparison."""
+    return " ".join(strip_html_tags(body).split())
+
+
 class _MediaCollector(HTMLParser):
     """Collect embedded-media elements from a Canvas page body.
 
@@ -931,7 +936,18 @@ def register_educator_course_tools(mcp: FastMCP) -> None:
                 "Open the course Syllabus tab in Canvas to check whether it saved.",
             )
 
-        if saved_body.strip() != new_body.strip():
+        # Compare the visible text, not the markup. Canvas returns HTML it
+        # rewrote server-side: institutional themes (DesignPlus on the Canvas
+        # this was tested against) inject <link>/<script> tags into every
+        # syllabus body, and the sanitizer drops attributes such as
+        # rel="noopener". Byte equality therefore fails on writes that
+        # succeeded perfectly, which would train the reader to ignore the
+        # warning. Text containment still catches the failure that matters --
+        # a token without manage_course_content leaves the old body in place,
+        # so the text just written is absent.
+        sent_text = _syllabus_text(new_body)
+        stored_text = _syllabus_text(saved_body)
+        if sent_text and sent_text not in stored_text:
             return unconfirmed_write_warning(
                 "the syllabus update",
                 {
@@ -940,9 +956,9 @@ def register_educator_course_tools(mcp: FastMCP) -> None:
                     "Sent": f"{len(new_body)} characters",
                     "Stored by Canvas": f"{len(saved_body)} characters",
                 },
-                "Canvas accepted the request but stored something different. This "
-                "usually means the token lacks permission to edit the syllabus, or "
-                "Canvas rewrote the HTML. Check the Syllabus tab.",
+                "Canvas accepted the request but the syllabus does not contain "
+                "what was sent. This usually means the token lacks permission to "
+                "edit the syllabus. Check the Syllabus tab.",
             )
 
         verb = {
@@ -950,9 +966,15 @@ def register_educator_course_tools(mcp: FastMCP) -> None:
             "append": "Appended to",
             "prepend": "Prepended to",
         }[normalized_mode]
-        return (
-            f"✅ {verb} the syllabus of course {course_display}.\n\n"
-            f"  Mode: {normalized_mode}\n"
-            f"  Syllabus is now {len(saved_body)} characters\n"
-            f"  Verified by reading the syllabus back from Canvas"
-        )
+        lines = [
+            f"✅ {verb} the syllabus of course {course_display}.\n",
+            f"  Mode: {normalized_mode}",
+            f"  Syllabus is now {len(saved_body)} characters",
+            "  Verified by reading the syllabus back from Canvas",
+        ]
+        if saved_body.strip() != new_body.strip():
+            lines.append(
+                "  Note: Canvas stored a rewritten copy of the HTML (institutional "
+                "theme injection or sanitizing). The text sent is present."
+            )
+        return "\n".join(lines)

--- a/tests/test_role_filtering.py
+++ b/tests/test_role_filtering.py
@@ -77,6 +77,9 @@ EDUCATOR_ONLY_SAMPLE = {
     "create_module",
     "upload_course_file",
     "create_page",
+    # Writing a syllabus needs an instructor-scoped token, so it must not leak
+    # into the student profile even though its read twin get_syllabus is shared.
+    "update_syllabus",
     "list_users",
     "get_student_analytics",
 }

--- a/tests/tools/test_courses.py
+++ b/tests/tools/test_courses.py
@@ -780,13 +780,42 @@ class TestUpdateSyllabus:
         assert "fence" in result.lower() or "untrusted" in result.lower()
 
     @pytest.mark.asyncio
-    async def test_reports_a_warning_when_canvas_stores_something_else(self, mock_api):
-        """A 200 from Canvas is not proof the syllabus changed."""
-        fake, _ = self._canvas(existing="", stored="")
+    async def test_reports_a_warning_when_canvas_keeps_the_old_body(self, mock_api):
+        """A 200 from Canvas is not proof the syllabus changed.
+
+        A token without manage_course_content leaves the old body in place,
+        which is what the read-back is there to catch.
+        """
+        fake, _ = self._canvas(existing="<p>Old</p>", stored="<p>Old</p>")
+        mock_api['make_canvas_request'].side_effect = fake
+
+        update_syllabus = get_tool_function('update_syllabus')
+        result = await update_syllabus("CS101", "<p>New syllabus</p>", mode="append")
+
+        assert "✅" not in result
+        assert "Could not confirm" in result
+
+    @pytest.mark.asyncio
+    async def test_theme_injected_html_still_counts_as_success(self, mock_api):
+        """Canvas rewrites the body server-side; that is not a failed write.
+
+        Observed live: an institutional DesignPlus theme injects <link> and
+        <script> tags into every syllabus body, so the stored HTML never
+        matches the bytes sent. Byte equality reported "could not confirm" on
+        writes that had in fact succeeded.
+        """
+        injected = (
+            '<link rel="stylesheet" href="https://example.com/dp_app.css">'
+            "<p>New syllabus</p>"
+            '<script src="https://example.com/dp_app.js"></script>'
+        )
+        fake, sent = self._canvas(existing="", stored=injected)
         mock_api['make_canvas_request'].side_effect = fake
 
         update_syllabus = get_tool_function('update_syllabus')
         result = await update_syllabus("CS101", "<p>New syllabus</p>")
 
-        assert "✅" not in result
-        assert "Could not confirm" in result
+        assert "✅" in result, result
+        assert "Could not confirm" not in result
+        assert "rewritten copy" in result  # the rewrite is disclosed, not hidden
+        assert sent["body"] == "<p>New syllabus</p>"

--- a/tests/tools/test_courses.py
+++ b/tests/tools/test_courses.py
@@ -20,7 +20,10 @@ def get_tool_function(tool_name: str):
     """
     from fastmcp import FastMCP
 
-    from canvas_mcp.tools.courses import register_course_tools
+    from canvas_mcp.tools.courses import (
+        register_course_tools,
+        register_educator_course_tools,
+    )
 
     mcp = FastMCP("test")
     captured_functions = {}
@@ -37,6 +40,7 @@ def get_tool_function(tool_name: str):
 
     mcp.tool = capturing_tool
     register_course_tools(mcp)
+    register_educator_course_tools(mcp)
 
     return captured_functions.get(tool_name)
 
@@ -649,3 +653,140 @@ class TestPageMediaReporting:
         result = await tool("TEST-101", "missing")
 
         assert "Error fetching page details" in result
+
+
+class TestUpdateSyllabus:
+    """Tests for the update_syllabus tool.
+
+    The behaviour that matters here is which writes are allowed to happen in a
+    single call. Canvas keeps no revision history for syllabus_body, so a
+    replace over existing content must go through preview->token->confirm,
+    while a write into an empty syllabus or an append must not.
+    """
+
+    @pytest.fixture
+    def mock_api(self):
+        with patch('canvas_mcp.tools.courses.get_course_id', new_callable=AsyncMock) as mock_id, \
+             patch('canvas_mcp.tools.courses.make_canvas_request', new_callable=AsyncMock) as mock_req:
+            mock_id.return_value = "60366"
+            yield {'get_course_id': mock_id, 'make_canvas_request': mock_req}
+
+    @staticmethod
+    def _canvas(existing: str, stored: str | None = None):
+        """Sequence the GET / PUT / read-back the tool performs.
+
+        ``stored`` defaults to echoing whatever the PUT sent, i.e. Canvas
+        behaving. Pass it explicitly to simulate Canvas silently storing
+        something else.
+        """
+        sent: dict[str, str] = {}
+
+        async def fake(method, path, params=None, data=None):
+            if method == "put":
+                sent["body"] = data["course"]["syllabus_body"]
+                return {"id": 60366, "course_code": "CS101"}
+            body = existing if "body" not in sent else (
+                sent["body"] if stored is None else stored
+            )
+            return {"course_code": "CS101", "syllabus_body": body}
+
+        return fake, sent
+
+    @pytest.mark.asyncio
+    async def test_writes_into_empty_syllabus_without_a_token(self, mock_api):
+        """Nothing is destroyed, so this must not demand a confirmation step."""
+        fake, sent = self._canvas(existing="")
+        mock_api['make_canvas_request'].side_effect = fake
+
+        update_syllabus = get_tool_function('update_syllabus')
+        assert update_syllabus is not None
+
+        result = await update_syllabus("CS101", "<p>See the course website</p>")
+
+        assert "✅" in result
+        assert "confirmation" not in result.lower()
+        assert sent["body"] == "<p>See the course website</p>"
+
+    @pytest.mark.asyncio
+    async def test_replacing_existing_content_previews_instead_of_writing(self, mock_api):
+        """The first call must show what would be lost and write nothing."""
+        fake, sent = self._canvas(existing="<p>Original syllabus</p>")
+        mock_api['make_canvas_request'].side_effect = fake
+
+        update_syllabus = get_tool_function('update_syllabus')
+        result = await update_syllabus("CS101", "<p>Replacement</p>")
+
+        assert "body" not in sent, "preview call must not PUT anything"
+        assert "Original syllabus" in result
+        assert "cannot be recovered" in result
+
+    @pytest.mark.asyncio
+    async def test_replace_goes_through_with_the_previewed_token(self, mock_api):
+        fake, sent = self._canvas(existing="<p>Original syllabus</p>")
+        mock_api['make_canvas_request'].side_effect = fake
+
+        update_syllabus = get_tool_function('update_syllabus')
+        preview = await update_syllabus("CS101", "<p>Replacement</p>")
+
+        token = preview.split("Confirmation token: ", 1)[1].split("\n", 1)[0].strip()
+        result = await update_syllabus(
+            "CS101", "<p>Replacement</p>", confirmation_token=token
+        )
+
+        assert "✅" in result, result
+        assert sent["body"] == "<p>Replacement</p>"
+
+    @pytest.mark.asyncio
+    async def test_append_keeps_existing_content_and_needs_no_token(self, mock_api):
+        """Appending cannot lose anything, so it stays a single call."""
+        fake, sent = self._canvas(existing="<p>Original</p>")
+        mock_api['make_canvas_request'].side_effect = fake
+
+        update_syllabus = get_tool_function('update_syllabus')
+        result = await update_syllabus("CS101", "<p>Added</p>", mode="append")
+
+        assert "✅" in result
+        assert sent["body"] == "<p>Original</p>\n<p>Added</p>"
+
+    @pytest.mark.asyncio
+    async def test_prepend_puts_new_content_first(self, mock_api):
+        fake, sent = self._canvas(existing="<p>Original</p>")
+        mock_api['make_canvas_request'].side_effect = fake
+
+        update_syllabus = get_tool_function('update_syllabus')
+        await update_syllabus("CS101", "<p>Added</p>", mode="prepend")
+
+        assert sent["body"] == "<p>Added</p>\n<p>Original</p>"
+
+    @pytest.mark.asyncio
+    async def test_rejects_unknown_mode_before_any_request(self, mock_api):
+        update_syllabus = get_tool_function('update_syllabus')
+        result = await update_syllabus("CS101", "<p>x</p>", mode="overwrite")
+
+        assert "invalid mode" in result
+        mock_api['make_canvas_request'].assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_refuses_to_write_back_fence_markers(self, mock_api):
+        """get_syllabus fences its output; that must never be round-tripped in."""
+        from canvas_mcp.core.untrusted_content import FENCE_TEXT_START
+
+        update_syllabus = get_tool_function('update_syllabus')
+        result = await update_syllabus(
+            "CS101", f"{FENCE_TEXT_START} (course syllabus)>>>\nhi"
+        )
+
+        mock_api['make_canvas_request'].assert_not_called()
+        assert "fence" in result.lower() or "untrusted" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_reports_a_warning_when_canvas_stores_something_else(self, mock_api):
+        """A 200 from Canvas is not proof the syllabus changed."""
+        fake, _ = self._canvas(existing="", stored="")
+        mock_api['make_canvas_request'].side_effect = fake
+
+        update_syllabus = get_tool_function('update_syllabus')
+        result = await update_syllabus("CS101", "<p>New syllabus</p>")
+
+        assert "✅" not in result
+        assert "Could not confirm" in result

--- a/tools/README.md
+++ b/tools/README.md
@@ -1469,6 +1469,29 @@ Get the complete Canvas Syllabus tab content for a course, **untruncated**. Unli
 
 ---
 
+#### `update_syllabus`
+Write the Canvas Syllabus tab for a course. Educator-only — a student token cannot write a syllabus, so this tool is absent from the `student` profile.
+
+Canvas keeps **no revision history** for `syllabus_body`, unlike a wiki page. Replacing a syllabus that already has content is therefore two calls: the first returns a preview of what would be lost plus a single-use `Confirmation token: <token>`, and writes nothing; the second, with `confirmation_token=<token>` and identical arguments, performs the write. Writing into an empty syllabus, appending, or prepending destroys nothing and is a single call.
+
+After writing, the tool reads the syllabus back from Canvas and compares it to what was sent. If Canvas accepted the request but stored something different — most often a token without `manage_course_content` — it reports a warning rather than success.
+
+**Parameters:**
+- `course_identifier`: Course code or ID
+- `syllabus_body`: HTML for the syllabus. Canvas stores this as HTML; plain text is accepted but renders unformatted.
+- `mode` (optional): `replace` (default) swaps the whole body, `append` adds to the end, `prepend` adds to the start
+- `confirmation_token` (optional): Token from the preview call. Only required when replacing a syllabus that already has content.
+
+**Example:**
+```
+"Add a link to the course website at the top of the BADM 350 syllabus"
+"Replace the CS101 syllabus with this HTML"
+```
+
+**Returns:** Confirmation that the syllabus was written and verified by reading it back. A replace over existing content first returns a preview plus a token.
+
+---
+
 #### `get_course_content_overview`
 Get a comprehensive overview of course content including pages, modules, and syllabus in one call.
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1474,7 +1474,7 @@ Write the Canvas Syllabus tab for a course. Educator-only — a student token ca
 
 Canvas keeps **no revision history** for `syllabus_body`, unlike a wiki page. Replacing a syllabus that already has content is therefore two calls: the first returns a preview of what would be lost plus a single-use `Confirmation token: <token>`, and writes nothing; the second, with `confirmation_token=<token>` and identical arguments, performs the write. Writing into an empty syllabus, appending, or prepending destroys nothing and is a single call.
 
-After writing, the tool reads the syllabus back from Canvas and compares it to what was sent. If Canvas accepted the request but stored something different — most often a token without `manage_course_content` — it reports a warning rather than success.
+After writing, the tool reads the syllabus back from Canvas and checks that what was sent is present. If Canvas accepted the request but the syllabus does not contain it — most often a token without `manage_course_content` — it reports a warning rather than success. The check compares visible text, not markup, because Canvas rewrites the body server-side: institutional themes inject `<link>`/`<script>` tags into every syllabus and the sanitizer drops attributes such as `rel="noopener"`. When Canvas does rewrite the HTML, the success message says so.
 
 **Parameters:**
 - `course_identifier`: Course code or ID

--- a/tools/TOOL_MANIFEST.json
+++ b/tools/TOOL_MANIFEST.json
@@ -652,6 +652,44 @@
       ]
     },
     {
+      "name": "update_syllabus",
+      "category": "educator",
+      "description": "Set the Canvas Syllabus tab content for a course. Replacing a syllabus that already has content is two-step: preview first, then confirm with the token.",
+      "parameters": [
+        {
+          "name": "course_identifier",
+          "type": "string | integer",
+          "required": true,
+          "description": "Course code or Canvas ID"
+        },
+        {
+          "name": "syllabus_body",
+          "type": "string",
+          "required": true,
+          "description": "HTML for the syllabus. Canvas stores this as HTML; plain text renders without formatting"
+        },
+        {
+          "name": "mode",
+          "type": "string",
+          "required": false,
+          "default": "replace",
+          "description": "'replace' swaps the whole body, 'append' adds to the end, 'prepend' adds to the start"
+        },
+        {
+          "name": "confirmation_token",
+          "type": "string",
+          "required": false,
+          "description": "Token from the preview call. Only required when replacing a syllabus that already has content"
+        }
+      ],
+      "returns": "Confirmation that the syllabus was written, verified by reading it back from Canvas. Replacing existing content first returns a preview plus a single-use token and writes nothing.",
+      "examples": [
+        "Add a link to the course website at the top of the BADM 350 syllabus",
+        "Replace the CS101 syllabus with this HTML"
+      ],
+      "notes": "Canvas keeps no revision history for syllabus_body, so a replace cannot be undone. Append and prepend, and any write into an empty syllabus, are single-call because they destroy nothing."
+    },
+    {
       "name": "list_discussion_topics",
       "category": "shared",
       "description": "View discussion forums in a course. Returns discussion topics only; announcements are excluded unless include_announcements is set. Use list_announcements to list announcements on their own.",


### PR DESCRIPTION
## What this adds

`update_syllabus`, a write tool for the course Syllabus tab. `get_syllabus` (#134) could read it and nothing could write it, so setting a syllabus meant leaving the server for the Canvas UI or a raw `PUT /courses/:id`.

Modes: `replace` (default), `append`, `prepend`.

## Why the confirmation is where it is

Canvas keeps **no revision history** for `syllabus_body`, unlike a wiki page, so a replace over existing content is unrecoverable. That one case takes the `preview → token → confirm` path the delete tools already use (#318).

Writing into an empty syllabus, appending, or prepending destroys nothing, so those stay a single call. The intent is that the guard shows up exactly when something can be lost, and stays out of the way of the common "add a link to the syllabus" edit.

## Verifying the write

Canvas answers 200 on this PUT **without echoing `syllabus_body` back**, and drops the field entirely for a token lacking `manage_course_content`. So the tool reads the syllabus back rather than trusting the status code, per the house rule against reporting success for a state the user cannot see in Canvas.

The read-back compares **visible text, not markup**. That came out of running this against a live Canvas course, where the first version reported `Could not confirm the syllabus update` on every write that had in fact succeeded: the institution's DesignPlus theme injects `<link>`/`<script>` tags into every syllabus body, and the sanitizer drops attributes such as `rel="noopener"`, so the stored bytes never match the bytes sent. A check that fires on healthy writes trains the reader to ignore it. Text containment still catches the failure that matters, since a token without permission leaves the old body in place and the text just written is absent. When Canvas does rewrite the HTML, the success message says so rather than hiding it. There is a regression test built from the real injected markup.

## Role registration

Registered through a new `register_educator_course_tools` rather than the existing `register_course_tools`, which is shared with the student profile. A student token cannot write a syllabus, so exposing it there would only produce 401s and widen the student write surface. Counts move to 97 default / 102 with all feature gates / 91 educator; the student profile is unchanged at 37.

## One shared-helper change

`preview_with_token` takes an optional `action` verb, defaulting to `"delete"` so **every existing call site reads exactly as before**. Delete tools were its only callers, so its wording was hardcoded to deletion. This is the first irreversible write that is not a delete, and telling the user a replace would "delete" something describes the wrong risk.

## Testing

- Full suite green: **1479 passed, 22 skipped**. `ruff check` clean.
- 9 new tests covering each mode, preview-writes-nothing, token confirm, unknown mode, the fence-marker write-back guard, the permission-denied read-back, and the theme-injection regression.
- Manifest and role-filtering gates updated, so `test_tool_manifest_matches_registry_exactly` and the untrusted-content registry gate both pass.
- **Live-verified** against a real Canvas course: append, replace-previews-without-writing (confirmed byte-identical before and after), token confirm, single-use token rejection, and prepend ordering. The test course was restored to its original syllabus afterward.

## Known gap

The permission-denied branch is covered by unit tests only. Exercising it live needs a token without `manage_course_content`, which I did not have.

Docs updated: `AGENTS.md` (educator + shared tables, tool counts, a syllabus workflow, and the "Cannot Do" line that claimed no course settings could be modified), `tools/README.md`, `tools/TOOL_MANIFEST.json`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
